### PR TITLE
feat: access control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ endif()
 include(GNUInstallDirs)
 add_library(
     open62541pp
+    src/AccessControl.cpp
     src/Client.cpp
     src/Crypto.cpp
     src/CustomLogger.cpp

--- a/include/open62541pp/AccessControl.h
+++ b/include/open62541pp/AccessControl.h
@@ -1,0 +1,287 @@
+#pragma once
+
+#include <any>
+#include <vector>
+
+#include "open62541pp/Auth.h"  // Login
+#include "open62541pp/Config.h"
+#include "open62541pp/types/Builtin.h"
+#include "open62541pp/types/Composed.h"
+#include "open62541pp/types/ExtensionObject.h"
+
+// forward declare
+struct UA_AccessControl;
+
+namespace opcua {
+
+// forward declare
+class Server;
+
+/**
+ * Access control base class.
+ *
+ * Used to authenticate sessions and grant access rights accordingly.
+ * Custom access control can be implemented by deriving from this class and overwriting the access
+ * control callbacks.
+ *
+ * The `sessionId` and `sessionContext` can originally be both `NULL` in open62541.
+ * This is the case when, for example, a MonitoredItem (the underlying Subscription) is detached
+ * from its Session but continues to run.
+ * This wrapper passes `sessionId` and `sessionContext` by const reference, so they can't be `NULL`.
+ * Instead, an empty `NodeId` and `AccessControlBase::SessionContext` will be created.
+ *
+ * @see UA_AccessControl
+ * @see https://www.open62541.org/doc/1.3/plugin_accesscontrol.html
+ */
+class AccessControlBase {
+public:
+    /// Arbitrary data attached to a session.
+    using SessionContext = std::any;
+
+    explicit AccessControlBase(Server& server);
+
+    virtual ~AccessControlBase();
+
+    AccessControlBase(const AccessControlBase& other) = delete;
+    AccessControlBase(AccessControlBase&& other) noexcept = delete;
+
+    AccessControlBase& operator=(const AccessControlBase& other) = delete;
+    AccessControlBase& operator=(AccessControlBase&& other) noexcept = delete;
+
+    /// Get available user token policies.
+    virtual std::vector<UserTokenPolicy> getUserTokenPolicies() noexcept = 0;
+
+    /**
+     * Authenticate a session.
+     *
+     * The session context is attached to the session and later passed into the access control
+     * callbacks.
+     * The new session is rejected if a status code other than UA_STATUSCODE_GOOD is returned.
+     */
+    virtual UA_StatusCode activateSession(
+        const EndpointDescription& endpointDescription,
+        const ByteString& secureChannelRemoteCertificate,
+        const NodeId& sessionId,
+        const ExtensionObject& userIdentityToken,
+        SessionContext& sessionContext
+    ) noexcept = 0;
+
+    /// Deauthenticate a session and cleanup session context.
+    virtual void closeSesion(const NodeId& sessionId, SessionContext& sessionContext) noexcept = 0;
+
+    /// Access control for all nodes.
+    virtual uint32_t getUserRightsMask(
+        const NodeId& sessionId,
+        SessionContext& sessionContext,
+        const NodeId& nodeId,
+        void* nodeContext
+    ) noexcept = 0;
+
+    /// Additional access control for variable nodes.
+    virtual uint8_t getUserAccessLevel(
+        const NodeId& sessionId,
+        SessionContext& sessionContext,
+        const NodeId& nodeId,
+        void* nodeContext
+    ) noexcept = 0;
+
+    /// Additional access control for method nodes.
+    virtual bool getUserExecutable(
+        const NodeId& sessionId,
+        SessionContext& sessionContext,
+        const NodeId& methodId,
+        void* methodContext
+    ) noexcept = 0;
+
+    /// Additional access control for calling a method node in the context of a specific object.
+    virtual bool getUserExecutableOnObject(
+        const NodeId& sessionId,
+        SessionContext& sessionContext,
+        const NodeId& methodId,
+        void* methodContext,
+        const NodeId& objectId,
+        void* objectContext
+    ) noexcept = 0;
+
+    /// Allow adding a node.
+    virtual bool allowAddNode(
+        const NodeId& sessionId, SessionContext& sessionContext, const AddNodesItem& item
+    ) noexcept = 0;
+
+    /// Allow adding a reference.
+    virtual bool allowAddReference(
+        const NodeId& sessionId, SessionContext& sessionContext, const AddReferencesItem& item
+    ) noexcept = 0;
+
+    /// Allow deleting a node.
+    virtual bool allowDeleteNode(
+        const NodeId& sessionId, SessionContext& sessionContext, const DeleteNodesItem& item
+    ) noexcept = 0;
+
+    /// Allow deleting a reference.
+    virtual bool allowDeleteReference(
+        const NodeId& sessionId, SessionContext& sessionContext, const DeleteReferencesItem& item
+    ) noexcept = 0;
+
+    /// Allow browsing a node.
+    virtual bool allowBrowseNode(
+        const NodeId& sessionId,
+        SessionContext& sessionContext,
+        const NodeId& nodeId,
+        void* nodeContext
+    ) noexcept = 0;
+
+#ifdef UA_ENABLE_SUBSCRIPTIONS
+    /// Allow transfer of a subscription to another session.
+    virtual bool allowTransferSubscription(
+        const NodeId& oldSessionId,
+        SessionContext& oldSessionContext,
+        const NodeId& newSessionId,
+        SessionContext& newSessionContext
+    ) noexcept = 0;
+#endif
+
+#ifdef UA_ENABLE_HISTORIZING
+    /// Allow insert, replace, update of historical data.
+    virtual bool allowHistoryUpdate(
+        const NodeId& sessionId,
+        SessionContext& sessionContext,
+        const NodeId& nodeId,
+        PerformUpdateType performInsertReplace,  // TODO
+        const UA_DataValue& value
+    ) noexcept = 0;
+
+    /// Allow delete of historical data.
+    virtual bool allowHistoryDelete(
+        const NodeId& sessionId,
+        SessionContext& sessionContext,
+        const NodeId& nodeId,
+        DateTime startTimestamp,
+        DateTime endTimestamp,
+        bool isDeleteModified
+    ) noexcept = 0;
+#endif
+
+protected:
+    Server& getServer() noexcept;
+    const Server& getServer() const noexcept;
+
+private:
+    Server& server_;
+};
+
+/* ----------------------------------- Default access control ----------------------------------- */
+
+/**
+ * Default access control.
+ *
+ * This class implements the same logic as @ref UA_AccessControl_default().
+ * The log-in can be anonymous or username-password. A logged-in user has all access rights.
+ *
+ * @warning Use less permissive access control in production!
+ */
+class AccessControlDefault : public AccessControlBase {
+public:
+    explicit AccessControlDefault(
+        Server& server, bool allowAnonymous = true, std::vector<Login> logins = {}
+    );
+
+    std::vector<UserTokenPolicy> getUserTokenPolicies() noexcept override;
+
+    UA_StatusCode activateSession(
+        const EndpointDescription& endpointDescription,
+        const ByteString& secureChannelRemoteCertificate,
+        const NodeId& sessionId,
+        const ExtensionObject& userIdentityToken,
+        SessionContext& sessionContext
+    ) noexcept override;
+
+    void closeSesion(const NodeId& sessionId, SessionContext& sessionContext) noexcept override;
+
+    uint32_t getUserRightsMask(
+        const NodeId& sessionId,
+        SessionContext& sessionContext,
+        const NodeId& nodeId,
+        void* nodeContext
+    ) noexcept override;
+
+    uint8_t getUserAccessLevel(
+        const NodeId& sessionId,
+        SessionContext& sessionContext,
+        const NodeId& nodeId,
+        void* nodeContext
+    ) noexcept override;
+
+    bool getUserExecutable(
+        const NodeId& sessionId,
+        SessionContext& sessionContext,
+        const NodeId& methodId,
+        void* methodContext
+    ) noexcept override;
+
+    bool getUserExecutableOnObject(
+        const NodeId& sessionId,
+        SessionContext& sessionContext,
+        const NodeId& methodId,
+        void* methodContext,
+        const NodeId& objectId,
+        void* objectContext
+    ) noexcept override;
+
+    bool allowAddNode(
+        const NodeId& sessionId, SessionContext& sessionContext, const AddNodesItem& item
+    ) noexcept override;
+
+    bool allowAddReference(
+        const NodeId& sessionId, SessionContext& sessionContext, const AddReferencesItem& item
+    ) noexcept override;
+
+    bool allowDeleteNode(
+        const NodeId& sessionId, SessionContext& sessionContext, const DeleteNodesItem& item
+    ) noexcept override;
+
+    bool allowDeleteReference(
+        const NodeId& sessionId, SessionContext& sessionContext, const DeleteReferencesItem& item
+    ) noexcept override;
+
+    bool allowBrowseNode(
+        const NodeId& sessionId,
+        SessionContext& sessionContext,
+        const NodeId& nodeId,
+        void* nodeContext
+    ) noexcept override;
+
+#ifdef UA_ENABLE_SUBSCRIPTIONS
+    bool allowTransferSubscription(
+        const NodeId& oldSessionId,
+        SessionContext& oldSessionContext,
+        const NodeId& newSessionId,
+        SessionContext& newSessionContext
+    ) noexcept override;
+#endif
+
+#ifdef UA_ENABLE_HISTORIZING
+    bool allowHistoryUpdate(
+        const NodeId& sessionId,
+        SessionContext& sessionContext,
+        const NodeId& nodeId,
+        PerformUpdateType performInsertReplace,  // TODO
+        const UA_DataValue& value
+    ) noexcept override;
+
+    bool allowHistoryDelete(
+        const NodeId& sessionId,
+        SessionContext& sessionContext,
+        const NodeId& nodeId,
+        DateTime startTimestamp,
+        DateTime endTimestamp,
+        bool isDeleteModified
+    ) noexcept override;
+#endif
+
+private:
+    bool allowAnonymous_;
+    std::vector<Login> logins_;
+};
+
+}  // namespace opcua

--- a/include/open62541pp/open62541pp.h
+++ b/include/open62541pp/open62541pp.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "open62541pp/AccessControl.h"
 #include "open62541pp/Auth.h"
 #include "open62541pp/Client.h"
 #include "open62541pp/Common.h"

--- a/include/open62541pp/types/Composed.h
+++ b/include/open62541pp/types/Composed.h
@@ -8,6 +8,7 @@
 #include "open62541pp/TypeConverter.h"
 #include "open62541pp/TypeWrapper.h"
 #include "open62541pp/types/Builtin.h"
+#include "open62541pp/types/ExtensionObject.h"
 #include "open62541pp/types/NodeId.h"
 
 #include <initializer_list>
@@ -65,6 +66,19 @@ public:
 };
 
 /**
+ * User identity token type.
+ * @see https://reference.opcfoundation.org/Core/Part4/v105/docs/7.43
+ */
+enum class UserTokenType : uint32_t {
+    // clang-format off
+    Anonymous   = 0,  ///< No token is required
+    Username    = 1,  ///< A username/password token
+    Certificate = 2,  ///< An X.509 v3 certificate token
+    IssuedToken = 3,  ///< Any token issued by an authorization service
+    // clang-format on
+};
+
+/**
  * UA_UserTokenPolicy wrapper class.
  * @ingroup TypeWrapper
  */
