### PR TITLE
feat: add variable node value callbacks

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -51,6 +51,7 @@ add_example(client_minimal.cpp)
 add_example(server.cpp)
 add_example(server_instantiation.cpp)
 add_example(server_minimal.cpp)
+add_example(server_valuecallback.cpp)
 
 if(UA_ENABLE_METHODCALLS)
     add_example(client_method.cpp)

--- a/examples/server_valuecallback.cpp
+++ b/examples/server_valuecallback.cpp
@@ -22,8 +22,6 @@ int main() {
         server.getNode(id).writeScalar(timeNow);
     };
     server.setVariableNodeValueCallback(currentTimeId, valueCallback);
-    server.setVariableNodeValueCallback(currentTimeId, valueCallback);
-    server.setVariableNodeValueCallback(currentTimeId, valueCallback);
 
     server.run();
 }

--- a/examples/server_valuecallback.cpp
+++ b/examples/server_valuecallback.cpp
@@ -1,0 +1,29 @@
+#include <iostream>
+
+#include "open62541pp/open62541pp.h"
+
+int main() {
+    opcua::Server server;
+
+    opcua::NodeId currentTimeId(1, "CurrentTime");
+    auto currentTimeNode = server.getObjectsNode().addVariable(currentTimeId, "CurrentTime");
+    currentTimeNode.writeDataType(opcua::Type::DateTime);
+    currentTimeNode.writeDisplayName({"en-US", "Current time"});
+    currentTimeNode.writeDescription({"en-US", "Current time"});
+    currentTimeNode.writeScalar(opcua::DateTime::now());
+
+    // set variable value callback to write current time before every read operation
+    opcua::ValueCallback valueCallback;
+    valueCallback.onBeforeRead = [&](const opcua::NodeId& id, const opcua::DataValue& value) {
+        const auto timeOld = value.getValue().getScalar<opcua::DateTime>();
+        const auto timeNow = opcua::DateTime::now();
+        std::cout << "Time before read: " << timeOld.format("%Y-%m-%d %H:%M:%S") << std::endl;
+        std::cout << "Set current time: " << timeNow.format("%Y-%m-%d %H:%M:%S") << std::endl;
+        server.getNode(id).writeScalar(timeNow);
+    };
+    server.setVariableNodeValueCallback(currentTimeId, valueCallback);
+    server.setVariableNodeValueCallback(currentTimeId, valueCallback);
+    server.setVariableNodeValueCallback(currentTimeId, valueCallback);
+
+    server.run();
+}

