### PR TITLE
feat: client state callbacks

### DIFF
--- a/examples/client_minimal.cpp
+++ b/examples/client_minimal.cpp
@@ -4,10 +4,16 @@
 
 int main() {
     opcua::Client client;
+    client.onConnected([] { std::cout << "Connected\n"; });
+    client.onDisconnected([] { std::cout << "Disconnected\n"; });
+    client.onSessionActivated([] { std::cout << "Session activated\n"; });
+    client.onSessionClosed([] { std::cout << "Session closed\n"; });
+
     client.connect("opc.tcp://localhost:4840");
 
     auto node = client.getNode(opcua::VariableId::Server_ServerStatus_CurrentTime);
     const auto dt = node.readScalar<opcua::DateTime>();
 
     std::cout << "Server date (UTC): " << dt.format("%Y-%m-%d %H:%M:%S") << std::endl;
+    client.disconnect();
 }

--- a/examples/client_subscription.cpp
+++ b/examples/client_subscription.cpp
@@ -6,41 +6,56 @@
 
 int main() {
     opcua::Client client;
-    client.connect("opc.tcp://localhost:4840");
 
-    auto sub = client.createSubscription();
+    // Add a state callback (session activated) to create subscription(s) and monitored items(s) in
+    // a newly activated session. If the client is disconnected, the subscriptions and monitored
+    // items are deleted. This approach with the state callback assures, that the subscriptions are
+    // recreated whenever the client reconnects to the server.
+    client.onSessionActivated([&] {
+        auto sub = client.createSubscription();
 
-    // Modify and delete the subscription via the returend Subscription<T> object
-    opcua::SubscriptionParameters subscriptionParameters{};
-    subscriptionParameters.publishingInterval = 1000.0;
-    sub.setSubscriptionParameters(subscriptionParameters);
-    sub.setPublishingMode(true);
-    // sub.deleteSubscription();
+        // Modify and delete the subscription via the returend Subscription<T> object
+        opcua::SubscriptionParameters subscriptionParameters{};
+        subscriptionParameters.publishingInterval = 1000.0;
+        sub.setSubscriptionParameters(subscriptionParameters);
+        sub.setPublishingMode(true);
+        // sub.deleteSubscription();
 
-    // Create a monitored item within the subscription for data change notifications
-    auto mon = sub.subscribeDataChange(
-        opcua::VariableId::Server_ServerStatus_CurrentTime,  // monitored node id
-        opcua::AttributeId::Value,  // monitored attribute
-        [](const auto& item, const opcua::DataValue& value) {
-            std::cout << "Data change notification:\n"
-                      << "- subscription id:   " << item.getSubscriptionId() << "\n"
-                      << "- monitored item id: " << item.getMonitoredItemId() << "\n"
-                      << "- node id:           " << item.getNodeId().toString() << "\n"
-                      << "- attribute id:      " << static_cast<int>(item.getAttributeId()) << "\n";
+        // Create a monitored item within the subscription for data change notifications
+        auto mon = sub.subscribeDataChange(
+            opcua::VariableId::Server_ServerStatus_CurrentTime,  // monitored node id
+            opcua::AttributeId::Value,  // monitored attribute
+            [&](const auto& item, const opcua::DataValue& value) {
+                std::cout << "Data change notification:\n"
+                          << "- subscription id:   " << item.getSubscriptionId() << "\n"
+                          << "- monitored item id: " << item.getMonitoredItemId() << "\n"
+                          << "- node id:           " << item.getNodeId().toString() << "\n"
+                          << "- attribute id:      " << static_cast<int>(item.getAttributeId())
+                          << "\n";
 
-            const auto dt = value.getValue().getScalarCopy<opcua::DateTime>();
-            std::cout << "Current server time (UTC): " << dt.format("%H:%M:%S") << std::endl;
+                const auto dt = value.getValue().getScalarCopy<opcua::DateTime>();
+                std::cout << "Current server time (UTC): " << dt.format("%H:%M:%S") << std::endl;
+            }
+        );
+
+        // Modify and delete the monitored item via the returned MonitoredItem<T> object
+        opcua::MonitoringParameters monitoringParameters{};
+        monitoringParameters.samplingInterval = 100.0;
+        mon.setMonitoringParameters(monitoringParameters);
+        mon.setMonitoringMode(opcua::MonitoringMode::Reporting);
+        // mon.deleteMonitoredItem();
+    });
+
+    // Endless loop to automatically (try to) reconnect to server.
+    while (true) {
+        try {
+            client.connect("opc.tcp://localhost:4840");
+            // Run the client's main loop to process callbacks and events.
+            // This will block until client.stop() is called or an exception is thrown.
+            client.run();
+        } catch (const opcua::BadDisconnect&) {
+            std::cout << "Disconnected. Retry to connect in 3 seconds\n";
+            std::this_thread::sleep_for(std::chrono::seconds(3));
         }
-    );
-
-    // Modify and delete the monitored item via the returned MonitoredItem<T> object
-    opcua::MonitoringParameters monitoringParameters{};
-    monitoringParameters.samplingInterval = 100.0;
-    mon.setMonitoringParameters(monitoringParameters);
-    mon.setMonitoringMode(opcua::MonitoringMode::Reporting);
-    // mon.deleteMonitoredItem();
-
-    // Run the client's main loop to process callbacks and events.
-    // This will block until client.stop() is called or an exception is thrown.
-    client.run();
+    }
 }

--- a/include/open62541pp/Client.h
+++ b/include/open62541pp/Client.h
@@ -52,9 +52,13 @@ public:
     /// Set custom logging function.
     void setLogger(Logger logger);
 
+    /// Set a state callback that will be called after the client is connected.
     void onConnected(StateCallback callback);
+    /// Set a state callback that will be called after the client is disconnected.
     void onDisconnected(StateCallback callback);
+    /// Set a state callback that will be called after the session is activated.
     void onSessionActivated(StateCallback callback);
+    /// Set a state callback that will be called after the session is closed.
     void onSessionClosed(StateCallback callback);
 
     /**

--- a/include/open62541pp/Client.h
+++ b/include/open62541pp/Client.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -21,6 +22,8 @@ namespace opcua {
 class ClientContext;
 template <typename ServerOrClient>
 class Node;
+
+using StateCallback = std::function<void()>;
 
 /**
  * High-level client class.
@@ -48,6 +51,11 @@ public:
 
     /// Set custom logging function.
     void setLogger(Logger logger);
+
+    void onConnected(StateCallback callback);
+    void onDisconnected(StateCallback callback);
+    void onSessionActivated(StateCallback callback);
+    void onSessionClosed(StateCallback callback);
 
     /**
      * Connect to the selected server.

--- a/include/open62541pp/ErrorHandling.h
+++ b/include/open62541pp/ErrorHandling.h
@@ -28,6 +28,16 @@ private:
     UA_StatusCode code_;
 };
 
+/**
+ * Specific exception for open62541 status code `UA_STATUSCODE_BADDISCONNECT`.
+ * Useful to catch Client disconnects.
+ */
+class BadDisconnect : public BadStatus {
+public:
+    BadDisconnect()
+        : BadStatus(UA_STATUSCODE_BADDISCONNECT) {}
+};
+
 class BadVariantAccess : public std::runtime_error {
 public:
     using std::runtime_error::runtime_error;  // inherit contructors
@@ -45,7 +55,13 @@ namespace detail {
 
 inline void throwOnBadStatus(UA_StatusCode code) {
     if (isBadStatus(code)) {
-        throw BadStatus(code);
+        // NOLINTNEXTLINE
+        switch (code) {
+        case UA_STATUSCODE_BADDISCONNECT:
+            throw BadDisconnect();
+        default:
+            throw BadStatus(code);
+        }
     }
 }
 

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -172,8 +172,13 @@ public:
             return;
         }
         running_ = true;
-        while (running_) {
-            runIterate(1000);
+        try {
+            while (running_) {
+                runIterate(1000);
+            }
+        } catch (...) {
+            running_ = false;
+            throw;
         }
     }
 

--- a/src/MonitoredItem.cpp
+++ b/src/MonitoredItem.cpp
@@ -1,5 +1,7 @@
 #include "open62541pp/MonitoredItem.h"
 
+#include <cassert>
+
 #include "open62541pp/Client.h"
 #include "open62541pp/ErrorHandling.h"
 #include "open62541pp/Server.h"
@@ -51,6 +53,7 @@ inline static ServerContext::MonitoredItem& getMonitoredItemContext(
     if (it == monitoredItems.end()) {
         throw BadStatus(UA_STATUSCODE_BADMONITOREDITEMIDINVALID);
     }
+    assert(it->second != nullptr);  // NOLINT
     return *(it->second);
 }
 
@@ -62,6 +65,7 @@ inline static ClientContext::MonitoredItem& getMonitoredItemContext(
     if (it == monitoredItems.end()) {
         throw BadStatus(UA_STATUSCODE_BADMONITOREDITEMIDINVALID);
     }
+    assert(it->second != nullptr);  // NOLINT
     return *(it->second);
 }
 

--- a/src/Subscription.cpp
+++ b/src/Subscription.cpp
@@ -135,10 +135,10 @@ MonitoredItem<Client> Subscription<Client>::subscribeDataChange(
         {id, attribute},
         monitoringMode,
         parameters,
-        [&, callback = std::move(onDataChange)](
+        [connectionPtr = &connection_, callback = std::move(onDataChange)](
             uint32_t subId, uint32_t monId, const DataValue& value
         ) {
-            static const MonitoredItem<Client> monitoredItem(connection_, subId, monId);
+            static const MonitoredItem<Client> monitoredItem(*connectionPtr, subId, monId);
             callback(monitoredItem, value);
         }
     );
@@ -158,10 +158,10 @@ MonitoredItem<Client> Subscription<Client>::subscribeEvent(
         {id, AttributeId::EventNotifier},
         monitoringMode,
         parameters,
-        [&, callback = std::move(onEvent)](
+        [connectionPtr = &connection_, callback = std::move(onEvent)](
             uint32_t subId, uint32_t monId, const std::vector<Variant>& eventFields
         ) {
-            static const MonitoredItem<Client> monitoredItem(connection_, subId, monId);
+            static const MonitoredItem<Client> monitoredItem(*connectionPtr, subId, monId);
             callback(monitoredItem, eventFields);
         }
     );

--- a/src/types/Builtin.cpp
+++ b/src/types/Builtin.cpp
@@ -71,7 +71,7 @@ std::string_view ByteString::get() const {
     return detail::toStringView(*handle());
 }
 
-ByteString ByteString::fromBase64(std::string_view encoded) {
+ByteString ByteString::fromBase64([[maybe_unused]] std::string_view encoded) {
 #if UAPP_OPEN62541_VER_GE(1, 1)
     ByteString output;
     UA_ByteString_fromBase64(output.handle(), String(encoded).handle());

--- a/src/version.h
+++ b/src/version.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <tuple>
 
 #include "open62541_impl.h"


### PR DESCRIPTION
Register client state callbacks:
- `Client::onConnected`
- `Client::onDisconnected`
- `Client::onSessionActivated`
- `Client::onSessionClosed`

This is especially useful to recreate subscriptions and monitored items after the connection to the server was lost and the client has to reconnect (see updated `client_subscription` example).