### PR TITLE
feat: mask class to simplify usage with enum masks

### DIFF
--- a/include/open62541pp/Common.h
+++ b/include/open62541pp/Common.h
@@ -14,7 +14,7 @@ using TypeIndex = uint16_t;
 
 /**
  * Built-in types.
- * @see https://reference.opcfoundation.org/v104/Core/docs/Part6/5.1.2/
+ * @see https://reference.opcfoundation.org/Core/Part6/v105/docs/5.1.2
  */
 enum class Type : TypeIndex {
     // clang-format off
@@ -89,23 +89,8 @@ constexpr std::string_view getNodeClassName(NodeClass nodeClass) {
 }
 
 /**
- * Value rank.
- */
-enum class ValueRank : int32_t {
-    // clang-format off
-    ScalarOrOneDimension = UA_VALUERANK_SCALAR_OR_ONE_DIMENSION,
-    Any                  = UA_VALUERANK_ANY,
-    Scalar               = UA_VALUERANK_SCALAR,
-    OneOrMoreDimensions  = UA_VALUERANK_ONE_OR_MORE_DIMENSIONS,
-    OneDimension         = UA_VALUERANK_ONE_DIMENSION,
-    TwoDimensions        = UA_VALUERANK_TWO_DIMENSIONS,
-    ThreeDimensions      = UA_VALUERANK_THREE_DIMENSIONS,
-    // clang-format on
-};
-
-/**
  * Reference types.
- * @see https://reference.opcfoundation.org/v104/Core/ReferenceTypes/
+ * @see https://reference.opcfoundation.org/Core/Part3/v105/docs/7
  * Missing reference types in open62541?
  * - AliasFor
  * - HasReaderGroup
@@ -160,8 +145,71 @@ enum class ReferenceType : uint16_t {
 };
 
 /**
+ * Write mask.
+ * Exposes the possibilities of a client to write the Attributes of the Node.
+ * @see https://reference.opcfoundation.org/Core/Part3/v105/docs/5.2.7
+ */
+enum class WriteMask : uint32_t {
+    // clang-format off
+    AccessLevel             = UA_WRITEMASK_ACCESSLEVEL,
+    ArrrayDimensions        = UA_WRITEMASK_ARRRAYDIMENSIONS,
+    BrowseName              = UA_WRITEMASK_BROWSENAME,
+    ContainsNoLoops         = UA_WRITEMASK_CONTAINSNOLOOPS,
+    DataType                = UA_WRITEMASK_DATATYPE,
+    Description             = UA_WRITEMASK_DESCRIPTION,
+    DisplayName             = UA_WRITEMASK_DISPLAYNAME,
+    EventNotifier           = UA_WRITEMASK_EVENTNOTIFIER,
+    Executable              = UA_WRITEMASK_EXECUTABLE,
+    Historizing             = UA_WRITEMASK_HISTORIZING,
+    InverseName             = UA_WRITEMASK_INVERSENAME,
+    IsAbstract              = UA_WRITEMASK_ISABSTRACT,
+    MinimumSamplingInterval = UA_WRITEMASK_MINIMUMSAMPLINGINTERVAL,
+    NodeClass               = UA_WRITEMASK_NODECLASS,
+    NodeId                  = UA_WRITEMASK_NODEID,
+    Symmetric               = UA_WRITEMASK_SYMMETRIC,
+    UserAccesslevel         = UA_WRITEMASK_USERACCESSLEVEL,
+    UserExecutable          = UA_WRITEMASK_USEREXECUTABLE,
+    UserWritemask           = UA_WRITEMASK_USERWRITEMASK,
+    ValueRank               = UA_WRITEMASK_VALUERANK,
+    WriteMask               = UA_WRITEMASK_WRITEMASK,
+    ValueForVariableType    = UA_WRITEMASK_VALUEFORVARIABLETYPE,
+    // clang-format on
+};
+
+/**
+ * Access level.
+ * @see https://reference.opcfoundation.org/Core/Part3/v105/docs/8.57
+ */
+enum class AccessLevel : uint8_t {
+    // clang-format off
+    Read           = UA_ACCESSLEVELMASK_READ,
+    Write          = UA_ACCESSLEVELMASK_WRITE,
+    HistoryRead    = UA_ACCESSLEVELMASK_HISTORYREAD,
+    HistoryWrite   = UA_ACCESSLEVELMASK_HISTORYWRITE,
+    SemanticChange = UA_ACCESSLEVELMASK_SEMANTICCHANGE,
+    StatusWrite    = UA_ACCESSLEVELMASK_STATUSWRITE,
+    TimestampwWite = UA_ACCESSLEVELMASK_TIMESTAMPWRITE,
+    // clang-format on
+};
+
+/**
+ * Value rank.
+ */
+enum class ValueRank : int32_t {
+    // clang-format off
+    ScalarOrOneDimension = UA_VALUERANK_SCALAR_OR_ONE_DIMENSION,
+    Any                  = UA_VALUERANK_ANY,
+    Scalar               = UA_VALUERANK_SCALAR,
+    OneOrMoreDimensions  = UA_VALUERANK_ONE_OR_MORE_DIMENSIONS,
+    OneDimension         = UA_VALUERANK_ONE_DIMENSION,
+    TwoDimensions        = UA_VALUERANK_TWO_DIMENSIONS,
+    ThreeDimensions      = UA_VALUERANK_THREE_DIMENSIONS,
+    // clang-format on
+};
+
+/**
  * Modelling rules.
- * @see https://reference.opcfoundation.org/v104/Core/docs/Part3/6.4.4/
+ * @see https://reference.opcfoundation.org/Core/Part3/v105/docs/6.4.4
  */
 enum class ModellingRule : uint16_t {
     // clang-format off
@@ -176,13 +224,15 @@ enum class ModellingRule : uint16_t {
 /**
  * Browse direction.
  * An enumeration that specifies the direction of references to follow.
- * @see https://reference.opcfoundation.org/Core/Part4/v104/docs/5.8.2
+ * @see https://reference.opcfoundation.org/Core/Part4/v105/docs/5.8.2
  */
 enum class BrowseDirection : uint32_t {
+    // clang-format off
     Forward = UA_BROWSEDIRECTION_FORWARD,
     Inverse = UA_BROWSEDIRECTION_INVERSE,
-    Both = UA_BROWSEDIRECTION_BOTH,
+    Both    = UA_BROWSEDIRECTION_BOTH,
     Invalid = UA_BROWSEDIRECTION_INVALID,
+    // clang-format on
 };
 
 namespace detail {

--- a/include/open62541pp/Mask.h
+++ b/include/open62541pp/Mask.h
@@ -1,0 +1,155 @@
+#pragma once
+
+#include <initializer_list>
+#include <type_traits>
+
+namespace opcua {
+
+/**
+ * Bit mask using (scoped) enums as flags.
+ * This class allows scoped enums to be used interchangeable with the native `UA_*` enums.
+ * Additional methods to test/set/reset/flip bits similar to `std::bitset`.
+ */
+template <typename T>
+class Mask {
+public:
+    static_assert(std::is_enum_v<T>, "Template type must be an enumeration type");
+
+    /// Underlying type of enum.
+    using U = std::underlying_type_t<T>;
+
+    /// Create empty mask.
+    constexpr Mask() = default;
+
+    /// Create mask with single flag.
+    constexpr Mask(T flag)  // NOLINT
+        : mask_(static_cast<U>(flag)) {}
+
+    /// Create mask with flag(s) of underlying type.
+    constexpr Mask(U flag)  // NOLINT
+        : mask_(flag) {}
+
+    /// Create mask with OR-combined flags.
+    constexpr Mask(std::initializer_list<T> flags) {  // NOLINT
+        for (auto flag : flags) {
+            set(flag);
+        }
+    }
+
+    /// Get mask as underlying type.
+    constexpr auto get() const noexcept {
+        return mask_;
+    }
+
+    /// Implicit conversion to underlying type.
+    constexpr operator U() noexcept {  // NOLINT
+        return get();
+    }
+
+    /// Set a specific flag (underlying type) to 1.
+    constexpr void set(U flag) noexcept {
+        mask_ |= flag;
+    }
+
+    /// Set a specific flag to 1.
+    constexpr void set(T flag) noexcept {
+        set(static_cast<U>(flag));
+    }
+
+    /// Reset all flags to 0.
+    constexpr void reset() noexcept {
+        mask_ = nullValue;
+    }
+
+    /// Reset a specific flag (underlying type) to 0.
+    constexpr void reset(U flag) noexcept {
+        mask_ &= ~flag;
+    }
+
+    /// Reset a specific flag to 0.
+    constexpr void reset(T flag) noexcept {
+        reset(static_cast<U>(flag));
+    }
+
+    /// Flip all bits.
+    constexpr void flip() noexcept {
+        mask_ = ~mask_;
+    }
+
+    /// Test if a specific flag (underlying type) is set.
+    constexpr bool test(U flag) const noexcept {
+        return (mask_ & flag) != nullValue;
+    }
+
+    /// Test if a specific flag is set.
+    constexpr bool test(T flag) const noexcept {
+        return test(static_cast<U>(flag));
+    }
+
+    /// Check if no flags are set.
+    constexpr bool none() const noexcept {
+        return mask_ == nullValue;
+    }
+
+    /// Check if any flags are set.
+    constexpr bool any() const noexcept {
+        return mask_ != nullValue;
+    }
+
+    /// Check if all flags are set.
+    constexpr bool all() const noexcept {
+        constexpr U all = ~nullValue;
+        return mask_ == all;
+    }
+
+private:
+    static constexpr U nullValue{};
+    U mask_{};
+};
+
+/* ---------------------------------------------------------------------------------------------- */
+
+template <typename T>
+constexpr Mask<T> operator|(Mask<T> left, Mask<T> right) {
+    return left.get() | right.get();
+}
+
+template <typename T, typename TFlag>
+constexpr Mask<T> operator|(Mask<T> mask, TFlag flag) {
+    using U = typename Mask<T>::U;
+    return mask.get() | static_cast<U>(flag);
+}
+
+template <typename T, typename TFlag>
+constexpr Mask<T> operator|(TFlag flag, Mask<T> mask) {
+    return mask | flag;
+}
+
+template <typename T, typename TFlag>
+constexpr Mask<T>& operator|=(Mask<T>& mask, TFlag flag) {
+    mask.set(flag);
+    return mask;
+}
+
+template <typename T, typename TFlag>
+constexpr bool operator==(Mask<T> mask, TFlag flag) noexcept {
+    using U = typename Mask<T>::U;
+    return mask.get() == static_cast<U>(flag);
+}
+
+template <typename T, typename TFlag>
+constexpr bool operator==(TFlag flag, Mask<T> mask) noexcept {
+    return mask == flag;
+}
+
+template <typename T, typename TFlag>
+constexpr bool operator!=(Mask<T> mask, TFlag flag) noexcept {
+    return !(mask == flag);
+}
+
+template <typename T, typename TFlag>
+constexpr bool operator!=(TFlag flag, Mask<T> mask) noexcept {
+    return !(mask == flag);
+}
+
+}  // namespace opcua

--- a/include/open62541pp/Mask.h
+++ b/include/open62541pp/Mask.h
@@ -7,7 +7,15 @@ namespace opcua {
 
 /**
  * Bit mask using (scoped) enums as flags.
- * This class allows scoped enums to be used interchangeable with the native `UA_*` enums.
+ *
+ * This class allows scoped enums to be used interchangeable with the native `UA_*` enums:
+ * @code{.cpp}
+ * // construct with scoped enums
+ * Mask<NodeClass> mask = NodeClass::Object;
+ * Mask<NodeClass> mask{NodeClass::Object, NodeClass::Variable};  // OR combination
+ * // construct with unscoped (native) enums
+ * Mask<NodeClass> mask = UA_NODECLASS_VARIABLE | UA_NODECLASS_OBJECT;
+ * @endcode
  * Additional methods to test/set/reset/flip bits similar to `std::bitset`.
  */
 template <typename T>

--- a/include/open62541pp/Node.h
+++ b/include/open62541pp/Node.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "open62541pp/Common.h"
+#include "open62541pp/Mask.h"
 #include "open62541pp/Server.h"
 #include "open62541pp/TypeConverter.h"  // guessType
 #include "open62541pp/services/services.h"
@@ -138,7 +139,7 @@ public:
         BrowseDirection browseDirection = BrowseDirection::Both,
         ReferenceType referenceType = ReferenceType::References,
         bool includeSubtypes = true,
-        uint32_t nodeClassMask = UA_NODECLASS_UNSPECIFIED
+        Mask<NodeClass> nodeClassMask = NodeClass::Unspecified
     );
 
     /// Browse referenced nodes (only local nodes).
@@ -146,13 +147,13 @@ public:
         BrowseDirection browseDirection = BrowseDirection::Both,
         ReferenceType referenceType = ReferenceType::References,
         bool includeSubtypes = true,
-        uint32_t nodeClassMask = UA_NODECLASS_UNSPECIFIED
+        Mask<NodeClass> nodeClassMask = NodeClass::Unspecified
     );
 
     /// Browse child nodes (only local nodes).
     std::vector<Node> browseChildren(
         ReferenceType referenceType = ReferenceType::HierarchicalReferences,
-        uint32_t nodeClassMask = UA_NODECLASS_UNSPECIFIED
+        Mask<NodeClass> nodeClassMask = NodeClass::Unspecified
     ) {
         return browseReferencedNodes(BrowseDirection::Forward, referenceType, true, nodeClassMask);
     }
@@ -188,12 +189,12 @@ public:
     }
 
     /// @copydoc services::readWriteMask
-    uint32_t readWriteMask() {
+    Mask<WriteMask> readWriteMask() {
         return services::readWriteMask(connection_, nodeId_);
     }
 
     /// @copydoc services::readUserWriteMask
-    uint32_t readUserWriteMask() {
+    Mask<WriteMask> readUserWriteMask() {
         return services::readUserWriteMask(connection_, nodeId_);
     }
 
@@ -254,12 +255,12 @@ public:
     }
 
     /// @copydoc services::readAccessLevel
-    uint8_t readAccessLevel() {
+    Mask<AccessLevel> readAccessLevel() {
         return services::readAccessLevel(connection_, nodeId_);
     }
 
     /// @copydoc services::readUserAccessLevel
-    uint8_t readUserAccessLevel() {
+    Mask<AccessLevel> readUserAccessLevel() {
         return services::readUserAccessLevel(connection_, nodeId_);
     }
 
@@ -279,12 +280,12 @@ public:
     }
 
     /// @copydoc services::writeWriteMask
-    void writeWriteMask(uint32_t mask) {
+    void writeWriteMask(Mask<WriteMask> mask) {
         services::writeWriteMask(connection_, nodeId_, mask);
     }
 
     /// @copydoc services::writeWriteMask
-    void writeUserWriteMask(uint32_t mask) {
+    void writeUserWriteMask(Mask<WriteMask> mask) {
         services::writeUserWriteMask(connection_, nodeId_, mask);
     }
 
@@ -363,12 +364,12 @@ public:
     }
 
     /// @copydoc services::writeAccessLevel
-    void writeAccessLevel(uint8_t mask) {
+    void writeAccessLevel(Mask<AccessLevel> mask) {
         services::writeAccessLevel(connection_, nodeId_, mask);
     }
 
     /// @copydoc services::writeUserAccessLevel
-    void writeUserAccessLevel(uint8_t mask) {
+    void writeUserAccessLevel(Mask<AccessLevel> mask) {
         services::writeUserAccessLevel(connection_, nodeId_, mask);
     }
 

--- a/include/open62541pp/open62541pp.h
+++ b/include/open62541pp/open62541pp.h
@@ -5,6 +5,7 @@
 #include "open62541pp/Common.h"
 #include "open62541pp/ErrorHandling.h"
 #include "open62541pp/Logger.h"
+#include "open62541pp/Mask.h"
 #include "open62541pp/Node.h"
 #include "open62541pp/Server.h"
 #include "open62541pp/TypeConverter.h"

--- a/include/open62541pp/services/Attribute.h
+++ b/include/open62541pp/services/Attribute.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "open62541pp/Common.h"
+#include "open62541pp/Mask.h"
 #include "open62541pp/detail/helper.h"
 #include "open62541pp/types/Builtin.h"
 #include "open62541pp/types/DataValue.h"
@@ -38,7 +39,7 @@ namespace opcua::services {
  * - UserExecutable
  *
  * @see https://www.open62541.org/doc/1.3/server.html
- * @see https://reference.opcfoundation.org/Core/Part3/v105/docs
+ * @see https://reference.opcfoundation.org/Core/Part4/v105/docs/5.10
  * @ingroup Services
  */
 
@@ -138,7 +139,7 @@ inline LocalizedText readDescription(T& serverOrClient, const NodeId& id) {
  * @ingroup Attribute
  */
 template <typename T>
-inline uint32_t readWriteMask(T& serverOrClient, const NodeId& id) {
+inline Mask<WriteMask> readWriteMask(T& serverOrClient, const NodeId& id) {
     return readAttributeScalar<uint32_t>(serverOrClient, id, UA_ATTRIBUTEID_WRITEMASK);
 }
 
@@ -150,7 +151,7 @@ inline uint32_t readWriteMask(T& serverOrClient, const NodeId& id) {
  * @ingroup Attribute
  */
 template <typename T>
-inline uint32_t readUserWriteMask(T& serverOrClient, const NodeId& id) {
+inline Mask<WriteMask> readUserWriteMask(T& serverOrClient, const NodeId& id) {
     return readAttributeScalar<uint32_t>(serverOrClient, id, UA_ATTRIBUTEID_USERWRITEMASK);
 }
 
@@ -253,7 +254,7 @@ inline std::vector<uint32_t> readArrayDimensions(T& serverOrClient, const NodeId
  * @ingroup Attribute
  */
 template <typename T>
-inline uint8_t readAccessLevel(T& serverOrClient, const NodeId& id) {
+inline Mask<AccessLevel> readAccessLevel(T& serverOrClient, const NodeId& id) {
     return readAttributeScalar<uint8_t>(serverOrClient, id, UA_ATTRIBUTEID_ACCESSLEVEL);
 }
 
@@ -265,7 +266,7 @@ inline uint8_t readAccessLevel(T& serverOrClient, const NodeId& id) {
  * @ingroup Attribute
  */
 template <typename T>
-inline uint8_t readUserAccessLevel(T& serverOrClient, const NodeId& id) {
+inline Mask<AccessLevel> readUserAccessLevel(T& serverOrClient, const NodeId& id) {
     return readAttributeScalar<uint8_t>(serverOrClient, id, UA_ATTRIBUTEID_USERACCESSLEVEL);
 }
 
@@ -310,8 +311,8 @@ inline void writeDescription(T& serverOrClient, const NodeId& id, const Localize
  * @ingroup Attribute
  */
 template <typename T>
-inline void writeWriteMask(T& serverOrClient, const NodeId& id, uint32_t mask) {
-    writeAttribute(serverOrClient, id, UA_ATTRIBUTEID_WRITEMASK, DataValue::fromScalar(mask));
+inline void writeWriteMask(T& serverOrClient, const NodeId& id, Mask<WriteMask> mask) {
+    writeAttribute(serverOrClient, id, UA_ATTRIBUTEID_WRITEMASK, DataValue::fromScalar(mask.get()));
 }
 
 /**
@@ -321,8 +322,10 @@ inline void writeWriteMask(T& serverOrClient, const NodeId& id, uint32_t mask) {
  * @ingroup Attribute
  */
 template <typename T>
-inline void writeUserWriteMask(T& serverOrClient, const NodeId& id, uint32_t mask) {
-    writeAttribute(serverOrClient, id, UA_ATTRIBUTEID_USERWRITEMASK, DataValue::fromScalar(mask));
+inline void writeUserWriteMask(T& serverOrClient, const NodeId& id, Mask<WriteMask> mask) {
+    writeAttribute(
+        serverOrClient, id, UA_ATTRIBUTEID_USERWRITEMASK, DataValue::fromScalar(mask.get())
+    );
 }
 
 /**
@@ -436,8 +439,8 @@ inline void writeArrayDimensions(
  * @ingroup Attribute
  */
 template <typename T>
-inline void writeAccessLevel(T& serverOrClient, const NodeId& id, uint8_t mask) {
-    const auto native = static_cast<UA_Byte>(mask);
+inline void writeAccessLevel(T& serverOrClient, const NodeId& id, Mask<AccessLevel> mask) {
+    const auto native = static_cast<UA_Byte>(mask.get());
     writeAttribute(serverOrClient, id, UA_ATTRIBUTEID_ACCESSLEVEL, DataValue::fromScalar(native));
 }
 
@@ -448,8 +451,8 @@ inline void writeAccessLevel(T& serverOrClient, const NodeId& id, uint8_t mask) 
  * @ingroup Attribute
  */
 template <typename T>
-inline void writeUserAccessLevel(T& serverOrClient, const NodeId& id, uint8_t mask) {
-    const auto native = static_cast<UA_Byte>(mask);
+inline void writeUserAccessLevel(T& serverOrClient, const NodeId& id, Mask<AccessLevel> mask) {
+    const auto native = static_cast<UA_Byte>(mask.get());
     writeAttribute(
         serverOrClient, id, UA_ATTRIBUTEID_USERACCESSLEVEL, DataValue::fromScalar(native)
     );

--- a/include/open62541pp/types/Builtin.h
+++ b/include/open62541pp/types/Builtin.h
@@ -88,8 +88,8 @@ public:
  * The format of locale is `<language>[-<country/region>]`:
  * - `<language>` is the two letter ISO 639 code for a language
  * - `<country/region>` is the two letter ISO 3166 code for the country/region
- * @see https://reference.opcfoundation.org/Core/Part3/v104/docs/8.5/
- * @see https://reference.opcfoundation.org/Core/Part3/v104/docs/8.4/
+ * @see https://reference.opcfoundation.org/Core/Part3/v105/docs/8.5/
+ * @see https://reference.opcfoundation.org/Core/Part3/v105/docs/8.4/
  * @ingroup TypeWrapper
  */
 class LocalizedText : public TypeWrapper<UA_LocalizedText, UA_TYPES_LOCALIZEDTEXT> {

--- a/include/open62541pp/types/Composed.h
+++ b/include/open62541pp/types/Composed.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "open62541pp/Mask.h"
 #include "open62541pp/TypeConverter.h"
 #include "open62541pp/TypeWrapper.h"
 #include "open62541pp/types/Builtin.h"
@@ -105,7 +106,7 @@ public:
         BrowseDirection browseDirection,
         ReferenceType referenceType = ReferenceType::References,
         bool includeSubtypes = true,
-        uint32_t nodeClassMask = UA_NODECLASS_UNSPECIFIED,
+        Mask<NodeClass> nodeClassMask = NodeClass::Unspecified,
         uint32_t resultMask = UA_BROWSERESULTMASK_ALL
     );
 
@@ -113,7 +114,7 @@ public:
     UAPP_COMPOSED_GETTER_CAST(BrowseDirection, getBrowseDirection, browseDirection)
     UAPP_COMPOSED_GETTER_WRAPPER(NodeId, getReferenceTypeId, referenceTypeId)
     UAPP_COMPOSED_GETTER(bool, getIncludeSubtypes, includeSubtypes)
-    UAPP_COMPOSED_GETTER(uint32_t, getNodeClassMask, nodeClassMask)
+    UAPP_COMPOSED_GETTER(Mask<NodeClass>, getNodeClassMask, nodeClassMask)
     UAPP_COMPOSED_GETTER(uint32_t, getResultMask, resultMask)
 };
 

--- a/include/open62541pp/types/DataValue.h
+++ b/include/open62541pp/types/DataValue.h
@@ -13,7 +13,7 @@ namespace opcua {
 
 /**
  * UA_DataValue wrapper class.
- * @see https://reference.opcfoundation.org/v104/Core/docs/Part4/7.7
+ * @see https://reference.opcfoundation.org/Core/Part4/v105/docs/7.11
  * @ingroup TypeWrapper
  */
 class DataValue : public TypeWrapper<UA_DataValue, UA_TYPES_DATAVALUE> {

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -15,14 +15,14 @@ std::vector<ReferenceDescription> Node<T>::browseReferences(
     BrowseDirection browseDirection,
     ReferenceType referenceType,
     bool includeSubtypes,
-    uint32_t nodeClassMask
+    Mask<NodeClass> nodeClassMask
 ) {
     const BrowseDescription bd(
         nodeId_,
         browseDirection,
         referenceType,
         includeSubtypes,
-        nodeClassMask,
+        nodeClassMask.get(),
         UA_BROWSERESULTMASK_ALL
     );
     return services::browseAll(connection_, bd);
@@ -33,14 +33,14 @@ std::vector<Node<T>> Node<T>::browseReferencedNodes(
     BrowseDirection browseDirection,
     ReferenceType referenceType,
     bool includeSubtypes,
-    uint32_t nodeClassMask
+    Mask<NodeClass> nodeClassMask
 ) {
     const BrowseDescription bd(
         nodeId_,
         browseDirection,
         referenceType,
         includeSubtypes,
-        nodeClassMask,
+        nodeClassMask.get(),
         UA_BROWSERESULTMASK_TARGETINFO  // only node id required here
     );
     const auto refs = services::browseAll(connection_, bd);

--- a/src/types/Composed.cpp
+++ b/src/types/Composed.cpp
@@ -9,14 +9,14 @@ BrowseDescription::BrowseDescription(
     BrowseDirection browseDirection,
     ReferenceType referenceType,
     bool includeSubtypes,
-    uint32_t nodeClassMask,  // NOLINT
+    Mask<NodeClass> nodeClassMask,  // NOLINT
     uint32_t resultMask  // NOLINT
 ) {
     asWrapper<NodeId>(handle()->nodeId) = nodeId;
     handle()->browseDirection = static_cast<UA_BrowseDirection>(browseDirection);
     handle()->referenceTypeId = detail::getUaNodeId(referenceType);
     handle()->includeSubtypes = includeSubtypes;
-    handle()->nodeClassMask = nodeClassMask;
+    handle()->nodeClassMask = nodeClassMask.get();
     handle()->resultMask = resultMask;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(
     main.cpp
     Client.cpp
     helper.cpp
+    Mask.cpp
     Node.cpp
     overloads.cpp
     Server.cpp

--- a/tests/Mask.cpp
+++ b/tests/Mask.cpp
@@ -1,0 +1,114 @@
+#include <cstdint>
+
+#include <doctest/doctest.h>
+
+#include "open62541pp/Mask.h"
+
+using namespace opcua;
+
+enum class Flags : uint8_t {
+    Bit1 = 0b00000001,
+    Bit2 = 0b00000010,
+    Bit3 = 0b00000100,
+    Bit4 = 0b00001000,
+    Bit5 = 0b00010000,
+    Bit6 = 0b00100000,
+    Bit7 = 0b01000000,
+    Bit8 = 0b10000000,
+};
+
+TEST_CASE("Mask") {
+    SUBCASE("Empty") {
+        Mask<Flags> mask;
+        CHECK(mask.get() == 0b00000000);
+        CHECK(mask.none());
+        CHECK_FALSE(mask.any());
+        CHECK_FALSE(mask.all());
+    }
+
+    SUBCASE("Construct with enum value") {
+        Mask<Flags> mask = Flags::Bit3;
+        CHECK(mask.get() == 0b00000100);
+    }
+
+    SUBCASE("Construct with enum values") {
+        Mask<Flags> mask{Flags::Bit1, Flags::Bit3};
+        CHECK(mask.get() == 0b00000101);
+    }
+
+    SUBCASE("Construct with underlying value") {
+        Mask<Flags> mask = 1 | 2;
+        CHECK(mask.get() == 0b00000011);
+    }
+
+    SUBCASE("Set flag") {
+        Mask<Flags> mask;
+        mask.set(Flags::Bit7);
+        mask.set(Flags::Bit8);
+        CHECK(mask.get() == 0b11000000);
+    }
+
+    SUBCASE("Reset flags") {
+        Mask<Flags> mask{Flags::Bit1, Flags::Bit2};
+        mask.reset();
+        CHECK(mask.get() == 0b00000000);
+    }
+
+    SUBCASE("Reset specific flag") {
+        Mask<Flags> mask = Flags::Bit2;
+        mask.reset(Flags::Bit2);
+        CHECK(mask.get() == 0b00000000);
+    }
+
+    SUBCASE("Flip bits") {
+        Mask<Flags> mask = Flags::Bit2;
+        mask.flip();
+        CHECK(mask.get() == 0b11111101);
+    }
+
+    SUBCASE("Test flags") {
+        Mask<Flags> mask{Flags::Bit1, Flags::Bit2};
+        CHECK(mask.test(Flags::Bit1));
+        CHECK(mask.test(Flags::Bit2));
+        CHECK_FALSE(mask.test(Flags::Bit3));
+    }
+
+    SUBCASE("None") {
+        CHECK(Mask<Flags>().none());
+        CHECK_FALSE(Mask<Flags>(Flags::Bit1).none());
+    }
+
+    SUBCASE("Any") {
+        CHECK_FALSE(Mask<Flags>().any());
+        CHECK(Mask<Flags>(Flags::Bit1).any());
+    }
+
+    SUBCASE("All") {
+        CHECK_FALSE(Mask<Flags>(Flags::Bit1).all());
+        CHECK(Mask<Flags>(0b11111111).all());
+    }
+}
+
+TEST_CASE("Mask overloads") {
+    SUBCASE("OR") {
+        CHECK((Mask<Flags>(Flags::Bit1) | Mask<Flags>(Flags::Bit2)).get() == 0b00000011);
+        CHECK((Mask<Flags>(Flags::Bit1) | Flags::Bit2).get() == 0b00000011);
+        CHECK((Flags::Bit1 | Mask<Flags>(Flags::Bit2)).get() == 0b00000011);
+    }
+
+    SUBCASE("OR assignment") {
+        Mask<Flags> mask;
+        mask |= Flags::Bit1;
+        CHECK(mask.get() == 0b00000001);
+        mask |= Mask<Flags>(Flags::Bit2);
+        CHECK(mask.get() == 0b00000011);
+    }
+
+    SUBCASE("Comparison") {
+        CHECK(Mask<Flags>(Flags::Bit1) == 0b00000001);
+        CHECK(Mask<Flags>(Flags::Bit1) != 0);
+
+        CHECK(1 == Mask<Flags>(Flags::Bit1));
+        CHECK(1 != Mask<Flags>());
+    }
+}

--- a/tests/Services.cpp
+++ b/tests/Services.cpp
@@ -122,14 +122,12 @@ TEST_CASE("Attribute (server)") {
         CHECK(services::readDescription(server, id).getText().empty());
         CHECK(services::readDescription(server, id).getLocale().empty());
         CHECK(services::readWriteMask(server, id) == 0);
-        const uint32_t adminUserWriteMask = ~0;  // all bits set
-        CHECK(services::readUserWriteMask(server, id) == adminUserWriteMask);
+        CHECK(services::readUserWriteMask(server, id).all());  // -> admin rights
         CHECK(services::readDataType(server, id) == NodeId(0, UA_NS0ID_BASEDATATYPE));
         CHECK(services::readValueRank(server, id) == ValueRank::Any);
         CHECK(services::readArrayDimensions(server, id).empty());
         CHECK(services::readAccessLevel(server, id) == UA_ACCESSLEVELMASK_READ);
-        const uint8_t adminUserAccessLevel = ~0;  // all bits set
-        CHECK(services::readUserAccessLevel(server, id) == adminUserAccessLevel);
+        CHECK(services::readUserAccessLevel(server, id).all());  // -> admin rights
         CHECK(services::readMinimumSamplingInterval(server, id) == 0.0);
 
         // write new attributes

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -504,7 +504,7 @@ TEST_CASE("BrowseDescription") {
     CHECK(bd.getBrowseDirection() == BrowseDirection::Forward);
     CHECK(bd.getReferenceTypeId() == NodeId(0, UA_NS0ID_REFERENCES));
     CHECK(bd.getIncludeSubtypes() == true);
-    CHECK(bd.getNodeClassMask() == UA_NODECLASS_UNSPECIFIED);
+    CHECK(bd.getNodeClassMask().get() == UA_NODECLASS_UNSPECIFIED);
     CHECK(bd.getResultMask() == UA_BROWSERESULTMASK_ALL);
 }
 


### PR DESCRIPTION
Idea to simplify handling with enum masks and add (a little bit) type-safety.

 This class allows scoped enums to be used interchangeable with the native `UA_*` enums:

```cpp
// construct with scoped enums
Mask<NodeClass> mask = NodeClass::Object;
Mask<NodeClass> mask{NodeClass::Object, NodeClass::Variable};  // OR combination
// construct with unscoped (native) enums
Mask<NodeClass> mask = UA_NODECLASS_VARIABLE | UA_NODECLASS_OBJECT;
```

Additional methods to set/reset/flip flags:
```cpp
Mask<NodeClass> mask;
mask.set(NodeClass::Object);
mask.flip();  // all flags set except NodeClass::Object
mask.reset(NodeClass::Method);  // set NodeClass::Method flag to 0
// ...
```

@duca, is this any helpful or just over-engineering?