@@ -72,8 +86,16 @@ class UserTokenPolicy : public TypeWrapper<UA_UserTokenPolicy, UA_TYPES_USERTOKE
 public:
     using TypeWrapperBase::TypeWrapperBase;
 
+    UserTokenPolicy(
+        std::string_view policyId,
+        UserTokenType tokenType,
+        std::string_view issuedTokenType = {},
+        std::string_view issuerEndpointUrl = {},
+        std::string_view securityPolicyUri = {}
+    );
+
     UAPP_COMPOSED_GETTER_WRAPPER(String, getPolicyId, policyId)
-    UAPP_COMPOSED_GETTER(UA_UserTokenType, getTokenType, tokenType)
+    UAPP_COMPOSED_GETTER_CAST(UserTokenType, getTokenType, tokenType)
     UAPP_COMPOSED_GETTER_WRAPPER(String, getIssuedTokenType, issuedTokenType)
     UAPP_COMPOSED_GETTER_WRAPPER(String, getIssuerEndpointUrl, issuerEndpointUrl)
     UAPP_COMPOSED_GETTER_WRAPPER(String, getSecurityPolicyUri, securityPolicyUri)
@@ -98,6 +120,131 @@ public:
     )
     UAPP_COMPOSED_GETTER_WRAPPER(String, getTransportProfileUri, transportProfileUri)
     UAPP_COMPOSED_GETTER(UA_Byte, getSecurityLevel, securityLevel)
