### PR TITLE
feat: addReferenceType, addDataType, addView

### DIFF
--- a/include/open62541pp/Node.h
+++ b/include/open62541pp/Node.h
@@ -106,31 +106,6 @@ public:
         return {connection_, id, false};
     }
 
-    /// @copydoc services::addObjectType
-    Node addObjectType(
-        const NodeId& id,
-        std::string_view browseName,
-        const ObjectTypeAttributes& attributes = {},
-        const NodeId& referenceType = ReferenceTypeId::HasSubtype
-    ) {
-        services::addObjectType(connection_, nodeId_, id, browseName, attributes, referenceType);
-        return {connection_, id, false};
-    }
-
-    /// @copydoc services::addVariableType
-    Node addVariableType(
-        const NodeId& id,
-        std::string_view browseName,
-        const VariableTypeAttributes& attributes = {},
-        const NodeId& variableType = VariableTypeId::BaseDataVariableType,
-        const NodeId& referenceType = ReferenceTypeId::HasSubtype
-    ) {
-        services::addVariableType(
-            connection_, nodeId_, id, browseName, attributes, variableType, referenceType
-        );
-        return {connection_, id, false};
-    }
-
 #ifdef UA_ENABLE_METHODCALLS
     /// @copydoc services::addMethod
     Node addMethod(
@@ -156,6 +131,64 @@ public:
         return {connection_, id, false};
     }
 #endif
+
+    /// @copydoc services::addObjectType
+    Node addObjectType(
+        const NodeId& id,
+        std::string_view browseName,
+        const ObjectTypeAttributes& attributes = {},
+        const NodeId& referenceType = ReferenceTypeId::HasSubtype
+    ) {
+        services::addObjectType(connection_, nodeId_, id, browseName, attributes, referenceType);
+        return {connection_, id, false};
+    }
+
+    /// @copydoc services::addVariableType
+    Node addVariableType(
+        const NodeId& id,
+        std::string_view browseName,
+        const VariableTypeAttributes& attributes = {},
+        const NodeId& variableType = VariableTypeId::BaseDataVariableType,
+        const NodeId& referenceType = ReferenceTypeId::HasSubtype
+    ) {
+        services::addVariableType(
+            connection_, nodeId_, id, browseName, attributes, variableType, referenceType
+        );
+        return {connection_, id, false};
+    }
+
+    /// @copydoc services::addReferenceType
+    Node addReferenceType(
+        const NodeId& id,
+        std::string_view browseName,
+        const ReferenceTypeAttributes& attributes = {},
+        const NodeId& referenceType = ReferenceTypeId::HasSubtype
+    ) {
+        services::addReferenceType(connection_, nodeId_, id, browseName, attributes, referenceType);
+        return {connection_, id, false};
+    }
+
+    /// @copydoc services::addDataType
+    Node addDataType(
+        const NodeId& id,
+        std::string_view browseName,
+        const DataTypeAttributes& attributes = {},
+        const NodeId& referenceType = ReferenceTypeId::HasSubtype
+    ) {
+        services::addDataType(connection_, nodeId_, id, browseName, attributes, referenceType);
+        return {connection_, id, false};
+    }
+
+    /// @copydoc services::addView
+    Node addView(
+        const NodeId& id,
+        std::string_view browseName,
+        const ViewAttributes& attributes = {},
+        const NodeId& referenceType = ReferenceTypeId::Organizes
+    ) {
+        services::addView(connection_, nodeId_, id, browseName, attributes, referenceType);
+        return {connection_, id, false};
+    }
 
     /// @copydoc services::addReference
     /// @return Current node instance to chain multiple methods (fluent interface)

--- a/include/open62541pp/services/NodeManagement.h
+++ b/include/open62541pp/services/NodeManagement.h
@@ -28,7 +28,7 @@ namespace opcua::services {
  */
 
 /**
- * Add child object.
+ * Add object.
  * @exception BadStatus
  * @ingroup NodeManagement
  */
@@ -44,7 +44,7 @@ void addObject(
 );
 
 /**
- * Add child folder.
+ * Add folder.
  * @exception BadStatus
  * @ingroup NodeManagement
  */
@@ -69,7 +69,7 @@ inline void addFolder(
 }
 
 /**
- * Add child variable.
+ * Add variable.
  * @exception BadStatus
  * @ingroup NodeManagement
  */
@@ -85,7 +85,7 @@ void addVariable(
 );
 
 /**
- * Add child property.
+ * Add property.
  * @exception BadStatus
  * @ingroup NodeManagement
  */
@@ -108,37 +108,6 @@ inline void addProperty(
     );
 }
 
