### PR TITLE
fix: amalgamation support

### DIFF
--- a/.github/workflows/open62541-compatibility.yml
+++ b/.github/workflows/open62541-compatibility.yml
@@ -4,7 +4,11 @@ on: [push, pull_request]
 
 jobs:
   external-open62541:
-    name: open62541 ${{ matrix.version }} (${{ matrix.build_type }}, ${{ matrix.library_type }})
+    name: >-
+      ${{ matrix.version }}
+      (${{ matrix.build_type }},
+      ${{ matrix.library_type }},
+      ${{ matrix.amalgamation && 'amalgamated' || 'default' }})
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
@@ -16,6 +20,7 @@ jobs:
           - v1.3.5
         build_type: ["Debug", "Release"]
         library_type: ["static", "shared"]
+        amalgamation: [false, true]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -37,6 +42,7 @@ jobs:
           cmake \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DBUILD_SHARED_LIBS=${{ matrix.library_type == 'shared' }} \
+            -DUA_ENABLE_AMALGAMATION=${{ matrix.amalgamation }} \
             ..
           cmake --build .
           sudo cmake --install .

--- a/include/open62541pp/open62541.h
+++ b/include/open62541pp/open62541.h
@@ -1,5 +1,7 @@
 #pragma once
 
+// public open62541 headers needed by open62541++
+
 #ifndef _MSC_VER
 // ignore compile warnings of open62541 v1.3:
 // - missing initializer for member ‘UA_NodeId::identifier’
@@ -9,10 +11,15 @@
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
 #endif
 
-// public open62541 headers needed by open62541++
+#if __has_include(<open62541.h>)
+// UA_ENABLE_AMALGAMATION=ON
+#include <open62541.h>
+#else
+// UA_ENABLE_AMALGAMATION=OFF
 #include <open62541/nodeids.h>
 #include <open62541/types.h>
 #include <open62541/types_generated.h>
+#endif
 
 #ifndef _MSC_VER
 #pragma GCC diagnostic pop

--- a/src/open62541_impl.h
+++ b/src/open62541_impl.h
@@ -10,6 +10,12 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #endif
 
+#if __has_include(<open62541.h>)
+// UA_ENABLE_AMALGAMATION=ON
+#include <open62541.h>
+#else
+
+// UA_ENABLE_AMALGAMATION=OFF
 // common
 #include <open62541/config.h>
 #include <open62541/plugin/accesscontrol_default.h>
@@ -30,6 +36,8 @@
 #include <open62541/server_config.h>
 #endif
 #include <open62541/server_config_default.h>
+
+#endif
 
 #ifndef _MSC_VER
 #pragma GCC diagnostic pop


### PR DESCRIPTION
Fix support for open62541 with amalgamated header and source files as reported in issue #46.
Amalgamation is enabled with the `UA_ENABLE_AMALGAMATION` CMake option.