### PR TITLE
Feature/read write ua data value

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ endif()
 # open62541pp library (static/shared depending on option BUILD_SHARED_LIBS)
 add_library(
     open62541pp
+    src/DataValue.cpp
     src/Helper.cpp
     src/Node.cpp
     src/NodeId.cpp

--- a/include/open62541pp/DataValue.h
+++ b/include/open62541pp/DataValue.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "open62541pp/TypeWrapper.h"
+#include "open62541pp/Variant.h"
+
+namespace opcua {
+
+class DataValue : public TypeWrapper<UA_DataValue, UA_TYPES_DATAVALUE> {
+public:
+    using TypeWrapperBase::TypeWrapperBase;
+
+    void setVariant(const Variant& variant);
+    Variant getVariant() const;
+
+    void setSourceTimeStamp(const DateTime& ts);
+    DateTime getSourceTimeStamp() const;
+
+    void setStatusCode(const UA_StatusCode);
+    UA_StatusCode getStatusCode() const;
+};
+
+}  // namespace opcua

--- a/include/open62541pp/open62541pp.h
+++ b/include/open62541pp/open62541pp.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "open62541pp/Comparison.h"
+#include "open62541pp/DataValue.h"
 #include "open62541pp/ErrorHandling.h"
 #include "open62541pp/Helper.h"
 #include "open62541pp/Logger.h"

--- a/src/DataValue.cpp
+++ b/src/DataValue.cpp
@@ -1,0 +1,34 @@
+#include "open62541pp/DataValue.h"
+
+namespace opcua {
+
+void DataValue::setVariant(const Variant& variant) {
+    this->handle()->value = *variant.handle();
+    this->handle()->hasValue = true;
+}
+
+Variant DataValue::getVariant() const {
+    return Variant(this->handle()->value);
+}
+
+void DataValue::setSourceTimeStamp(const DateTime& ts) {
+    this->handle()->sourceTimestamp = *ts.handle();
+    this->handle()->hasSourceTimestamp = true;
+}
+
+DateTime DataValue::getSourceTimeStamp() const {
+    if (this->handle()->hasSourceTimestamp) {
+        return DateTime(this->handle()->sourceTimestamp);
+    }
+    return DateTime();
+}
+
+void DataValue::setStatusCode(const UA_StatusCode code) {
+    this->handle()->status = code;
+}
+
+UA_StatusCode DataValue::getStatusCode() const {
+    return this->handle()->status;
+}
+
+}  // namespace opcua

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -316,6 +316,19 @@ void Node::readValue(Variant& var) {
     detail::throwOnBadStatus(status);
 }
 
+void Node::writeDataValue(const DataValue& var) {
+    const auto status = UA_Server_writeDataValue(server_.handle(), nodeId_, var);
+    detail::throwOnBadStatus(status);
+}
+
+DataValue Node::readDataValue() {
+    UA_ReadValueId rvi;
+    UA_ReadValueId_init(&rvi);
+    rvi.nodeId = nodeId_;
+    rvi.attributeId = UA_ATTRIBUTEID_VALUE;
+    return DataValue(UA_Server_read(server_.handle(), &rvi, UA_TIMESTAMPSTORETURN_BOTH));
+}
+
 void Node::remove(bool deleteReferences) {
     const auto status = UA_Server_deleteNode(server_.handle(), nodeId_, deleteReferences);
     detail::throwOnBadStatus(status);

--- a/tests/Node.cpp
+++ b/tests/Node.cpp
@@ -144,6 +144,24 @@ TEST_CASE("Node") {
         String str("test");
         REQUIRE_NOTHROW(node.writeScalar(str));
         REQUIRE(node.readScalar<std::string>() == "test");
+
+        SECTION("Write with timestamp") {
+            String str1("test1");
+            auto ts = DateTime::now();
+            REQUIRE_NOTHROW(node.writeScalar(str1, ts));
+            auto dv = node.readDataValue();
+            REQUIRE(dv.getVariant().getScalarCopy<std::string>() == "test1");
+            REQUIRE(dv.getSourceTimeStamp() == ts);
+        }
+        SECTION("Write with timestamp and status code") {
+            String str2("test2");
+            auto ts = DateTime::now();
+            REQUIRE_NOTHROW(node.writeScalar(str2, ts, UA_STATUSCODE_BADINTERNALERROR));
+            auto dv = node.readDataValue();
+            REQUIRE(dv.getVariant().getScalarCopy<std::string>() == "test2");
+            REQUIRE(dv.getSourceTimeStamp() == ts);
+            REQUIRE(dv.getStatusCode() == UA_STATUSCODE_BADINTERNALERROR);
+        }
     }
 
     SECTION("Read/write array") {


### PR DESCRIPTION
There was a commented out writeDataValue method inside the Node. I implemented these method alongside a new DataValue wrapper type. It's now possible to read and write node values with timestamp and status code.