### PR TITLE
feat: use LocalizedText as argument instead of members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Pass `LocalizedText` instead of members (`locale`, `text`) to `Node::writeDisplayName`, `Node::writeDescription`, `services::writeDisplayName`, services::writeDescription` (#29)
+
 ## [0.2.0] - 2023-04-12
 
 ### Added

--- a/examples/server.cpp
+++ b/examples/server.cpp
@@ -20,8 +20,8 @@ int main() {
 
     // set node attributes
     myIntegerNode.writeDataType(opcua::Type::Int32);
-    myIntegerNode.writeDisplayName("en-US", "the answer");
-    myIntegerNode.writeDescription("en-US", "the answer");
+    myIntegerNode.writeDisplayName({"en-US", "the answer"});
+    myIntegerNode.writeDescription({"en-US", "the answer"});
 
     // write value
     myIntegerNode.writeScalar(42);

--- a/examples/server_instantiation.cpp
+++ b/examples/server_instantiation.cpp
@@ -12,22 +12,22 @@ int main() {
      */
     auto nodeBaseObjectType = server.getBaseObjectTypeNode();
     auto nodeMamalType = nodeBaseObjectType.addObjectType({1, 10000}, "MamalType");
-    nodeMamalType.writeDisplayName("en-US", "MamalType");
-    nodeMamalType.writeDescription("en-US", "A mamal");
+    nodeMamalType.writeDisplayName({"en-US", "MamalType"});
+    nodeMamalType.writeDescription({"en-US", "A mamal"});
 
     auto nodeMamalTypeAge = nodeMamalType.addVariable({1, 10001}, "Age");
-    nodeMamalTypeAge.writeDisplayName("en-US", "Age");
-    nodeMamalTypeAge.writeDescription("en-US", "This mamals age in months");
+    nodeMamalTypeAge.writeDisplayName({"en-US", "Age"});
+    nodeMamalTypeAge.writeDescription({"en-US", "This mamals age in months"});
     nodeMamalTypeAge.writeModellingRule(opcua::ModellingRule::Mandatory);  // create on new instance
     nodeMamalTypeAge.writeScalar<uint32_t>(0);  // default age
 
     auto nodeDogType = nodeMamalType.addObjectType({1, 10002}, "DogType");
-    nodeDogType.writeDisplayName("en-US", "DogType");
-    nodeDogType.writeDescription("en-US", "A dog, subtype of mamal");
+    nodeDogType.writeDisplayName({"en-US", "DogType"});
+    nodeDogType.writeDescription({"en-US", "A dog, subtype of mamal"});
 
     auto nodeDogTypeName = nodeDogType.addVariable({1, 10003}, "Name");
-    nodeDogTypeName.writeDisplayName("en-US", "Name");
-    nodeDogTypeName.writeDescription("en-US", "This dogs name");
+    nodeDogTypeName.writeDisplayName({"en-US", "Name"});
+    nodeDogTypeName.writeDescription({"en-US", "This dogs name"});
     nodeDogTypeName.writeModellingRule(opcua::ModellingRule::Mandatory);  // create on new instance
     nodeDogTypeName.writeScalar(opcua::String("unnamed dog"));  // default name
 
@@ -39,8 +39,8 @@ int main() {
      */
     auto nodeObjects = server.getObjectsNode();
     auto nodeBello = nodeObjects.addObject({1, 20000}, "Bello", nodeDogType.getNodeId());
-    nodeBello.writeDisplayName("en-US", "Bello");
-    nodeBello.writeDescription("en-US", "A dog named Bello");
+    nodeBello.writeDisplayName({"en-US", "Bello"});
+    nodeBello.writeDescription({"en-US", "A dog named Bello"});
 
     // Set variables Age and Name
     nodeBello.getChild({{1, "Age"}}).writeScalar(3U);

--- a/include/open62541pp/Node.h
+++ b/include/open62541pp/Node.h
@@ -180,13 +180,13 @@ public:
     std::vector<T> readArray();
 
     /// @copydoc services::writeDisplayName
-    void writeDisplayName(std::string_view locale, std::string_view name) {
-        services::writeDisplayName(server_, nodeId_, locale, name);
+    void writeDisplayName(const LocalizedText& name) {
+        services::writeDisplayName(server_, nodeId_, name);
     }
 
     /// @copydoc services::writeDescription
-    void writeDescription(std::string_view locale, std::string_view name) {
-        services::writeDescription(server_, nodeId_, locale, name);
+    void writeDescription(const LocalizedText& name) {
+        services::writeDescription(server_, nodeId_, name);
     }
 
     /// @copydoc services::writeWriteMask

--- a/include/open62541pp/services/Attribute.h
+++ b/include/open62541pp/services/Attribute.h
@@ -93,17 +93,13 @@ void readValue(Server& server, const NodeId& id, Variant& value);
  * Set localized display name.
  * @ingroup Attribute
  */
-void writeDisplayName(
-    Server& server, const NodeId& id, std::string_view locale, std::string_view name
-);
+void writeDisplayName(Server& server, const NodeId& id, const LocalizedText& name);
 
 /**
  * Set localized description.
  * @ingroup Attribute
  */
-void writeDescription(
-    Server& server, const NodeId& id, std::string_view locale, std::string_view name
-);
+void writeDescription(Server& server, const NodeId& id, const LocalizedText& name);
 
 /**
  * Set write mask, for example `::UA_WRITEMASK_ACCESSLEVEL | ::UA_WRITEMASK_DESCRIPTION`.

--- a/src/services/Attribute.cpp
+++ b/src/services/Attribute.cpp
@@ -91,21 +91,13 @@ void readValue(Server& server, const NodeId& id, Variant& value) {
     detail::throwOnBadStatus(status);
 }
 
-void writeDisplayName(
-    Server& server, const NodeId& id, std::string_view locale, std::string_view name
-) {
-    const auto status = UA_Server_writeDisplayName(
-        server.handle(), id, LocalizedText(locale, name)
-    );
+void writeDisplayName(Server& server, const NodeId& id, const LocalizedText& name) {
+    const auto status = UA_Server_writeDisplayName(server.handle(), id, name);
     detail::throwOnBadStatus(status);
 }
 
-void writeDescription(
-    Server& server, const NodeId& id, std::string_view locale, std::string_view name
-) {
-    const auto status = UA_Server_writeDescription(
-        server.handle(), id, LocalizedText(locale, name)
-    );
+void writeDescription(Server& server, const NodeId& id, const LocalizedText& name) {
+    const auto status = UA_Server_writeDescription(server.handle(), id, name);
     detail::throwOnBadStatus(status);
 }
 

--- a/tests/Services.cpp
+++ b/tests/Services.cpp
@@ -72,8 +72,8 @@ TEST_CASE("Attribute") {
         REQUIRE(services::readAccessLevel(server, id) == UA_ACCESSLEVELMASK_READ);
 
         // write new attributes
-        REQUIRE_NOTHROW(services::writeDisplayName(server, id, "en-US", "newDisplayName"));
-        REQUIRE_NOTHROW(services::writeDescription(server, id, "de-DE", "newDescription"));
+        REQUIRE_NOTHROW(services::writeDisplayName(server, id, {"en-US", "newDisplayName"}));
+        REQUIRE_NOTHROW(services::writeDescription(server, id, {"de-DE", "newDescription"}));
         REQUIRE_NOTHROW(services::writeWriteMask(server, id, 11));
         REQUIRE_NOTHROW(services::writeDataType(server, id, NodeId{0, 2}));
         REQUIRE_NOTHROW(services::writeValueRank(server, id, ValueRank::TwoDimensions));


### PR DESCRIPTION
Pass `LocalizedText` instead of members (`locale`, `text`) to `Node::writeDisplayName`, `Node::writeDescription`, `services::writeDisplayName`, `services::writeDescription`.

As discussed in #27.