-/**
- * Add child object type.
- * @exception BadStatus
- * @ingroup NodeManagement
- */
-template <typename T>
-void addObjectType(
-    T& serverOrClient,
-    const NodeId& parentId,
-    const NodeId& id,
-    std::string_view browseName,
-    const ObjectTypeAttributes& attributes = {},
-    const NodeId& referenceType = ReferenceTypeId::HasSubtype
-);
-
-/**
- * Add child variable type.
- * @exception BadStatus
- * @ingroup NodeManagement
- */
-template <typename T>
-void addVariableType(
-    T& serverOrClient,
-    const NodeId& parentId,
-    const NodeId& id,
-    std::string_view browseName,
-    const VariableTypeAttributes& attributes = {},
-    const NodeId& variableType = VariableTypeId::BaseDataVariableType,
-    const NodeId& referenceType = ReferenceTypeId::HasSubtype
-);
-
 #ifdef UA_ENABLE_METHODCALLS
 /**
  * Method callback.
@@ -147,7 +116,7 @@ void addVariableType(
 using MethodCallback = std::function<void(const std::vector<Variant>&, std::vector<Variant>&)>;
 
 /**
- * Add child method.
+ * Add method.
  * Callbacks can not be set by clients. Servers can assign callbacks to method nodes afterwards.
  * @exception BadStatus
  * @ingroup NodeManagement
@@ -165,6 +134,82 @@ void addMethod(
     const NodeId& referenceType = ReferenceTypeId::HasComponent
 );
 #endif
+
+/**
+ * Add object type.
+ * @exception BadStatus
+ * @ingroup NodeManagement
+ */
+template <typename T>
+void addObjectType(
+    T& serverOrClient,
+    const NodeId& parentId,
+    const NodeId& id,
+    std::string_view browseName,
+    const ObjectTypeAttributes& attributes = {},
+    const NodeId& referenceType = ReferenceTypeId::HasSubtype
+);
+
+/**
+ * Add variable type.
+ * @exception BadStatus
+ * @ingroup NodeManagement
+ */
+template <typename T>
+void addVariableType(
+    T& serverOrClient,
+    const NodeId& parentId,
+    const NodeId& id,
+    std::string_view browseName,
+    const VariableTypeAttributes& attributes = {},
+    const NodeId& variableType = VariableTypeId::BaseDataVariableType,
+    const NodeId& referenceType = ReferenceTypeId::HasSubtype
+);
+
+/**
+ * Add reference type.
+ * @exception BadStatus
+ * @ingroup NodeManagement
+ */
+template <typename T>
+void addReferenceType(
+    T& serverOrClient,
+    const NodeId& parentId,
+    const NodeId& id,
+    std::string_view browseName,
+    const ReferenceTypeAttributes& attributes = {},
+    const NodeId& referenceType = ReferenceTypeId::HasSubtype
+);
+
+/**
+ * Add data type.
+ * @exception BadStatus
+ * @ingroup NodeManagement
+ */
+template <typename T>
+void addDataType(
+    T& serverOrClient,
+    const NodeId& parentId,
+    const NodeId& id,
+    std::string_view browseName,
+    const DataTypeAttributes& attributes = {},
+    const NodeId& referenceType = ReferenceTypeId::HasSubtype
+);
+
+/**
+ * Add view.
+ * @exception BadStatus
+ * @ingroup NodeManagement
+ */
+template <typename T>
+void addView(
+    T& serverOrClient,
+    const NodeId& parentId,
+    const NodeId& id,
+    std::string_view browseName,
+    const ViewAttributes& attributes = {},
+    const NodeId& referenceType = ReferenceTypeId::Organizes
+);
 
 /**
  * Add reference.

--- a/include/open62541pp/types/Composed.h
+++ b/include/open62541pp/types/Composed.h
@@ -297,6 +297,57 @@ public:
     UAPP_NODEATTR(bool, IsAbstract, isAbstract, UA_NODEATTRIBUTESMASK_ISABSTRACT)
 };
 
+/**
+ * UA_ReferenceTypeAttributes wrapper class.
+ * @ingroup TypeWrapper
+ */
+class ReferenceTypeAttributes
+    : public TypeWrapper<UA_ReferenceTypeAttributes, UA_TYPES_REFERENCETYPEATTRIBUTES> {
+public:
+    using TypeWrapperBase::TypeWrapperBase;
+
+    /// Construct with default attribute definitions.
+    ReferenceTypeAttributes();
+
+    UAPP_NODEATTR_COMMON
+    UAPP_NODEATTR(bool, IsAbstract, isAbstract, UA_NODEATTRIBUTESMASK_ISABSTRACT)
+    UAPP_NODEATTR(bool, Symmetric, symmetric, UA_NODEATTRIBUTESMASK_SYMMETRIC)
+    UAPP_NODEATTR_WRAPPER(
+        LocalizedText, InverseName, inverseName, UA_NODEATTRIBUTESMASK_INVERSENAME
+    )
+};
+
+/**
+ * UA_DataTypeAttributes wrapper class.
+ * @ingroup TypeWrapper
+ */
+class DataTypeAttributes : public TypeWrapper<UA_DataTypeAttributes, UA_TYPES_DATATYPEATTRIBUTES> {
+public:
+    using TypeWrapperBase::TypeWrapperBase;
+
+    /// Construct with default attribute definitions.
+    DataTypeAttributes();
+
+    UAPP_NODEATTR_COMMON
+    UAPP_NODEATTR(bool, IsAbstract, isAbstract, UA_NODEATTRIBUTESMASK_ISABSTRACT)
+};
+
+/**
+ * UA_ViewAttributes wrapper class.
+ * @ingroup TypeWrapper
+ */
+class ViewAttributes : public TypeWrapper<UA_ViewAttributes, UA_TYPES_VIEWATTRIBUTES> {
+public:
+    using TypeWrapperBase::TypeWrapperBase;
+
+    /// Construct with default attribute definitions.
+    ViewAttributes();
+
+    UAPP_NODEATTR_COMMON
+    UAPP_NODEATTR(bool, IsAbstract, containsNoLoops, UA_NODEATTRIBUTESMASK_CONTAINSNOLOOPS)
+    UAPP_NODEATTR(uint8_t, EventNotifier, eventNotifier, UA_NODEATTRIBUTESMASK_EVENTNOTIFIER)
+};
+
 #undef UAPP_NODEATTR
 #undef UAPP_NODEATTR_WRAPPER
 #undef UAPP_NODEATTR_ARRAY