--- a/examples/server_valuecallback.cpp
+++ b/examples/server_valuecallback.cpp
@@ -14,12 +14,12 @@ int main() {
 
     // set variable value callback to write current time before every read operation
     opcua::ValueCallback valueCallback;
-    valueCallback.onBeforeRead = [&](const opcua::NodeId& id, const opcua::DataValue& value) {
+    valueCallback.onBeforeRead = [&](const opcua::DataValue& value) {
         const auto timeOld = value.getValue().getScalar<opcua::DateTime>();
         const auto timeNow = opcua::DateTime::now();
         std::cout << "Time before read: " << timeOld.format("%Y-%m-%d %H:%M:%S") << std::endl;
         std::cout << "Set current time: " << timeNow.format("%Y-%m-%d %H:%M:%S") << std::endl;
-        server.getNode(id).writeScalar(timeNow);
+        currentTimeNode.writeScalar(timeNow);
     };
     server.setVariableNodeValueCallback(currentTimeId, valueCallback);
 

--- a/include/open62541pp/Server.h
+++ b/include/open62541pp/Server.h
@@ -9,6 +9,7 @@
 #include "open62541pp/Auth.h"
 #include "open62541pp/Logger.h"
 #include "open62541pp/Subscription.h"
+#include "open62541pp/ValueBackend.h"
 #include "open62541pp/types/NodeId.h"
 
 // forward declaration open62541
@@ -54,6 +55,9 @@ public:
     std::vector<std::string> getNamespaceArray();
     /// Register namespace. The new namespace index will be returned.
     [[nodiscard]] uint16_t registerNamespace(std::string_view uri);
+
+    /// Set value callbacks to execute before every read and after every write operation.
+    void setVariableNodeValueCallback(const NodeId& id, ValueCallback callback);
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
     /// Create a (pseudo) subscription to monitor local data changes and events.

--- a/include/open62541pp/ValueBackend.h
+++ b/include/open62541pp/ValueBackend.h
@@ -19,13 +19,13 @@ struct ValueCallback {
      * during onBeforeRead (using e.g. services::writeValue or Node::writeValue). The node is
      * re-opened afterwards so that changes are considered in the following read operation.
      */
-    std::function<void(const NodeId&, const DataValue&)> onBeforeRead;
+    std::function<void(const DataValue& value)> onBeforeRead;
 
     /**
      * Called after writing the value attribute. The node is re-opened after
      * writing so that the new value is visible in the callback.
      */
-    std::function<void(const NodeId&, const DataValue&)> onAfterWrite;
+    std::function<void(const DataValue& value)> onAfterWrite;
 };
 
 }  // namespace opcua

--- a/include/open62541pp/ValueBackend.h
+++ b/include/open62541pp/ValueBackend.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <functional>
+
+namespace opcua {
+
+// forward declaration
+class NodeId;
+class DataValue;
+
+/**
+ * Value callbacks allow to synchronize a variable value with an external representation.
+ * The attached callbacks are executed before every read and after every write operation.
+ * @see https://www.open62541.org/doc/1.3/tutorial_server_datasource.html
+ */
+struct ValueCallback {
+    /**
+     * Called before the value attribute is read. It is possible to write into the value attribute
+     * during onBeforeRead (using e.g. services::writeValue or Node::writeValue). The node is
+     * re-opened afterwards so that changes are considered in the following read operation.
+     */
+    std::function<void(const NodeId&, const DataValue&)> onBeforeRead;
+
+    /**
+     * Called after writing the value attribute. The node is re-opened after
+     * writing so that the new value is visible in the callback.
+     */
+    std::function<void(const NodeId&, const DataValue&)> onAfterWrite;
+};
+
+}  // namespace opcua

--- a/include/open62541pp/open62541pp.h
+++ b/include/open62541pp/open62541pp.h
@@ -14,6 +14,7 @@
 #include "open62541pp/TypeConverter.h"
 #include "open62541pp/TypeConverterNative.h"
 #include "open62541pp/TypeWrapper.h"
+#include "open62541pp/ValueBackend.h"
 #include "open62541pp/detail/helper.h"
 #include "open62541pp/detail/traits.h"
 #include "open62541pp/overloads/comparison.h"

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -235,15 +235,15 @@ static void valueCallbackOnRead(
     [[maybe_unused]] UA_Server* server,
     [[maybe_unused]] const UA_NodeId* sessionId,
     [[maybe_unused]] void* sessionContext,
-    const UA_NodeId* nodeId,
+    [[maybe_unused]] const UA_NodeId* nodeId,
     void* nodeContext,
     [[maybe_unused]] const UA_NumericRange* range,
     const UA_DataValue* value
 ) {
-    assert(nodeContext != nullptr && nodeId != nullptr && value != nullptr);  // NOLINT
+    assert(nodeContext != nullptr && value != nullptr);  // NOLINT
     auto& cb = static_cast<ServerContext::NodeContext*>(nodeContext)->valueCallback.onBeforeRead;
     if (cb) {
-        cb(asWrapper<NodeId>(*nodeId), asWrapper<DataValue>(*value));
+        cb(asWrapper<DataValue>(*value));
     }
 }
 
@@ -251,15 +251,15 @@ static void valueCallbackOnWrite(
     [[maybe_unused]] UA_Server* server,
     [[maybe_unused]] const UA_NodeId* sessionId,
     [[maybe_unused]] void* sessionContext,
-    const UA_NodeId* nodeId,
+    [[maybe_unused]] const UA_NodeId* nodeId,
     void* nodeContext,
     [[maybe_unused]] const UA_NumericRange* range,
     const UA_DataValue* value
 ) {
-    assert(nodeContext != nullptr && nodeId != nullptr && value != nullptr);  // NOLINT
+    assert(nodeContext != nullptr && value != nullptr);  // NOLINT
     auto& cb = static_cast<ServerContext::NodeContext*>(nodeContext)->valueCallback.onAfterWrite;
     if (cb) {
-        cb(asWrapper<NodeId>(*nodeId), asWrapper<DataValue>(*value));
+        cb(asWrapper<DataValue>(*value));
     }
 }
 

--- a/src/ServerContext.h
+++ b/src/ServerContext.h
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "open62541pp/Config.h"
+#include "open62541pp/ValueBackend.h"
 #include "open62541pp/services/NodeManagement.h"
 #include "open62541pp/services/Subscription.h"
 #include "open62541pp/types/Composed.h"
@@ -26,13 +27,18 @@ public:
     std::map<uint32_t, std::unique_ptr<MonitoredItem>> monitoredItems;
 #endif
 
-#ifdef UA_ENABLE_METHODCALLS
     struct NodeContext {
+        ValueCallback valueCallback;
+#ifdef UA_ENABLE_METHODCALLS
         services::MethodCallback methodCallback;
+#endif
     };
 
     std::map<NodeId, std::unique_ptr<NodeContext>> nodeContexts;
-#endif
+
+    NodeContext* getOrCreateNodeContext(const NodeId& id) {
+        return nodeContexts.emplace(id, std::make_unique<NodeContext>()).first->second.get();
+    }
 };
 
 }  // namespace opcua

--- a/src/services/NodeManagement.cpp
+++ b/src/services/NodeManagement.cpp
@@ -1,5 +1,6 @@
 #include "open62541pp/services/NodeManagement.h"
 
+#include <cassert>
 #include <memory>
 #include <stdexcept>
 #include <utility>  // move
