### PR TITLE
feat: asWrapper function to cast native refs to wrapper refs

### DIFF
--- a/include/open62541pp/TypeConverter.h
+++ b/include/open62541pp/TypeConverter.h
@@ -276,10 +276,10 @@ struct TypeConverter<UA_ExtensionObject>
 
 template <typename WrapperType>
 struct TypeConverter<WrapperType, std::enable_if_t<detail::IsTypeWrapper<WrapperType>::value>> {
-    using NativeConverter = TypeConverter<typename WrapperType::UaType>;
+    using NativeConverter = TypeConverter<typename WrapperType::NativeType>;
 
     using ValueType = WrapperType;
-    using NativeType = typename WrapperType::UaType;
+    using NativeType = typename WrapperType::NativeType;
     using ValidTypes = TypeList<WrapperType::getType()>;
 
     static void fromNative(const NativeType& src, ValueType& dst) {

--- a/include/open62541pp/TypeWrapper.h
+++ b/include/open62541pp/TypeWrapper.h
@@ -23,10 +23,14 @@ namespace opcua {
  */
 
 /**
- * Template base class to wrap UA_* type objects.
+ * Template base class to wrap `UA_*` type objects.
  *
- * Zero cost abstraction to wrap the C API objects and delete them on destruction.
- * The derived classes should implement specific constructors to convert from other data types.
+ * Zero cost abstraction to wrap the C API objects and delete them on destruction. The derived
+ * classes should implement specific constructors to convert from other data types.
+ *
+ * `TypeWrapper<T, typeIndex>` is pointer-interconvertible to `T`. Use asWrapper(NativeType&) or
+ * asWrapper(constNativeType&) to cast native object references to wrapper object references.
+ *
  * @warning No virtual constructor defined, don't implement a destructor in the derived classes.
  * @ingroup TypeWrapper
  */
@@ -186,6 +190,41 @@ template <typename T>
 using IsTypeWrapper = decltype(isTypeWrapperImpl(std::declval<T*>()));
 
 }  // namespace detail
+
+/* ------------------------------ Cast native type to wrapper type ------------------------------ */
+
+namespace detail {
+
+template <typename T1, typename T2>
+constexpr void assertIsPointerInterconvertible() noexcept {
+    static_assert(std::is_standard_layout_v<T1>);
+    static_assert(std::is_standard_layout_v<T2>);
+    static_assert(sizeof(T1) == sizeof(T2));
+}
+
+}  // namespace detail
+
+/**
+ * Cast native `UA_*` type object references to TypeWrapper object references.
+ *
+ * This is especially helpful to avoid copies in getter methods of composed types.
+ * A reference to a native type object be casted to a reference to a wrapper object.
+ * @see https://en.cppreference.com/w/cpp/language/static_cast#pointer-interconvertible
+ * @ingroup TypeWrapper
+ */
+template <typename WrapperType, typename NativeType = typename WrapperType::Native>
+constexpr WrapperType& asWrapper(NativeType& native) noexcept {
+    detail::assertIsPointerInterconvertible<WrapperType, NativeType>();
+    return *static_cast<WrapperType*>(static_cast<void*>(&native));
+}
+
+/// @copydoc asWrapper(NativeType&)
+/// @ingroup TypeWrapper
+template <typename WrapperType, typename NativeType = typename WrapperType::Native>
+constexpr const WrapperType& asWrapper(const NativeType& native) noexcept {
+    detail::assertIsPointerInterconvertible<WrapperType, NativeType>();
+    return *static_cast<const WrapperType*>(static_cast<const void*>(&native));
+}
 
 /* ----------------------------------------- Comparison ----------------------------------------- */
 

--- a/include/open62541pp/TypeWrapper.h
+++ b/include/open62541pp/TypeWrapper.h
@@ -36,7 +36,7 @@ public:
     static_assert(typeIndex < UA_TYPES_COUNT);
 
     using TypeWrapperBase = TypeWrapper<T, typeIndex>;
-    using UaType = T;
+    using NativeType = T;
 
     TypeWrapper() = default;
 

--- a/include/open62541pp/types/NodeId.h
+++ b/include/open62541pp/types/NodeId.h
@@ -90,8 +90,11 @@ public:
 
     bool isLocal() const noexcept;
 
-    NodeId getNodeId() const noexcept;
+    NodeId& getNodeId() noexcept;
+    const NodeId& getNodeId() const noexcept;
+
     std::string_view getNamespaceUri() const;
+
     uint32_t getServerIndex() const noexcept;
 };
 

--- a/src/types/NodeId.cpp
+++ b/src/types/NodeId.cpp
@@ -78,8 +78,12 @@ bool ExpandedNodeId::isLocal() const noexcept {
     return detail::isEmpty(handle()->namespaceUri) && handle()->serverIndex == 0;
 }
 
-NodeId ExpandedNodeId::getNodeId() const noexcept {
-    return NodeId(handle()->nodeId);  // NOLINT
+NodeId& ExpandedNodeId::getNodeId() noexcept {
+    return asWrapper<NodeId>(handle()->nodeId);
+}
+
+const NodeId& ExpandedNodeId::getNodeId() const noexcept {
+    return asWrapper<NodeId>(handle()->nodeId);
 }
 
 std::string_view ExpandedNodeId::getNamespaceUri() const {

--- a/tests/TypeWrapper.cpp
+++ b/tests/TypeWrapper.cpp
@@ -169,3 +169,31 @@ TEMPLATE_TEST_CASE_SIG(
         REQUIRE(TypeWrapper<T, typeIndex>::getDataType() == &UA_TYPES[typeIndex]);
     }
 }
+
+TEST_CASE("asWrapper") {
+    class Int32Wrapper : public TypeWrapper<int32_t, UA_TYPES_INT32> {
+    public:
+        void increment() {
+            auto& ref = *handle();
+            ++ref;
+        }
+
+        int32_t get() const {
+            return *handle();
+        }
+    };
+
+    SECTION("non-const") {
+        int32_t value = 1;
+        Int32Wrapper& wrapper = asWrapper<Int32Wrapper>(value);
+        wrapper.increment();
+        REQUIRE(value == 2);
+        REQUIRE(wrapper.get() == 2);
+    }
+
+    SECTION("const") {
+        const int32_t value = 1;
+        const Int32Wrapper& wrapper = asWrapper<Int32Wrapper>(value);
+        REQUIRE(wrapper.get() == 1);
+    }
+}

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -171,6 +171,7 @@ TEST_CASE("ExpandedNodeId") {
     ExpandedNodeId idLocal({1, "local"}, {}, 0);
     REQUIRE(idLocal.isLocal());
     REQUIRE(idLocal.getNodeId() == NodeId{1, "local"});
+    REQUIRE(idLocal.getNodeId().handle() == &idLocal.handle()->nodeId);  // return ref
     REQUIRE(idLocal.getNamespaceUri().empty());
     REQUIRE(idLocal.getServerIndex() == 0);
 


### PR DESCRIPTION
As described in #30 to create efficient wrapper of composed types.