--- a/src/services/NodeManagement.cpp
+++ b/src/services/NodeManagement.cpp
@@ -110,96 +110,6 @@ void addVariable<Client>(
     detail::throwOnBadStatus(status);
 }
 
-template <>
-void addObjectType<Server>(
-    Server& server,
-    const NodeId& parentId,
-    const NodeId& id,
-    std::string_view browseName,
-    const ObjectTypeAttributes& attributes,
-    const NodeId& referenceType
-) {
-    const auto status = UA_Server_addObjectTypeNode(
-        server.handle(),
-        id,
-        parentId,
-        referenceType,
-        QualifiedName(id.getNamespaceIndex(), browseName),
-        attributes,
-        nullptr,  // node context
-        nullptr  // output new node id
-    );
-    detail::throwOnBadStatus(status);
-}
-
-template <>
-void addObjectType<Client>(
-    Client& client,
-    const NodeId& parentId,
-    const NodeId& id,
-    std::string_view browseName,
-    const ObjectTypeAttributes& attributes,
-    const NodeId& referenceType
-) {
-    const auto status = UA_Client_addObjectTypeNode(
-        client.handle(),
-        id,
-        parentId,
-        referenceType,
-        QualifiedName(id.getNamespaceIndex(), browseName),
-        attributes,
-        nullptr  // output new node id
-    );
-    detail::throwOnBadStatus(status);
-}
-
-template <>
-void addVariableType<Server>(
-    Server& server,
-    const NodeId& parentId,
-    const NodeId& id,
-    std::string_view browseName,
-    const VariableTypeAttributes& attributes,
-    const NodeId& variableType,
-    const NodeId& referenceType
-) {
-    const auto status = UA_Server_addVariableTypeNode(
-        server.handle(),
-        id,
-        parentId,
-        referenceType,
-        QualifiedName(id.getNamespaceIndex(), browseName),
-        variableType,
-        attributes,
-        nullptr,  // node context
-        nullptr  // output new node id
-    );
-    detail::throwOnBadStatus(status);
-}
-
-template <>
-void addVariableType<Client>(
-    Client& client,
-    const NodeId& parentId,
-    const NodeId& id,
-    std::string_view browseName,
-    const VariableTypeAttributes& attributes,
-    const NodeId& variableType,
-    const NodeId& referenceType
-) {
-    (void)variableType;  // TODO: variableType is currently unused
-    const auto status = UA_Client_addVariableTypeNode(
-        client.handle(),
-        id,
-        parentId,
-        referenceType,
-        QualifiedName(id.getNamespaceIndex(), browseName),
-        attributes,
-        nullptr  // output new node id
-    );
-    detail::throwOnBadStatus(status);
-}
-
 #ifdef UA_ENABLE_METHODCALLS
 static UA_StatusCode methodCallback(
     [[maybe_unused]] UA_Server* server,
@@ -295,6 +205,225 @@ void addMethod(
     detail::throwOnBadStatus(status);
 }
 #endif
+
+template <>
+void addObjectType<Server>(
+    Server& server,
+    const NodeId& parentId,
+    const NodeId& id,
+    std::string_view browseName,
+    const ObjectTypeAttributes& attributes,
+    const NodeId& referenceType
+) {
+    const auto status = UA_Server_addObjectTypeNode(
+        server.handle(),
+        id,
+        parentId,
+        referenceType,
+        QualifiedName(id.getNamespaceIndex(), browseName),
+        attributes,
+        nullptr,  // node context
+        nullptr  // output new node id
+    );
+    detail::throwOnBadStatus(status);
+}
+
+template <>
+void addObjectType<Client>(
+    Client& client,
+    const NodeId& parentId,
+    const NodeId& id,
+    std::string_view browseName,
+    const ObjectTypeAttributes& attributes,
+    const NodeId& referenceType
+) {
+    const auto status = UA_Client_addObjectTypeNode(
+        client.handle(),
+        id,
+        parentId,
+        referenceType,
+        QualifiedName(id.getNamespaceIndex(), browseName),
+        attributes,
+        nullptr  // output new node id
+    );
+    detail::throwOnBadStatus(status);
+}
+
+template <>
+void addVariableType<Server>(
+    Server& server,
+    const NodeId& parentId,
+    const NodeId& id,
+    std::string_view browseName,
+    const VariableTypeAttributes& attributes,
+    const NodeId& variableType,
+    const NodeId& referenceType
+) {
+    const auto status = UA_Server_addVariableTypeNode(
+        server.handle(),
+        id,
+        parentId,
+        referenceType,
+        QualifiedName(id.getNamespaceIndex(), browseName),
+        variableType,
+        attributes,
+        nullptr,  // node context
+        nullptr  // output new node id
+    );
+    detail::throwOnBadStatus(status);
+}
+
+template <>
+void addVariableType<Client>(
+    Client& client,
+    const NodeId& parentId,
+    const NodeId& id,
+    std::string_view browseName,
+    const VariableTypeAttributes& attributes,
+    const NodeId& variableType,
+    const NodeId& referenceType
+) {
+    (void)variableType;  // TODO: variableType is currently unused
+    const auto status = UA_Client_addVariableTypeNode(
+        client.handle(),
+        id,
+        parentId,
+        referenceType,
+        QualifiedName(id.getNamespaceIndex(), browseName),
+        attributes,
+        nullptr  // output new node id
+    );
+    detail::throwOnBadStatus(status);
+}
+
+template <>
+void addReferenceType<Server>(
+    Server& server,
+    const NodeId& parentId,
+    const NodeId& id,
+    std::string_view browseName,
+    const ReferenceTypeAttributes& attributes,
+    const NodeId& referenceType
+) {
+    const auto status = UA_Server_addReferenceTypeNode(
+        server.handle(),
+        id,
+        parentId,
+        referenceType,
+        QualifiedName(id.getNamespaceIndex(), browseName),
+        attributes,
+        nullptr,  // node context
+        nullptr  // output new node id
+    );
+    detail::throwOnBadStatus(status);
+}
+
+template <>
+void addReferenceType<Client>(
+    Client& client,
+    const NodeId& parentId,
+    const NodeId& id,
+    std::string_view browseName,
+    const ReferenceTypeAttributes& attributes,
+    const NodeId& referenceType
+) {
+    const auto status = UA_Client_addReferenceTypeNode(
+        client.handle(),
+        id,
+        parentId,
+        referenceType,
+        QualifiedName(id.getNamespaceIndex(), browseName),
+        attributes,
+        nullptr  // output new node id
+    );
+    detail::throwOnBadStatus(status);
+}
+
+template <>
+void addDataType<Server>(
+    Server& server,
+    const NodeId& parentId,
+    const NodeId& id,
+    std::string_view browseName,
+    const DataTypeAttributes& attributes,
+    const NodeId& referenceType
+) {
+    const auto status = UA_Server_addDataTypeNode(
+        server.handle(),
+        id,
+        parentId,
+        referenceType,
+        QualifiedName(id.getNamespaceIndex(), browseName),
+        attributes,
+        nullptr,  // node context
+        nullptr  // output new node id
+    );
+    detail::throwOnBadStatus(status);
+}
+
+template <>
+void addDataType<Client>(
+    Client& client,
+    const NodeId& parentId,
+    const NodeId& id,
+    std::string_view browseName,
+    const DataTypeAttributes& attributes,
+    const NodeId& referenceType
+) {
+    const auto status = UA_Client_addDataTypeNode(
+        client.handle(),
+        id,
+        parentId,
+        referenceType,
+        QualifiedName(id.getNamespaceIndex(), browseName),
+        attributes,
+        nullptr  // output new node id
+    );
+    detail::throwOnBadStatus(status);
+}
+
+template <>
+void addView<Server>(
+    Server& server,
+    const NodeId& parentId,
+    const NodeId& id,
+    std::string_view browseName,
+    const ViewAttributes& attributes,
+    const NodeId& referenceType
+) {
+    const auto status = UA_Server_addViewNode(
+        server.handle(),
+        id,
+        parentId,
+        referenceType,
+        QualifiedName(id.getNamespaceIndex(), browseName),
+        attributes,
+        nullptr,  // node context
+        nullptr  // output new node id
+    );
+    detail::throwOnBadStatus(status);
+}
+
+template <>
+void addView<Client>(
+    Client& client,
+    const NodeId& parentId,
+    const NodeId& id,
+    std::string_view browseName,
+    const ViewAttributes& attributes,
+    const NodeId& referenceType
+) {
+    const auto status = UA_Client_addViewNode(
+        client.handle(),
+        id,
+        parentId,
+        referenceType,
+        QualifiedName(id.getNamespaceIndex(), browseName),
+        attributes,
+        nullptr  // output new node id
+    );
+    detail::throwOnBadStatus(status);
+}
 
 template <>
 void addReference<Server>(

--- a/src/types/Composed.cpp
+++ b/src/types/Composed.cpp
@@ -22,6 +22,15 @@ ObjectTypeAttributes::ObjectTypeAttributes()
 VariableTypeAttributes::VariableTypeAttributes()
     : TypeWrapperBase(UA_VariableTypeAttributes_default) {}
 
+ReferenceTypeAttributes::ReferenceTypeAttributes()
+    : TypeWrapperBase(UA_ReferenceTypeAttributes_default) {}
+
+DataTypeAttributes::DataTypeAttributes()
+    : TypeWrapperBase(UA_DataTypeAttributes_default) {}
+
+ViewAttributes::ViewAttributes()
+    : TypeWrapperBase(UA_ViewAttributes_default) {}
+
 BrowseDescription::BrowseDescription(
     const NodeId& nodeId,
     BrowseDirection browseDirection,

--- a/tests/Services.cpp
+++ b/tests/Services.cpp
@@ -55,6 +55,19 @@ TEST_CASE("NodeManagement service set (server & client)") {
                 serverOrClient, {0, UA_NS0ID_BASEVARIABLETYPE}, {1, 1001}, "variabletype"
             );
             CHECK(services::readNodeClass(server, {1, 1001}) == NodeClass::VariableType);
+
+            services::addReferenceType(
+                serverOrClient, {0, UA_NS0ID_ORGANIZES}, {1, 1002}, "referenceType"
+            );
+            CHECK(services::readNodeClass(server, {1, 1002}) == NodeClass::ReferenceType);
+
+            services::addDataType(serverOrClient, {0, UA_NS0ID_STRUCTURE}, {1, 1003}, "dataType");
+            CHECK(services::readNodeClass(server, {1, 1003}) == NodeClass::DataType);
+        }
+
+        SUBCASE("View nodes") {
+            services::addView(serverOrClient, {0, UA_NS0ID_VIEWSFOLDER}, {1, 1000}, "view");
+            CHECK(services::readNodeClass(server, {1, 1000}) == NodeClass::View);
         }
 
         SUBCASE("Add reference") {


### PR DESCRIPTION
Add missing node management functions:
- `Node::addReferenceType` / `services::addReferenceType`
- `Node::addDataType` / `services::addDataType`
- `Node::addView` / `services::addView`

Add missing node attributes wrapper:
- `ReferenceTypeAttributes`
- `DataTypeAttributes`
- `ViewAttributes`