### PR TITLE
ci: test cmake package

### DIFF
--- a/.github/workflows/open62541-compatibility.yml
+++ b/.github/workflows/open62541-compatibility.yml
@@ -4,13 +4,13 @@ on: [push, pull_request]
 
 jobs:
   external-open62541:
-    name: open62541 ${{ matrix.version }} (${{ matrix.build }})
+    name: open62541 ${{ matrix.version }} (${{ matrix.library_type }})
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
         version: [v1.0, v1.1, v1.2, v1.3]
-        build: ["static", "shared"]
+        library_type: ["static", "shared"]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -28,7 +28,7 @@ jobs:
           mkdir build
           cd build
           cmake \
-            -DBUILD_SHARED_LIBS=${{ matrix.build == 'shared' }} \
+            -DBUILD_SHARED_LIBS=${{ matrix.library_type == 'shared' }} \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
             -DUA_NAMESPACE_ZERO=FULL \
             ..

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,25 @@
+name: Package
+
+on: [push, pull_request]
+
+jobs:
+  cmake:
+    name: CMake package
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Compile and install open62541/open62541pp
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          cmake --build .
+          sudo cmake --install .
+      - name: Compile examples (stand-alone)
+        run: |
+          mkdir build_examples
+          cd build_examples
+          cmake ../examples
+          cmake --build .

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -4,8 +4,13 @@ on: [push, pull_request]
 
 jobs:
   cmake:
-    name: CMake package
+    name: CMake package (${{ matrix.build_type }}, ${{ matrix.library_type }})
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: ["Debug", "Release"]
+        library_type: ["static", "shared"]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -14,7 +19,10 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake ..
+          cmake \
+            -DCMAKE_BUILD_TYPE=${{matrix.config.build_type}} \
+            -DBUILD_SHARED_LIBS=${{ matrix.library_type == 'shared' }} \
+            ..
           cmake --build .
           sudo cmake --install .
       - name: Compile examples (stand-alone)

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -21,5 +21,5 @@ jobs:
         run: |
           mkdir build_examples
           cd build_examples
-          cmake ../examples
+          cmake --debug-find ../examples
           cmake --build .

--- a/cmake/open62541ppConfig.cmake.in
+++ b/cmake/open62541ppConfig.cmake.in
@@ -3,15 +3,7 @@
 include(CMakeFindDependencyMacro)
 
 find_dependency(Threads REQUIRED)
-
-if(NOT @UAPP_INTERNAL_OPEN62541@)
-    # find_dependency has no option to provide hints for modules, so temporary add the path to CMAKE_MODULE_PATH
-    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
-
-    find_dependency(open62541 REQUIRED)
-
-    list(REMOVE_AT CMAKE_MODULE_PATH -1)
-endif()
+find_dependency(open62541 REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/open62541ppTargets.cmake")
 check_required_components(open62541pp)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,12 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(open62541pp_examples)
+
+if(NOT TARGET open62541pp)
+    # stand-alone build
+    find_package(open62541pp REQUIRED)
+endif()
+
 set(examples_sources
     client_connect.cpp
     client_find_servers.cpp
@@ -17,7 +26,7 @@ foreach(source ${examples_sources})
         ${target_name}
         PRIVATE
             open62541pp::open62541pp
-            open62541pp_project_options
+            $<TARGET_NAME_IF_EXISTS:open62541pp_project_options>  # not available in stand-alone
     )
     set_target_properties(
         ${target_name}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,6 +7,8 @@ if(NOT TARGET open62541pp)
     find_package(open62541pp REQUIRED)
 endif()
 
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin/examples)
+
 set(examples_sources
     client_connect.cpp
     client_find_servers.cpp
@@ -32,7 +34,6 @@ foreach(source ${examples_sources})
         ${target_name}
         PROPERTIES
             OUTPUT_NAME ${name}
-            RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/examples"
     )
     # disable clang-tidy check to avoid try/except blocks in examples
     if(CMAKE_CXX_CLANG_TIDY)


### PR DESCRIPTION
Add CI workflow to test CMake package (install target and config file) as discussed in #41.

The existing examples are used for testing. They can be built stand-alone with an external open62541pp installation. If everything works fine, the examples should compile without errors. Running those examples should not be necessary.