### PR TITLE
feat: create variant from scalar/array

### DIFF
--- a/include/open62541pp/Node.h
+++ b/include/open62541pp/Node.h
@@ -204,23 +204,15 @@ std::vector<T> Node::readArray() {
 
 template <typename T, Type type>
 void Node::writeScalar(const T& value) {
-    Variant variant;
-    if constexpr (detail::isAssignableToVariantScalar<T>()) {
-        variant.setScalar<T, type>(const_cast<T&>(value));  // NOLINT, variant isn't modified
-    } else {
-        variant.setScalarCopy<T, type>(value);
-    }
+    // NOLINTNEXTLINE, variant isn't modified, try to avoid copy
+    const auto variant = Variant::fromScalar<T, type>(const_cast<T&>(value));
     writeValue(variant);
 }
 
 template <typename T, Type type>
 void Node::writeArray(const T* array, size_t size) {
-    Variant variant;
-    if constexpr (detail::isAssignableToVariantArray<T>()) {
-        variant.setArray<T, type>(const_cast<T*>(array), size);  // NOLINT, variant isn't modified
-    } else {
-        variant.setArrayCopy<T, type>(array, size);
-    }
+    // NOLINTNEXTLINE, variant isn't modified, try to avoid copy
+    const auto variant = Variant::fromArray<T, type>(const_cast<T*>(array), size);
     writeValue(variant);
 }
 
@@ -231,8 +223,7 @@ void Node::writeArray(const std::vector<T>& array) {
 
 template <typename InputIt, Type type>
 void Node::writeArray(InputIt first, InputIt last) {
-    Variant variant;
-    variant.setArrayCopy<InputIt, type>(first, last);
+    const auto variant = Variant::fromArray<InputIt, type>(first, last);
     writeValue(variant);
 }
 

--- a/include/open62541pp/TypeConverter.h
+++ b/include/open62541pp/TypeConverter.h
@@ -69,11 +69,12 @@ constexpr void assertTypeCombination() {
 
 template <typename T>
 constexpr Type guessType() {
+    using ValueType = typename std::remove_cv_t<std::remove_reference_t<T>>;
     static_assert(
-        TypeConverter<T>::ValidTypes::size() == 1,
+        TypeConverter<ValueType>::ValidTypes::size() == 1,
         "Ambiguous template type, please specify type enum (opcua::Type) manually"
     );
-    return TypeConverter<T>::ValidTypes::toArray().at(0);
+    return TypeConverter<ValueType>::ValidTypes::toArray().at(0);
 }
 
 template <typename It>

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -206,6 +206,53 @@ TEST_CASE("Variant") {
         }
     }
 
+    SECTION("Create from scalar") {
+        SECTION("Assign if possible") {
+            double value = 11.11;
+            const auto var = Variant::fromScalar(value);
+            REQUIRE(var.isScalar());
+            REQUIRE(var->data == &value);
+        }
+        SECTION("Copy if const") {
+            const double value = 11.11;
+            const auto var = Variant::fromScalar(value);
+            REQUIRE(var.isScalar());
+            REQUIRE(var->data != &value);
+        }
+        SECTION("Copy rvalue") {
+            auto var = Variant::fromScalar(11.11);
+            REQUIRE(var.isScalar());
+            REQUIRE(var.getScalar<double>() == 11.11);
+        }
+        SECTION("Copy if not assignable (const or conversion required)") {
+            std::string value{"test"};
+            const auto var = Variant::fromScalar<std::string, Type::String>(value);
+            REQUIRE(var.isScalar());
+            REQUIRE(var->data != &value);
+        }
+    }
+
+    SECTION("Create from array") {
+        SECTION("Assign if possible") {
+            std::vector<double> vec{1.1, 2.2, 3.3};
+            const auto var = Variant::fromArray(vec.data(), vec.size());
+            REQUIRE(var.isArray());
+            REQUIRE(var->data == vec.data());
+        }
+        SECTION("Copy if const") {
+            const std::vector<double> vec{1.1, 2.2, 3.3};
+            const auto var = Variant::fromArray(vec);
+            REQUIRE(var.isArray());
+            REQUIRE(var->data != vec.data());
+        }
+        SECTION("Copy from iterator") {
+            const std::vector<double> vec{1.1, 2.2, 3.3};
+            const auto var = Variant::fromArray(vec.begin(), vec.end());
+            REQUIRE(var.isArray());
+            REQUIRE(var->data != vec.data());
+        }
+    }
+
     SECTION("Set/get scalar") {
         Variant var;
         int32_t value = 5;


### PR DESCRIPTION
Addressing feature request #18.
Added new static methods `Variant::fromScalar`, `Variant::fromArray` to create variants the most efficient way (avoid copys).