+};
+
+/**
+ * UA_UserIdentityToken wrapper class.
+ * @ingroup TypeWrapper
+ */
+class UserIdentityToken : public TypeWrapper<UA_UserIdentityToken, UA_TYPES_USERIDENTITYTOKEN> {
+public:
+    using TypeWrapperBase::TypeWrapperBase;
+
+    UAPP_COMPOSED_GETTER_WRAPPER(String, getPolicyId, policyId)
+};
+
+/**
+ * UA_AnonymousIdentityToken wrapper class.
+ * @ingroup TypeWrapper
+ */
+class AnonymousIdentityToken
+    : public TypeWrapper<UA_AnonymousIdentityToken, UA_TYPES_ANONYMOUSIDENTITYTOKEN> {
+public:
+    using TypeWrapperBase::TypeWrapperBase;
+
+    UAPP_COMPOSED_GETTER_WRAPPER(String, getPolicyId, policyId)
+};
+
+/**
+ * UA_UserNameIdentityToken wrapper class.
+ * @ingroup TypeWrapper
+ */
+class UserNameIdentityToken
+    : public TypeWrapper<UA_UserNameIdentityToken, UA_TYPES_USERNAMEIDENTITYTOKEN> {
+public:
+    using TypeWrapperBase::TypeWrapperBase;
+
+    UAPP_COMPOSED_GETTER_WRAPPER(String, getPolicyId, policyId)
+    UAPP_COMPOSED_GETTER_WRAPPER(String, getUserName, userName)
+    UAPP_COMPOSED_GETTER_WRAPPER(ByteString, getPassword, password)
+    UAPP_COMPOSED_GETTER_WRAPPER(String, getEncryptionAlgorithm, encryptionAlgorithm)
+};
+
+/**
+ * UA_X509IdentityToken wrapper class.
+ * @ingroup TypeWrapper
+ */
+class X509IdentityToken : public TypeWrapper<UA_X509IdentityToken, UA_TYPES_X509IDENTITYTOKEN> {
+public:
+    using TypeWrapperBase::TypeWrapperBase;
+
+    UAPP_COMPOSED_GETTER_WRAPPER(String, getPolicyId, policyId)
+    UAPP_COMPOSED_GETTER_WRAPPER(ByteString, getCertificateData, certificateData)
+};
+
+/**
+ * UA_IssuedIdentityToken wrapper class.
+ * @ingroup TypeWrapper
+ */
+class IssuedIdentityToken
+    : public TypeWrapper<UA_IssuedIdentityToken, UA_TYPES_ISSUEDIDENTITYTOKEN> {
+public:
+    using TypeWrapperBase::TypeWrapperBase;
+
+    UAPP_COMPOSED_GETTER_WRAPPER(String, getPolicyId, policyId)
+    UAPP_COMPOSED_GETTER_WRAPPER(ByteString, getTokenData, tokenData)
+    UAPP_COMPOSED_GETTER_WRAPPER(String, getEncryptionAlgorithm, encryptionAlgorithm)
+};
+
+/**
+ * UA_AddNodesItem wrapper class.
+ * @ingroup TypeWrapper
+ */
+class AddNodesItem : public TypeWrapper<UA_AddNodesItem, UA_TYPES_ADDNODESITEM> {
+public:
+    using TypeWrapperBase::TypeWrapperBase;
+
+    UAPP_COMPOSED_GETTER_WRAPPER(ExpandedNodeId, getParentNodeId, parentNodeId)
+    UAPP_COMPOSED_GETTER_WRAPPER(NodeId, getReferenceTypeId, referenceTypeId)
+    UAPP_COMPOSED_GETTER_WRAPPER(ExpandedNodeId, getRequestedNewNodeId, requestedNewNodeId)
+    UAPP_COMPOSED_GETTER_WRAPPER(QualifiedName, getBrowseName, browseName)
+    UAPP_COMPOSED_GETTER_CAST(NodeClass, getNodeClass, nodeClass)
+    UAPP_COMPOSED_GETTER_WRAPPER(ExtensionObject, getNodeAttributes, nodeAttributes)
+    UAPP_COMPOSED_GETTER_WRAPPER(ExpandedNodeId, getTypeDefinition, typeDefinition)
+};
+
+/**
+ * UA_AddReferencesItem wrapper class.
+ * @ingroup TypeWrapper
+ */
+class AddReferencesItem : public TypeWrapper<UA_AddReferencesItem, UA_TYPES_ADDREFERENCESITEM> {
+public:
+    using TypeWrapperBase::TypeWrapperBase;
+
+    UAPP_COMPOSED_GETTER_WRAPPER(NodeId, getSourceNodeId, sourceNodeId)
+    UAPP_COMPOSED_GETTER_WRAPPER(NodeId, getReferenceTypeId, referenceTypeId)
+    UAPP_COMPOSED_GETTER(bool, getIsForward, isForward)
+    UAPP_COMPOSED_GETTER_WRAPPER(String, getTargetServerUri, targetServerUri)
+    UAPP_COMPOSED_GETTER_WRAPPER(ExpandedNodeId, getTargetNodeId, targetNodeId)
+    UAPP_COMPOSED_GETTER_CAST(NodeClass, getTargetNodeClass, targetNodeClass)
+};
+
+/**
+ * UA_DeleteNodesItem wrapper class.
+ * @ingroup TypeWrapper
+ */
+class DeleteNodesItem : public TypeWrapper<UA_DeleteNodesItem, UA_TYPES_DELETENODESITEM> {
+public:
+    using TypeWrapperBase::TypeWrapperBase;
+
+    UAPP_COMPOSED_GETTER_WRAPPER(NodeId, getNodeId, nodeId)
+    UAPP_COMPOSED_GETTER(bool, getDeleteTargetReferences, deleteTargetReferences)
+};
+
+/**
+ * UA_DeleteReferencesItem wrapper class.
+ * @ingroup TypeWrapper
+ */
+class DeleteReferencesItem
+    : public TypeWrapper<UA_DeleteReferencesItem, UA_TYPES_DELETEREFERENCESITEM> {
+public:
+    using TypeWrapperBase::TypeWrapperBase;
+
+    UAPP_COMPOSED_GETTER_WRAPPER(NodeId, getSourceNodeId, sourceNodeId)
+    UAPP_COMPOSED_GETTER_WRAPPER(NodeId, getReferenceTypeId, referenceTypeId)
+    UAPP_COMPOSED_GETTER(bool, getIsForward, isForward)
+    UAPP_COMPOSED_GETTER_WRAPPER(ExpandedNodeId, getTargetNodeId, targetNodeId)
+    UAPP_COMPOSED_GETTER(bool, getDeleteBidirectional, deleteBidirectional)
 };
 
 /**
@@ -270,6 +417,17 @@ public:
     UAPP_COMPOSED_GETTER_WRAPPER(NodeId, getDataType, dataType)
     UAPP_COMPOSED_GETTER_CAST(ValueRank, getValueRank, valueRank)
     UAPP_COMPOSED_GETTER_ARRAY(uint32_t, getArrayDimensions, arrayDimensions, arrayDimensionsSize)
+};
+#endif
+
+#ifdef UA_TYPES_PERFORMUPDATETYPE
+enum class PerformUpdateType : uint32_t {
+    // clang-format off
+    Insert  = 1,
+    Replace = 2,
+    Update  = 3,
+    Remove  = 4,
+    // clang-format on
 };
 #endif
 

--- a/include/open62541pp/types/ExtensionObject.h
+++ b/include/open62541pp/types/ExtensionObject.h
@@ -125,6 +125,15 @@ T* ExtensionObject::getDecodedData() noexcept {
 }
 
 template <typename T, TypeIndex typeIndex>
+const T* ExtensionObject::getDecodedData() const noexcept {
+    detail::assertTypeCombination<T, typeIndex>();
+    if (getDecodedDataType() == detail::getUaDataType(typeIndex)) {
+        return static_cast<const T*>(getDecodedData());
+    }
+    return nullptr;
+}
+
+template <typename T, TypeIndex typeIndex>
 ExtensionObject ExtensionObject::fromDecoded(T& data) noexcept {
     detail::assertTypeCombination<T, typeIndex>();
     static_assert(

--- a/src/AccessControl.cpp
+++ b/src/AccessControl.cpp
@@ -1,0 +1,244 @@
+#include "open62541pp/AccessControl.h"
+
+#include <cassert>
+#include <utility>  // move
+
+#include "open62541pp/Server.h"
+#include "open62541pp/detail/helper.h"
+
+#include "open62541_impl.h"
+
+namespace opcua {
+
+AccessControlBase::AccessControlBase(Server& server)
+    : server_(server) {}
+
+AccessControlBase::~AccessControlBase() = default;
+
+Server& AccessControlBase::getServer() noexcept {
+    return server_;
+}
+
+const Server& AccessControlBase::getServer() const noexcept {
+    return server_;
+}
+
+/* ----------------------------------- Default access control ----------------------------------- */
+
+constexpr std::string_view policyIdAnonymous = "open62541-anonymous-policy";
+constexpr std::string_view policyIdUsername = "open62541-username-policy";
+
+AccessControlDefault::AccessControlDefault(
+    Server& server, bool allowAnonymous, std::vector<Login> logins
+)
+    : AccessControlBase(server),
+      allowAnonymous_(allowAnonymous),
+      logins_(std::move(logins)) {}
+
+std::vector<UserTokenPolicy> AccessControlDefault::getUserTokenPolicies() noexcept {
+    // retrieve security policy from server instance
+    auto* config = UA_Server_getConfig(getServer().handle());
+    assert(config->securityPoliciesSize >= 1);  // NOLINT
+    auto securityPolicyUri = detail::toStringView(
+        config->securityPolicies[config->securityPoliciesSize - 1].policyUri  // NOLINT
+    );
+
+    std::vector<UserTokenPolicy> result;
+    std::string_view issuedTokenType{};
+    std::string_view issuerEndpointUrl{};
+    if (allowAnonymous_) {
+        result.emplace_back(
+            policyIdAnonymous,
+            UserTokenType::Anonymous,
+            issuedTokenType,
+            issuerEndpointUrl,
+            securityPolicyUri
+        );
+    }
+    if (!logins_.empty()) {
+        result.emplace_back(
+            policyIdUsername,
+            UserTokenType::Username,
+            issuedTokenType,
+            issuerEndpointUrl,
+            securityPolicyUri
+        );
+    }
+    return result;
+}
+
+UA_StatusCode AccessControlDefault::activateSession(
+    [[maybe_unused]] const EndpointDescription& endpointDescription,
+    [[maybe_unused]] const ByteString& secureChannelRemoteCertificate,
+    [[maybe_unused]] const NodeId& sessionId,
+    const ExtensionObject& userIdentityToken,
+    [[maybe_unused]] SessionContext& sessionContext
+) noexcept {
+    // https://github.com/open62541/open62541/blob/v1.3.6/plugins/ua_accesscontrol_default.c#L38-L134
+
+    // empty token
+    if (userIdentityToken.isEmpty()) {
+        if (allowAnonymous_) {
+            return UA_STATUSCODE_GOOD;
+        }
+        return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
+    }
+
+    // unknown token type
+    if (!userIdentityToken.isDecoded()) {
+        return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
+    }
+
+    // anonymous login
+    if (const auto* token = userIdentityToken.getDecodedData<AnonymousIdentityToken>();
+        token != nullptr) {
+        if (!allowAnonymous_) {
+            return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
+        }
+        if (token->getPolicyId().empty() || token->getPolicyId() == policyIdAnonymous) {
+            return UA_STATUSCODE_GOOD;
+        }
+        return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
+    }
+
+    // username and password
+    if (const auto* token = userIdentityToken.getDecodedData<UserNameIdentityToken>();
+        token != nullptr) {
+        if (token->getPolicyId() != policyIdUsername) {
+            return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
+        }
+        // empty username and password
+        if (token->getUserName().empty() && token->getPassword().empty()) {
+            return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
+        }
+        // try to match username / password
+        for (const auto& login : logins_) {
+            if ((login.username == token->getUserName()) &&
+                (login.password == token->getPassword())) {
+                return UA_STATUSCODE_GOOD;
+            }
+        }
+        return UA_STATUSCODE_BADUSERACCESSDENIED;
+    }
+
+    return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
+}
+
+void AccessControlDefault::closeSesion(
+    [[maybe_unused]] const NodeId& sessionId, [[maybe_unused]] SessionContext& sessionContext
+) noexcept {}
+
+uint32_t AccessControlDefault::getUserRightsMask(
+    [[maybe_unused]] const NodeId& sessionId,
+    [[maybe_unused]] SessionContext& sessionContext,
+    [[maybe_unused]] const NodeId& nodeId,
+    [[maybe_unused]] void* nodeContext
+) noexcept {
+    return 0xFFFFFFFF;
+}
+
+uint8_t AccessControlDefault::getUserAccessLevel(
+    [[maybe_unused]] const NodeId& sessionId,
+    [[maybe_unused]] SessionContext& sessionContext,
+    [[maybe_unused]] const NodeId& nodeId,
+    [[maybe_unused]] void* nodeContext
+) noexcept {
+    return 0xFF;
+}
+
+bool AccessControlDefault::getUserExecutable(
+    [[maybe_unused]] const NodeId& sessionId,
+    [[maybe_unused]] SessionContext& sessionContext,
+    [[maybe_unused]] const NodeId& methodId,
+    [[maybe_unused]] void* methodContext
+) noexcept {
+    return true;
+}
+
+bool AccessControlDefault::getUserExecutableOnObject(
+    [[maybe_unused]] const NodeId& sessionId,
+    [[maybe_unused]] SessionContext& sessionContext,
+    [[maybe_unused]] const NodeId& methodId,
+    [[maybe_unused]] void* methodContext,
+    [[maybe_unused]] const NodeId& objectId,
+    [[maybe_unused]] void* objectContext
+) noexcept {
+    return true;
+}
+
+bool AccessControlDefault::allowAddNode(
+    [[maybe_unused]] const NodeId& sessionId,
+    [[maybe_unused]] SessionContext& sessionContext,
+    [[maybe_unused]] const AddNodesItem& item
+) noexcept {
+    return true;
+}
+
+bool AccessControlDefault::allowAddReference(
+    [[maybe_unused]] const NodeId& sessionId,
+    [[maybe_unused]] SessionContext& sessionContext,
+    [[maybe_unused]] const AddReferencesItem& item
+) noexcept {
+    return true;
+}
+
+bool AccessControlDefault::allowDeleteNode(
+    [[maybe_unused]] const NodeId& sessionId,
+    [[maybe_unused]] SessionContext& sessionContext,
+    [[maybe_unused]] const DeleteNodesItem& item
+) noexcept {
+    return true;
+}
+
+bool AccessControlDefault::allowDeleteReference(
+    [[maybe_unused]] const NodeId& sessionId,
+    [[maybe_unused]] SessionContext& sessionContext,
+    [[maybe_unused]] const DeleteReferencesItem& item
+) noexcept {
+    return true;
+}
+
+bool AccessControlDefault::allowBrowseNode(
+    [[maybe_unused]] const NodeId& sessionId,
+    [[maybe_unused]] SessionContext& sessionContext,
+    [[maybe_unused]] const NodeId& nodeId,
+    [[maybe_unused]] void* nodeContext
+) noexcept {
+    return true;
+}
+
+#ifdef UA_ENABLE_SUBSCRIPTIONS
+bool AccessControlDefault::allowTransferSubscription(
+    [[maybe_unused]] const NodeId& oldSessionId,
+    [[maybe_unused]] SessionContext& oldSessionContext,
+    [[maybe_unused]] const NodeId& newSessionId,
+    [[maybe_unused]] SessionContext& newSessionContext
+) noexcept {
+    return true;
+}
+#endif
+
+#ifdef UA_ENABLE_HISTORIZING
+bool AccessControlDefault::allowHistoryUpdate(
+    [[maybe_unused]] const NodeId& sessionId,
+    [[maybe_unused]] SessionContext& sessionContext,
+    [[maybe_unused]] const NodeId& nodeId,
+    [[maybe_unused]] PerformUpdateType performInsertReplace,  // TODO
+    [[maybe_unused]] const UA_DataValue& value
+) noexcept {
+    return true;
+}
+
+bool AccessControlDefault::allowHistoryDelete(
+    [[maybe_unused]] const NodeId& sessionId,
+    [[maybe_unused]] SessionContext& sessionContext,
+    [[maybe_unused]] const NodeId& nodeId,
+    [[maybe_unused]] DateTime startTimestamp,  // NOLINT
+    [[maybe_unused]] DateTime endTimestamp,  // NOLINT
+    [[maybe_unused]] bool isDeleteModified
+) noexcept {
+    return true;
+}
+#endif
+
+}  // namespace opcua

