### PR TITLE
chore: fix cmake code in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Add it to your project as a Git submodule (`git submodule add https://github.com
 
 ```cmake
 add_subdirectory(extern/open62541pp)  # the submodule directory
-target_link_library(myexecutable PRIVATE open62541pp::open62541pp)
+target_link_libraries(myexecutable PRIVATE open62541pp::open62541pp)
 ```
 
 ### Integrate as a pre-compiled library
@@ -207,7 +207,7 @@ The installed library can be found and linked within CMake:
 
 ```cmake 
 find_package(open62541pp::open62541pp CONFIG REQUIRED)
-target_link_library(myexecutable PRIVATE open62541pp::open62541pp)
+target_link_libraries(myexecutable PRIVATE open62541pp::open62541pp)
 ```
 
 ### Build and install


### PR DESCRIPTION
Fix cmake code in the main readme which does not compile as is.