### PR TITLE
Add ArrayTypeWrapper to create a StringArray wrapper class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 # generate compile_commands.json
-set(CMAKE_EXPORT_COMPILE_COMMANDS ON) 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # compiled binaries folders (same as open62541)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
@@ -100,6 +100,7 @@ endif()
 # open62541pp library (static/shared depending on option BUILD_SHARED_LIBS)
 add_library(
     open62541pp
+    src/ArrayTypeWrapper.cpp
     src/Helper.cpp
     src/Node.cpp
     src/NodeId.cpp

--- a/include/open62541pp/ArrayTypeWrapper.h
+++ b/include/open62541pp/ArrayTypeWrapper.h
@@ -1,0 +1,224 @@
+#pragma once
+
+#include <vector>
+
+#include "open62541pp/Helper.h"
+#include "open62541pp/TypeWrapper.h"
+#include "open62541pp/open62541.h"
+
+namespace opcua {
+
+/**
+ * @defgroup ArrayTypeWrapper Wrapper classes of UA_* c-array types
+ *
+ * Safe wrapper classes for heap-allocated open62541 `UA_*` c-array types to prevent memory leaks.
+ * @n
+ * All array wrapper classes inherit from opcua::ArrayTypeWrapper.
+ * Native open62541 objects can be accessed using the opcua::TypeWrapper::handle() method.
+ * Elements can be accessed with the index operator [i], at(i), and for pointer elements
+ * getPtrAt(i).
+ */
+
+/**
+ * Template base class to wrap UA_* c-array type objects.
+ *
+ * The derived classes should implement specific constructors to convert from other data types.
+ * @ingroup ArrayTypeWrapper
+ */
+template <typename T, uint16_t typeIndex>
+class ArrayTypeWrapper {
+public:
+    static_assert(typeIndex < UA_TYPES_COUNT);
+
+    using ArrayTypeWrapperBase = ArrayTypeWrapper<T, typeIndex>;
+    using UaType = T;
+
+    ArrayTypeWrapper()
+        : size_(0),
+          data_(nullptr) {}
+
+    explicit ArrayTypeWrapper(std::size_t size)
+        : size_(size) {
+        init();
+    }
+
+    /// Constructor with native UA_* c-array type (deep copy).
+    explicit ArrayTypeWrapper(const T* data, std::size_t size)
+        : size_(size),
+          data_(nullptr) {
+        copy(data, size_);
+    }
+
+    /// Constructor with native UA_* c-array type (move rvalue).
+    explicit ArrayTypeWrapper(T*&& data, std::size_t size) noexcept
+        : size_(size),
+          data_(data) {}
+
+    virtual ~ArrayTypeWrapper() {
+        clear();
+    };
+
+    /// Copy constructor (deep copy).
+    ArrayTypeWrapper(const ArrayTypeWrapper& other) {
+        copy(other.data_, other.size_);
+    }
+
+    /// Move constructor.
+    ArrayTypeWrapper(ArrayTypeWrapper&& other) noexcept {
+        swap(other);
+    }
+
+    /// Copy assignment (deep copy).
+    ArrayTypeWrapper& operator=(const ArrayTypeWrapper& other) {  // NOLINT, false positive
+        if (this == &other) {
+            return *this;
+        }
+        copy(other.data_, other.size_);
+        return *this;
+    }
+
+    /// Move assignment.
+    ArrayTypeWrapper& operator=(ArrayTypeWrapper&& other) noexcept {
+        if (this == &other) {
+            return *this;
+        }
+        swap(other);
+        return *this;
+    }
+
+    /// Implicit conversion to wrapped object.
+    operator T*() noexcept {  // NOLINT
+        return data_;
+    }
+
+    /// Implicit conversion to wrapped object.
+    operator const T*() const noexcept {  // NOLINT
+        return data_;
+    }
+
+    /// Array access to element.
+    TypeWrapper<T, typeIndex> getElement(int index) noexcept {
+        return TypeWrapper<T, typeIndex>(data_[index]);
+    }
+
+    /// Array access to wrapped element.
+    T operator[](int index) noexcept {
+        return data_[index];
+    }
+
+    /// Array access to wrapped element.
+    const T operator[](int index) const noexcept {
+        return data_[index];
+    }
+
+    /// Array access to wrapped element with bounce check.
+    T at(int index) {
+        checkArrayIndex(index);
+        return data_[index];
+    }
+
+    /// Array access to wrapped element with bounce check.
+    const T at(int index) const {
+        checkArrayIndex(index);
+        return data_[index];
+    }
+
+    /// Array access to wrapped pointer element with bounce check.
+    T* getPtrAt(int index) {
+        checkArrayIndex(index);
+        return &data_[index];
+    }
+
+    /// Array access to wrapped pointer element with bounce check.
+    const T* getPtrAt(int index) const {
+        checkArrayIndex(index);
+        return &data_[index];
+    }
+
+    /// Swap wrapped objects.
+    void swap(ArrayTypeWrapper& other) noexcept {
+        static_assert(std::is_swappable_v<T>);
+        std::swap(this->size_, other.size_);
+        std::swap(this->data_, other.data_);
+    }
+
+    /// Get type as type index.
+    static constexpr uint16_t getTypeIndex() {
+        return typeIndex;
+    }
+
+    /// Get type as Type enum (only for builtin types).
+    static constexpr Type getType() {
+        static_assert(typeIndex < UA_TYPES_COUNT, "Only possible for builtin types");
+        return static_cast<Type>(typeIndex);
+    }
+
+    /// Get type as UA_DataType object.
+    static const UA_DataType* getDataType() {
+        return detail::getUaDataType<typeIndex>();
+    }
+
+    /// Return pointer to wrapped object.
+    T* handle() noexcept {
+        return data_;
+    }
+
+    /// Return const pointer to wrapped object.
+    const T* handle() const noexcept {
+        return data_;
+    };
+
+    std::size_t size() const noexcept {
+        return size_;
+    };
+
+protected:
+    inline static void checkMemSize() {
+        assert(sizeof(T) == getDataType()->memSize);  // NOLINT
+    }
+
+    inline void checkArrayIndex(int i) {
+        assert(i + 1 <= size_);
+    }
+
+    void init() noexcept {
+        checkMemSize();
+        data_ = reinterpret_cast<T*>(UA_Array_new(size_, getDataType()));
+    }
+
+    void clear() noexcept {
+        checkMemSize();
+        if (data_ != nullptr) {
+            UA_Array_delete(data_, size_, getDataType());
+        }
+    }
+
+    void copy(const T* data, std::size_t size) {
+        clear();
+        checkMemSize();
+        auto status = UA_Array_copy(
+            data, size, (void**)&data_, getDataType()
+        );  // deep copy of data
+        size_ = size;
+        detail::throwOnBadStatus(status);
+    }
+
+private:
+    std::size_t size_;
+    T* data_;
+};
+
+/**
+ * UA_String* wrapper class.
+ * @ingroup ArrayTypeWrapper
+ */
+class StringArray : public ArrayTypeWrapper<UA_String, UA_TYPES_STRING> {
+public:
+    using ArrayTypeWrapperBase::ArrayTypeWrapperBase;
+
+    explicit StringArray(const std::vector<std::string>& vStr);
+
+    std::vector<std::string> get() const;
+};
+
+}  // namespace opcua

--- a/include/open62541pp/open62541pp.h
+++ b/include/open62541pp/open62541pp.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "open62541pp/ArrayTypeWrapper.h"
 #include "open62541pp/Comparison.h"
 #include "open62541pp/ErrorHandling.h"
 #include "open62541pp/Helper.h"

--- a/src/ArrayTypeWrapper.cpp
+++ b/src/ArrayTypeWrapper.cpp
@@ -1,0 +1,25 @@
+#include <algorithm>
+
+#include "open62541pp/ArrayTypeWrapper.h"
+
+namespace opcua {
+
+/* ------------------------------------------- String ------------------------------------------- */
+
+StringArray::StringArray(const std::vector<std::string>& vStr)
+    : ArrayTypeWrapper<UA_String, 11>(vStr.size()) {
+    for (size_t i = 0; i < size(); i++) {
+        *getPtrAt(i) = detail::allocUaString(vStr[i]);
+    }
+}
+
+std::vector<std::string> StringArray::get() const {
+    std::vector<std::string> v;
+    int index = 0;
+    std::generate_n(std::back_inserter(v), size(), [this, &index] {
+        return detail::toString(operator[](index++));
+    });
+    return v;
+}
+
+}  // namespace opcua

--- a/tests/ArrayTypeWrapper.cpp
+++ b/tests/ArrayTypeWrapper.cpp
@@ -1,0 +1,139 @@
+#include <utility>  // move
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include "open62541pp/ArrayTypeWrapper.h"
+#include "open62541pp/Helper.h"  // detail::toString
+#include "open62541pp/TypeWrapper.h"
+#include "open62541pp/Types.h"
+
+using namespace Catch::Matchers;
+using namespace opcua;
+
+TEST_CASE("ArrayTypeWrapper") {
+    SECTION("Constructor") {
+        // Empty constructor
+        REQUIRE_NOTHROW(ArrayTypeWrapper<UA_Boolean, UA_TYPES_BOOLEAN>(1));
+
+        // Constructor with wrapped type (lvalue)
+        {
+            UA_Boolean dArray[1] = {true};
+            UA_Boolean* pdArray = &dArray[0];
+            ArrayTypeWrapper<UA_Boolean, UA_TYPES_BOOLEAN> wrapper(pdArray, 1);
+            REQUIRE(wrapper[0] == true);
+        }
+
+        // Constructor with wrapped type (rvalue)
+        {
+            UA_Double* dArray = reinterpret_cast<UA_Double*>(
+                UA_Array_new(1, &UA_TYPES[UA_TYPES_DOUBLE])
+            );
+            dArray[0] = 11.11;
+            ArrayTypeWrapper<UA_Double, UA_TYPES_DOUBLE> wrapper(std::move(dArray), 1);
+            REQUIRE(wrapper[0] == 11.11);
+        }
+    }
+
+    SECTION("Copy constructor / assignment") {
+        UA_String sArray[] = {UA_STRING_ALLOC("test")};
+        UA_String* psArray = &sArray[0];
+        ArrayTypeWrapper<UA_String, UA_TYPES_STRING> wrapper(psArray, 1);
+        UA_Array_delete(sArray[0].data, sArray[0].length, &UA_TYPES[UA_TYPES_BYTE]);
+        ArrayTypeWrapper<UA_String, UA_TYPES_STRING> wrapperConstructor(wrapper);
+
+        REQUIRE(wrapperConstructor.handle()->data != wrapper.handle()->data);
+        REQUIRE_THAT(detail::toString(wrapperConstructor[0]), Equals("test"));
+    }
+
+    SECTION("Copy assignment") {
+        UA_String sArray[] = {UA_STRING_ALLOC("test")};
+        UA_String* psArray = &sArray[0];
+        ArrayTypeWrapper<UA_String, UA_TYPES_STRING> wrapper(psArray, 1);
+        UA_Array_delete(sArray[0].data, sArray[0].length, &UA_TYPES[UA_TYPES_BYTE]);
+        ArrayTypeWrapper<UA_String, UA_TYPES_STRING> wrapperAssignmnet = wrapper;
+
+        REQUIRE(wrapperAssignmnet.handle()->data != wrapper.handle()->data);
+        REQUIRE_THAT(detail::toString(wrapperAssignmnet[0]), Equals("test"));
+
+        // self assignment
+        REQUIRE_NOTHROW(wrapper = wrapper);
+    }
+
+    SECTION("Move constructor") {
+        UA_String sArray[] = {UA_STRING_ALLOC("test")};
+        UA_String* psArray = &sArray[0];
+        ArrayTypeWrapper<UA_String, UA_TYPES_STRING> wrapper(psArray, 1);
+        UA_Array_delete(sArray[0].data, sArray[0].length, &UA_TYPES[UA_TYPES_BYTE]);
+        ArrayTypeWrapper<UA_String, UA_TYPES_STRING> wrapperConstructor(std::move(wrapper));
+
+        REQUIRE(wrapper.handle() == nullptr);
+        REQUIRE_THAT(detail::toString(wrapperConstructor[0]), Equals("test"));
+    }
+
+    SECTION("Move assignment") {
+        UA_String sArray[] = {UA_STRING_ALLOC("test")};
+        UA_String* psArray = &sArray[0];
+        ArrayTypeWrapper<UA_String, UA_TYPES_STRING> wrapper(psArray, 1);
+        UA_Array_delete(sArray[0].data, sArray[0].length, &UA_TYPES[UA_TYPES_BYTE]);
+        ArrayTypeWrapper<UA_String, UA_TYPES_STRING> wrapperAssignmnet = std::move(wrapper);
+
+        REQUIRE(wrapper.handle() == nullptr);
+        REQUIRE_THAT(detail::toString(wrapperAssignmnet[0]), Equals("test"));
+
+        // self assignment
+        REQUIRE_NOTHROW(wrapper = std::move(wrapper));
+    }
+
+    SECTION("Implicit conversion") {
+        UA_Float fArray[] = {11.11f, 22.22f};
+        UA_Float* pfArray = &fArray[0];
+        ArrayTypeWrapper<UA_Float, UA_TYPES_FLOAT> wrapper(pfArray, 2);
+
+        float* value = wrapper;
+        REQUIRE(value[0] == 11.11f);
+
+        const float* cvalue = wrapper;
+        REQUIRE(cvalue[1] == 22.22f);
+    }
+
+    SECTION("Member access") {
+        UA_NodeId nArray[] = {UA_NODEID_NUMERIC(1, 1000)};
+        UA_NodeId* pnArray = &nArray[0];
+        ArrayTypeWrapper<UA_NodeId, UA_TYPES_NODEID> wrapper(pnArray, 1);
+        REQUIRE(wrapper.at(0).namespaceIndex == 1);
+        REQUIRE(wrapper[0].identifierType == UA_NODEIDTYPE_NUMERIC);
+        REQUIRE(wrapper[0].identifier.numeric == 1000);
+    }
+
+    SECTION("Swap") {
+        UA_String sArray[] = {UA_STRING_ALLOC("test")};
+        UA_String* psArray = &sArray[0];
+        ArrayTypeWrapper<UA_String, UA_TYPES_STRING> wrapper1(psArray, 1);
+        UA_Array_delete(sArray[0].data, sArray[0].length, &UA_TYPES[UA_TYPES_BYTE]);
+        ArrayTypeWrapper<UA_String, UA_TYPES_STRING> wrapper2;
+
+        REQUIRE(wrapper1.handle() != nullptr);
+        REQUIRE(wrapper2.handle() == nullptr);
+        REQUIRE_THAT(detail::toString(wrapper1[0]), Equals("test"));
+
+        wrapper1.swap(wrapper2);
+        REQUIRE(wrapper1.handle() == nullptr);
+        REQUIRE(wrapper2.handle() != nullptr);
+        REQUIRE_THAT(detail::toString(wrapper2[0]), Equals("test"));
+    }
+}
+
+TEST_CASE("StringArray") {
+    SECTION("Constructor") {
+        REQUIRE_NOTHROW(StringArray({"test", "123"}));
+        {
+            StringArray wrapper({"test", "123"});
+            REQUIRE_THAT(detail::toString(wrapper[0]), Equals("test"));
+            REQUIRE_THAT(detail::toString(wrapper[1]), Equals("123"));
+            REQUIRE_THAT(wrapper.get()[0], Equals("test"));
+            REQUIRE_THAT(wrapper.get()[1], Equals("123"));
+        }
+    }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 
 add_executable(
     open62541pp_tests
+    ArrayTypeWrapper.cpp
     Helper.cpp
     Node.cpp
     NodeId.cpp


### PR DESCRIPTION
I added a ArrayTypeWrapper class equivalent to the existing scalar TypeWrapper for handling c-arrays safely.

The new StringArray class is a specific ArrayTypeWrapper with additional functions to convert between vectors of strings and c-array UA_Strings.