--- a/src/open62541_impl.h
+++ b/src/open62541_impl.h
@@ -18,6 +18,7 @@
 // UA_ENABLE_AMALGAMATION=OFF
 // common
 #include <open62541/config.h>
+#include <open62541/plugin/accesscontrol.h>
 #include <open62541/plugin/accesscontrol_default.h>
 #include <open62541/plugin/log.h>
 #if __has_include(<open62541/plugin/create_certificate.h>)  // since v1.3

--- a/src/types/Composed.cpp
+++ b/src/types/Composed.cpp
@@ -5,6 +5,20 @@
 
 namespace opcua {
 
+UserTokenPolicy::UserTokenPolicy(
+    std::string_view policyId,
+    UserTokenType tokenType,
+    std::string_view issuedTokenType,
+    std::string_view issuerEndpointUrl,
+    std::string_view securityPolicyUri
+) {
+    asWrapper<String>(handle()->policyId) = String(policyId);
+    handle()->tokenType = static_cast<UA_UserTokenType>(tokenType);
+    asWrapper<String>(handle()->issuedTokenType) = String(issuedTokenType);
+    asWrapper<String>(handle()->issuerEndpointUrl) = String(issuerEndpointUrl);
+    asWrapper<String>(handle()->securityPolicyUri) = String(securityPolicyUri);
+}
+
 BrowseDescription::BrowseDescription(
     const NodeId& nodeId,
     BrowseDirection browseDirection,

--- a/tests/AccessControl.cpp
+++ b/tests/AccessControl.cpp
@@ -1,0 +1,122 @@
+#include <doctest/doctest.h>
+
+#include "open62541pp/AccessControl.h"
+#include "open62541pp/Server.h"
+
+using namespace opcua;
+
+TEST_CASE("AccessControlDefault") {
+    Server server;
+
+    SUBCASE("getUserTokenPolicies") {
+        AccessControlDefault ac(server, true, {{"username", "password"}});
+        std::string_view securityPolicyUriNone = "http://opcfoundation.org/UA/SecurityPolicy#None";
+
+        const auto userTokenPolicies = ac.getUserTokenPolicies();
+        CHECK(userTokenPolicies.size() == 2);
+        CHECK(userTokenPolicies.at(0).getPolicyId() == "open62541-anonymous-policy");
+        CHECK(userTokenPolicies.at(0).getTokenType() == UserTokenType::Anonymous);
+        CHECK(userTokenPolicies.at(0).getSecurityPolicyUri() == securityPolicyUriNone);
+
+        CHECK(userTokenPolicies.at(1).getPolicyId() == "open62541-username-policy");
+        CHECK(userTokenPolicies.at(1).getTokenType() == UserTokenType::Username);
+        CHECK(userTokenPolicies.at(1).getSecurityPolicyUri() == securityPolicyUriNone);
+    }
+
+    SUBCASE("activateSession") {
+        for (bool allowAnonymous : {false, true}) {
+            CAPTURE(allowAnonymous);
+
+            AccessControlDefault ac(server, allowAnonymous, {{"username", "password"}});
+            const EndpointDescription endpointDescription{};
+            const ByteString secureChannelRemoteCertificate{};
+            const NodeId sessionId{};
+            AccessControlBase::SessionContext sessionContext{};
+
+            const auto activateSessionWithToken = [&](const ExtensionObject& userIdentityToken) {
+                return ac.activateSession(
+                    endpointDescription,
+                    secureChannelRemoteCertificate,
+                    sessionId,
+                    userIdentityToken,
+                    sessionContext
+                );
+            };
+
+            SUBCASE("Empty token") {
+                const ExtensionObject userIdentityToken{};
+                CHECK_EQ(
+                    activateSessionWithToken(userIdentityToken),
+                    allowAnonymous ? UA_STATUSCODE_GOOD : UA_STATUSCODE_BADIDENTITYTOKENINVALID
+                );
+            }
+
+            SUBCASE("Unknown token") {
+                IssuedIdentityToken token;
+                CHECK_EQ(
+                    activateSessionWithToken(ExtensionObject::fromDecoded(token)),
+                    UA_STATUSCODE_BADIDENTITYTOKENINVALID
+                );
+            }
+
+            SUBCASE("Anonymous login") {
+                AnonymousIdentityToken token;
+                token.getPolicyId() = String("open62541-anonymous-policy");
+                CHECK_EQ(
+                    activateSessionWithToken(ExtensionObject::fromDecoded(token)),
+                    allowAnonymous ? UA_STATUSCODE_GOOD : UA_STATUSCODE_BADIDENTITYTOKENINVALID
+                );
+            }
+
+            SUBCASE("Username and password") {
+                UserNameIdentityToken token;
+                CHECK_EQ(
+                    activateSessionWithToken(ExtensionObject::fromDecoded(token)),
+                    UA_STATUSCODE_BADIDENTITYTOKENINVALID
+                );
+
+                token.getPolicyId() = String("open62541-username-policy");
+                CHECK_EQ(
+                    activateSessionWithToken(ExtensionObject::fromDecoded(token)),
+                    UA_STATUSCODE_BADIDENTITYTOKENINVALID
+                );
+
+                token.getUserName() = String("username");
+                token.getPassword() = ByteString("wrongpassword");
+                CHECK_EQ(
+                    activateSessionWithToken(ExtensionObject::fromDecoded(token)),
+                    UA_STATUSCODE_BADUSERACCESSDENIED
+                );
+
+                token.getPassword() = ByteString("password");
+                CHECK_EQ(
+                    activateSessionWithToken(ExtensionObject::fromDecoded(token)),
+                    UA_STATUSCODE_GOOD
+                );
+            }
+        }
+    }
+
+    SUBCASE("Access control callbacks (all permissive)") {
+        AccessControlDefault ac(server);
+        const NodeId sessionId{};
+        AccessControlBase::SessionContext sessionContext{};
+
+        CHECK(ac.getUserRightsMask(sessionId, sessionContext, {}, {}) == 0xFFFFFFFF);
+        CHECK(ac.getUserAccessLevel(sessionId, sessionContext, {}, {}) == 0xFF);
+        CHECK(ac.getUserExecutable(sessionId, sessionContext, {}, {}));
+        CHECK(ac.getUserExecutableOnObject(sessionId, sessionContext, {}, {}, {}, {}));
+        CHECK(ac.allowAddNode(sessionId, sessionContext, {}));
+        CHECK(ac.allowAddReference(sessionId, sessionContext, {}));
+        CHECK(ac.allowDeleteNode(sessionId, sessionContext, {}));
+        CHECK(ac.allowDeleteReference(sessionId, sessionContext, {}));
+        CHECK(ac.allowBrowseNode(sessionId, sessionContext, {}, {}));
+#ifdef UA_ENABLE_SUBSCRIPTIONS
+        CHECK(ac.allowTransferSubscription(sessionId, sessionContext, sessionId, sessionContext));
+#endif
+#ifdef UA_ENABLE_HISTORIZING
+        CHECK(ac.allowHistoryUpdate(sessionId, sessionContext, {}, {}, {}));
+        CHECK(ac.allowHistoryDelete(sessionId, sessionContext, {}, {}, {}, {}));
+#endif
+    }
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(${PROJECT_SOURCE_DIR}/3rdparty/doctest doctest EXCLUDE_FROM_ALL
 add_executable(
     open62541pp_tests
     main.cpp
+    AccessControl.cpp
     Client.cpp
     Crypto.cpp
     helper.cpp

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -656,6 +656,21 @@ TEST_CASE("ExtensionObject") {
     }
 }
 
+TEST_CASE("UserTokenPolicy") {
+    UserTokenPolicy userTokenPolicy(
+        "policyId",
+        UserTokenType::Username,
+        "issuedTokenType",
+        "issuerEndpointUrl",
+        "securityPolicyUri"
+    );
+    CHECK(userTokenPolicy.getPolicyId() == String("policyId"));
+    CHECK(userTokenPolicy.getTokenType() == UserTokenType::Username);
+    CHECK(userTokenPolicy.getIssuedTokenType() == String("issuedTokenType"));
+    CHECK(userTokenPolicy.getIssuerEndpointUrl() == String("issuerEndpointUrl"));
+    CHECK(userTokenPolicy.getSecurityPolicyUri() == String("securityPolicyUri"));
+}
+
 TEST_CASE("BrowseDescription") {
     BrowseDescription bd(NodeId(1, 1000), BrowseDirection::Forward);
     CHECK(bd.getNodeId() == NodeId(1, 1000));


### PR DESCRIPTION
Wrapper of `UA_AccessControl` plugin with `Server` integration. As requested in #69 and #71.

Design idea:
- `AccessControlBase` base class with pure virtual methods
- `AccessControlDefault` class with same logic as `UA_AccessControl_default`
- Custom access control logics can be implemented by deriving from either the base class or `AccessControlDefault` and overriding (some) methods
- Hook `AccessControlBase&` into `Server`