@@ -205,9 +206,7 @@ static UA_StatusCode methodCallback(
     size_t outputSize,
     UA_Variant* output
 ) {
-    if (methodContext == nullptr) {
-        return UA_STATUSCODE_BADUNEXPECTEDERROR;
-    }
+    assert(methodContext != nullptr);  // NOLINT
     const auto* nodeContext = static_cast<ServerContext::NodeContext*>(methodContext);
     const std::vector<Variant> inputVector(input, input + inputSize);  // NOLINT
     std::vector<Variant> outputVector(outputSize);
@@ -238,7 +237,7 @@ void addMethod(
     const std::vector<Argument>& outputArguments,
     const NodeId& referenceType
 ) {
-    auto nodeContext = std::make_unique<ServerContext::NodeContext>();
+    auto* nodeContext = server.getContext().getOrCreateNodeContext(id);
     nodeContext->methodCallback = std::move(callback);
     const auto status = UA_Server_addMethodNode(
         server.handle(),
@@ -252,11 +251,10 @@ void addMethod(
         inputArguments.data()->handle(),
         outputArguments.size(),
         outputArguments.data()->handle(),
-        nodeContext.get(),
+        nodeContext,
         nullptr  // outNewNodeId
     );
     detail::throwOnBadStatus(status);
-    server.getContext().nodeContexts.insert_or_assign(id, std::move(nodeContext));
 }
 
 template <>

--- a/tests/Server.cpp
+++ b/tests/Server.cpp
@@ -87,6 +87,47 @@ TEST_CASE("Server") {
         CHECK(server.getNamespaceArray().at(3) == "test2");
     }
 
+    SUBCASE("Variable node value callback") {
+        NodeId id{1, 1000};
+        auto node = server.getObjectsNode().addVariable(id, "testVariable");
+        node.writeScalar<int>(1);
+
+        bool onBeforeReadCalled = false;
+        bool onAfterWriteCalled = false;
+        NodeId idRead;
+        NodeId idWrite;
+        int valueBeforeRead = 0;
+        int valueAfterWrite = 0;
+
+        ValueCallback valueCallback;
+        valueCallback.onBeforeRead = [&](const NodeId& nodeId, const DataValue& value) {
+            onBeforeReadCalled = true;
+            idRead = nodeId;
+            valueBeforeRead = value.getValue().getScalar<int>();
+        };
+        valueCallback.onAfterWrite = [&](const NodeId& nodeId, const DataValue& value) {
+            onAfterWriteCalled = true;
+            idWrite = nodeId;
+            valueAfterWrite = value.getValue().getScalar<int>();
+        };
+        server.setVariableNodeValueCallback(id, valueCallback);
+
+        // trigger onBeforeRead callback with read operation
+        const auto valueRead = node.readScalar<int>();
+        CHECK(onBeforeReadCalled == true);
+        CHECK(onAfterWriteCalled == false);
+        CHECK(idRead == id);
+        CHECK(valueBeforeRead == 1);
+        CHECK(valueRead == 1);
+
+        // trigger onAfterWrite callback with write operation
+        node.writeScalar<int>(2);
+        CHECK(onBeforeReadCalled == true);
+        CHECK(onAfterWriteCalled == true);
+        CHECK(idWrite == id);
+        CHECK(valueAfterWrite == 2);
+    }
+
     SUBCASE("Get default nodes") {
         // clang-format off
         CHECK_EQ(server.getRootNode().getNodeId(),    NodeId{0, UA_NS0ID_ROOTFOLDER});

--- a/tests/Server.cpp
+++ b/tests/Server.cpp
@@ -94,20 +94,16 @@ TEST_CASE("Server") {
 
         bool onBeforeReadCalled = false;
         bool onAfterWriteCalled = false;
-        NodeId idRead;
-        NodeId idWrite;
         int valueBeforeRead = 0;
         int valueAfterWrite = 0;
 
         ValueCallback valueCallback;
-        valueCallback.onBeforeRead = [&](const NodeId& nodeId, const DataValue& value) {
+        valueCallback.onBeforeRead = [&](const DataValue& value) {
             onBeforeReadCalled = true;
-            idRead = nodeId;
             valueBeforeRead = value.getValue().getScalar<int>();
         };
-        valueCallback.onAfterWrite = [&](const NodeId& nodeId, const DataValue& value) {
+        valueCallback.onAfterWrite = [&](const DataValue& value) {
             onAfterWriteCalled = true;
-            idWrite = nodeId;
             valueAfterWrite = value.getValue().getScalar<int>();
         };
         server.setVariableNodeValueCallback(id, valueCallback);
@@ -116,7 +112,6 @@ TEST_CASE("Server") {
         const auto valueRead = node.readScalar<int>();
         CHECK(onBeforeReadCalled == true);
         CHECK(onAfterWriteCalled == false);
-        CHECK(idRead == id);
         CHECK(valueBeforeRead == 1);
         CHECK(valueRead == 1);
 
@@ -124,7 +119,6 @@ TEST_CASE("Server") {
         node.writeScalar<int>(2);
         CHECK(onBeforeReadCalled == true);
         CHECK(onAfterWriteCalled == true);
-        CHECK(idWrite == id);
         CHECK(valueAfterWrite == 2);
     }
 


### PR DESCRIPTION
As requested in #62.

- `Server::setVariableNodeValueCallback` method
- Add example `server_valuecallback`

Open questions:
- Provide `NodeId` in callback functions?
