### PR TITLE
feat: variant methods for custom types

### DIFF
--- a/include/open62541pp/TypeConverter.h
+++ b/include/open62541pp/TypeConverter.h
@@ -230,6 +230,13 @@ struct TypeConverterNative {
     }
 };
 
+template <typename T>
+constexpr bool isNativeType() {
+    using ValueType = typename TypeConverter<T>::ValueType;
+    using NativeType = typename TypeConverter<T>::NativeType;
+    return std::is_same_v<ValueType, NativeType>;
+}
+
 }  // namespace detail
 
 // NOLINTNEXTLINE

--- a/include/open62541pp/TypeConverter.h
+++ b/include/open62541pp/TypeConverter.h
@@ -132,8 +132,8 @@ template <typename T, typename NativeType = typename TypeConverter<T>::NativeTyp
 /// Convert and copy from native type.
 /// @warning Type erased version, use with caution.
 template <typename T, typename NativeType = typename TypeConverter<T>::NativeType>
-[[nodiscard]] T fromNative(void* value, [[maybe_unused]] Type type) {
-    assert(isValidTypeCombination<T>(getUaDataType(type)));  // NOLINT
+[[nodiscard]] T fromNative(void* value, [[maybe_unused]] const UA_DataType* dataType) {
+    assert(isValidTypeCombination<T>(dataType));  // NOLINT
     return fromNative<T>(static_cast<NativeType*>(value));
 }
 
@@ -154,8 +154,10 @@ template <typename T, typename NativeType = typename TypeConverter<T>::NativeTyp
 /// Create and convert vector from native array.
 /// @warning Type erased version, use with caution.
 template <typename T, typename NativeType = typename TypeConverter<T>::NativeType>
-[[nodiscard]] std::vector<T> fromNativeArray(void* array, size_t size, [[maybe_unused]] Type type) {
-    assert(isValidTypeCombination<T>(getUaDataType(type)));  // NOLINT
+[[nodiscard]] std::vector<T> fromNativeArray(
+    void* array, size_t size, [[maybe_unused]] const UA_DataType* dataType
+) {
+    assert(isValidTypeCombination<T>(dataType));  // NOLINT
     return fromNativeArray<T>(static_cast<NativeType*>(array), size);
 }
 

--- a/include/open62541pp/TypeConverter.h
+++ b/include/open62541pp/TypeConverter.h
@@ -64,6 +64,20 @@ constexpr bool isValidTypeCombination(TypeIndexOrType typeOrTypeIndex) {
     return TypeConverter<T>::ValidTypes::contains(typeOrTypeIndex);
 }
 
+template <typename T>
+constexpr bool isValidTypeCombination(const UA_DataType* dataType) {
+    if (dataType == nullptr) {
+        return false;
+    }
+    for (auto typeIndex : TypeConverter<T>::ValidTypes::toArray()) {
+        // TODO: deep comparison
+        if (dataType == &UA_TYPES[typeIndex]) {  // NOLINT
+            return true;
+        }
+    }
+    return false;
+}
+
 template <typename T, auto typeOrTypeIndex>
 constexpr void assertTypeCombination() {
     static_assert(
@@ -119,7 +133,7 @@ template <typename T, typename NativeType = typename TypeConverter<T>::NativeTyp
 /// @warning Type erased version, use with caution.
 template <typename T, typename NativeType = typename TypeConverter<T>::NativeType>
 [[nodiscard]] T fromNative(void* value, [[maybe_unused]] Type type) {
-    assert(isValidTypeCombination<T>(type));  // NOLINT
+    assert(isValidTypeCombination<T>(getUaDataType(type)));  // NOLINT
     return fromNative<T>(static_cast<NativeType*>(value));
 }
 
@@ -141,7 +155,7 @@ template <typename T, typename NativeType = typename TypeConverter<T>::NativeTyp
 /// @warning Type erased version, use with caution.
 template <typename T, typename NativeType = typename TypeConverter<T>::NativeType>
 [[nodiscard]] std::vector<T> fromNativeArray(void* array, size_t size, [[maybe_unused]] Type type) {
-    assert(isValidTypeCombination<T>(type));  // NOLINT
+    assert(isValidTypeCombination<T>(getUaDataType(type)));  // NOLINT
     return fromNativeArray<T>(static_cast<NativeType*>(array), size);
 }
 

--- a/include/open62541pp/TypeWrapper.h
+++ b/include/open62541pp/TypeWrapper.h
@@ -146,23 +146,19 @@ public:
     };
 
 protected:
-    inline static const UA_DataType* getDataType() {
-        return detail::getUaDataType<typeIndex>();
-    }
-
     inline static void checkMemSize() {
-        assert(sizeof(T) == getDataType()->memSize);  // NOLINT
+        assert(sizeof(T) == UA_TYPES[typeIndex].memSize);  // NOLINT
     }
 
     void clear() noexcept {
         checkMemSize();
-        UA_clear(&data_, getDataType());
+        UA_clear(&data_, &UA_TYPES[typeIndex]);
     }
 
     void copy(const T& data) {
         clear();
         checkMemSize();
-        auto status = UA_copy(&data, &data_, getDataType());  // deep copy of data
+        auto status = UA_copy(&data, &data_, &UA_TYPES[typeIndex]);  // deep copy of data
         detail::throwOnBadStatus(status);
     }
 

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -46,11 +46,15 @@ public:
 
     /// Create Variant from std::vector (no copy if assignable without conversion).
     template <typename T, Type type = detail::guessType<T>()>
-    [[nodiscard]] static Variant fromArray(std::vector<T>& array);
+    [[nodiscard]] static Variant fromArray(std::vector<T>& array) {
+        return fromArray<T, type>(array.data(), array.size());
+    }
 
     /// Create Variant from std::vector (copy).
     template <typename T, Type type = detail::guessType<T>()>
-    [[nodiscard]] static Variant fromArray(const std::vector<T>& array);
+    [[nodiscard]] static Variant fromArray(const std::vector<T>& array) {
+        return fromArray<T, type>(array.data(), array.size());
+    }
 
     /// Create Variant from range of elements (copy).
     template <typename InputIt, Type type = detail::guessTypeFromIterator<InputIt>()>
@@ -134,7 +138,9 @@ public:
 
     /// Assign array (std::vector) to variant.
     template <typename T, Type type = detail::guessType<T>()>
-    void setArray(std::vector<T>& array) noexcept;
+    void setArray(std::vector<T>& array) noexcept {
+        setArray<T, type>(array.data(), array.size());
+    }
 
     /// Copy range of elements as array to variant.
     template <typename InputIt, Type type = detail::guessTypeFromIterator<InputIt>()>
@@ -146,7 +152,9 @@ public:
 
     /// Copy array (std::vector) to variant.
     template <typename T, Type type = detail::guessType<T>()>
-    void setArrayCopy(const std::vector<T>& array);
+    void setArrayCopy(const std::vector<T>& array) {
+        setArrayCopy<T, type>(array.data(), array.size());
+    }
 
 private:
     template <typename T>
@@ -232,16 +240,6 @@ Variant Variant::fromArray(const T* array, size_t size) {
     Variant variant;
     variant.setArrayCopy<T, type>(array, size);
     return variant;
-}
-
-template <typename T, Type type>
-Variant Variant::fromArray(std::vector<T>& array) {
-    return fromArray<T, type>(array.data(), array.size());
-}
-
-template <typename T, Type type>
-Variant Variant::fromArray(const std::vector<T>& array) {
-    return fromArray<T, type>(array.data(), array.size());
 }
 
 template <typename InputIt, Type type>
@@ -335,11 +333,6 @@ void Variant::setArray(T* array, size_t size) noexcept {
     setArrayImpl(array, size, detail::getUaDataType<type>());
 }
 
-template <typename T, Type type>
-void Variant::setArray(std::vector<T>& array) noexcept {
-    setArray<T, type>(array.data(), array.size());
-}
-
 template <typename InputIt, Type type>
 void Variant::setArrayCopy(InputIt first, InputIt last) {
     using ValueType = typename std::iterator_traits<InputIt>::value_type;
@@ -360,11 +353,6 @@ void Variant::setArrayCopy(const T* array, size_t size) {
     } else {
         setArrayCopy<const T*, type>(array, array + size);
     }
-}
-
-template <typename T, Type type>
-void Variant::setArrayCopy(const std::vector<T>& array) {
-    setArrayCopy<T, type>(array.data(), array.size());
 }
 
 }  // namespace opcua

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -28,49 +28,52 @@ public:
     // NOLINTNEXTLINE, false positive?
     using TypeWrapperBase::TypeWrapperBase;  // inherit contructors
 
-    /// Create Variant from scalar value (no copy if assignable without conversion)
+    /// Create Variant from scalar value (no copy if assignable without conversion).
     template <typename T, Type type = detail::guessType<T>()>
     [[nodiscard]] static Variant fromScalar(T& value);
 
-    /// Create Variant from scalar value (copy)
+    /// Create Variant from scalar value (copy).
     template <typename T, Type type = detail::guessType<T>()>
     [[nodiscard]] static Variant fromScalar(const T& value);
 
-    /// Create Variant from array (no copy if assignable without conversion)
+    /// Create Variant from array (no copy if assignable without conversion).
     template <typename T, Type type = detail::guessType<T>()>
     [[nodiscard]] static Variant fromArray(T* array, size_t size);
 
-    /// Create Variant from array (copy)
+    /// Create Variant from array (copy).
     template <typename T, Type type = detail::guessType<T>()>
     [[nodiscard]] static Variant fromArray(const T* array, size_t size);
 
-    /// Create Variant from std::vector (no copy if assignable without conversion)
+    /// Create Variant from std::vector (no copy if assignable without conversion).
     template <typename T, Type type = detail::guessType<T>()>
     [[nodiscard]] static Variant fromArray(std::vector<T>& array);
 
-    /// Create Variant from std::vector (copy)
+    /// Create Variant from std::vector (copy).
     template <typename T, Type type = detail::guessType<T>()>
     [[nodiscard]] static Variant fromArray(const std::vector<T>& array);
 
-    /// Create Variant from range of elements (copy)
+    /// Create Variant from range of elements (copy).
     template <typename InputIt, Type type = detail::guessTypeFromIterator<InputIt>()>
     [[nodiscard]] static Variant fromArray(InputIt first, InputIt last);
 
-    /// Check if variant is empty
+    /// Check if variant is empty.
     bool isEmpty() const noexcept;
-    /// Check if variant is a scalar
+    /// Check if variant is a scalar.
     bool isScalar() const noexcept;
-    /// Check if variant is an array
+    /// Check if variant is an array.
     bool isArray() const noexcept;
 
-    /// Check if variant type is equal to data type
+    /// Check if variant type is equal to data type.
     bool isType(const UA_DataType* type) const noexcept;
-    /// Check if variant type is equal to type enum
+    /// Check if variant type is equal to type enum.
     bool isType(Type type) const noexcept;
-    /// Check if variant type is equal to data type node id
+    /// Check if variant type is equal to data type node id.
     bool isType(const NodeId& id) const noexcept;
 
-    /// Get variant type
+    /// Get data type.
+    const UA_DataType* getDataType() const noexcept;
+
+    /// Get variant type.
     std::optional<Type> getVariantType() const noexcept;
 
     /// Get reference to scalar value with given template type (only native or wrapper types).
@@ -246,7 +249,7 @@ const T& Variant::getScalar() const {
     assertGetNoCopy<T>();
     checkIsScalar();
     checkReturnType<T>();
-    assert(sizeof(T) == handle()->type->memSize);  // NOLINT
+    assert(sizeof(T) == getDataType()->memSize);  // NOLINT
     return *static_cast<const T*>(handle()->data);
 }
 
@@ -267,7 +270,7 @@ const T* Variant::getArray() const {
     assertGetNoCopy<T>();
     checkIsArray();
     checkReturnType<T>();
-    assert(sizeof(T) == handle()->type->memSize);  // NOLINT
+    assert(sizeof(T) == getDataType()->memSize);  // NOLINT
     return static_cast<const T*>(handle()->data);
 }
 

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -147,7 +147,7 @@ public:
 private:
     template <typename T>
     static constexpr bool isConvertibleToNative() {
-        return detail::isBuiltinType<T>() || detail::IsTypeWrapper<T>::value;
+        return detail::isNativeType<T>() || detail::IsTypeWrapper<T>::value;
     }
 
     template <typename T>

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -124,6 +124,10 @@ public:
     template <typename T, Type type = detail::guessType<T>()>
     void setScalarCopy(const T& value);
 
+    /// Copy scalar value to variant with custom data type.
+    template <typename T>
+    void setScalarCopy(const T& value, const UA_DataType& dataType);
+
     /// Assign array (raw) to variant.
     template <typename T, Type type = detail::guessType<T>()>
     void setArray(T* array, size_t size) noexcept;
@@ -316,6 +320,12 @@ void Variant::setScalarCopy(const T& value) {
         detail::getUaDataType<type>(),
         true  // move ownership
     );
+}
+
+template <typename T>
+void Variant::setScalarCopy(const T& value, const UA_DataType& dataType) {
+    checkDataType<T>(dataType);
+    setScalarCopyImpl(&value, &dataType);
 }
 
 template <typename T, Type type>

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -181,8 +181,7 @@ private:
 
     template <typename T>
     void checkReturnType() const {
-        const auto optType = getVariantType();
-        if (!optType || !detail::isValidTypeCombination<T>(*optType)) {
+        if (!detail::isValidTypeCombination<T>(getDataType())) {
             throw BadVariantAccess("Variant does not contain a value convertible to template type");
         }
     }

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -183,6 +183,7 @@ public:
 private:
     template <typename T>
     static constexpr bool isConvertibleToNative() {
+        // TypeWrapper<T> is pointer-interconvertible with T
         return detail::isNativeType<T>() || detail::IsTypeWrapper<T>::value;
     }
 
@@ -323,11 +324,7 @@ void Variant::setScalar(T& value) noexcept {
     assertNoVariant<T>();
     assertSetNoCopy<T>();
     detail::assertTypeCombination<T, type>();
-    if constexpr (detail::IsTypeWrapper<T>::value) {
-        setScalarImpl(value.handle(), detail::getUaDataType<type>());
-    } else {
-        setScalarImpl(&value, detail::getUaDataType<type>());
-    }
+    setScalarImpl(&value, detail::getUaDataType<type>());
 }
 
 template <typename T>

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -144,6 +144,10 @@ public:
     template <typename T, Type type = detail::guessType<T>()>
     void setArray(T* array, size_t size) noexcept;
 
+    /// Assign array (raw) to variant with custom data type.
+    template <typename T>
+    void setArray(T* array, size_t size, const UA_DataType& dataType) noexcept;
+
     /// Assign array (std::vector) to variant.
     template <typename T, Type type = detail::guessType<T>()>
     void setArray(std::vector<T>& array) noexcept {
@@ -345,6 +349,13 @@ void Variant::setArray(T* array, size_t size) noexcept {
     assertSetNoCopy<T>();
     detail::assertTypeCombination<T, type>();
     setArrayImpl(array, size, detail::getUaDataType<type>());
+}
+
+template <typename T>
+void Variant::setArray(T* array, size_t size, const UA_DataType& dataType) noexcept {
+    assertNoVariant<T>();
+    checkDataType<T>(dataType);
+    setArrayImpl(array, size, &dataType);
 }
 
 template <typename InputIt, Type type>

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -80,6 +80,14 @@ public:
     /// Get variant type.
     std::optional<Type> getVariantType() const noexcept;
 
+    /// Get pointer to scalar value.
+    /// @exception BadVariantAccess If the variant is not a scalar
+    void* getScalar();
+
+    /// Get pointer to scalar value.
+    /// @exception BadVariantAccess If the variant is not a scalar
+    const void* getScalar() const;
+
     /// Get reference to scalar value with given template type (only native or wrapper types).
     /// @exception BadVariantAccess If the variant is not a scalar or not of type `T`.
     template <typename T>

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -265,7 +265,7 @@ template <typename T>
 T Variant::getScalarCopy() const {
     checkIsScalar();
     checkReturnType<T>();
-    return detail::fromNative<T>(handle()->data, getVariantType().value());
+    return detail::fromNative<T>(handle()->data, getDataType());
 }
 
 template <typename T>
@@ -286,9 +286,7 @@ template <typename T>
 std::vector<T> Variant::getArrayCopy() const {
     checkIsArray();
     checkReturnType<T>();
-    return detail::fromNativeArray<T>(
-        handle()->data, handle()->arrayLength, getVariantType().value()
-    );
+    return detail::fromNativeArray<T>(handle()->data, handle()->arrayLength, getDataType());
 }
 
 template <typename T, Type type>

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -109,6 +109,14 @@ public:
     /// Get array dimensions.
     std::vector<uint32_t> getArrayDimensions() const;
 
+    /// Get pointer to array value.
+    /// @exception BadVariantAccess If the variant is not an array
+    void* getArray();
+
+    /// Get pointer to array value.
+    /// @exception BadVariantAccess If the variant is not an array
+    const void* getArray() const;
+
     /// Get pointer to array with given template type (only native or wrapper types).
     /// @exception BadVariantAccess If the variant is not an array or not of type `T`.
     template <typename T>

--- a/src/types/Variant.cpp
+++ b/src/types/Variant.cpp
@@ -61,6 +61,16 @@ size_t Variant::getArrayLength() const noexcept {
     return isArray() ? handle()->arrayLength : 0;
 }
 
+void* Variant::getArray() {
+    checkIsArray();
+    return handle()->data;
+}
+
+const void* Variant::getArray() const {
+    checkIsArray();
+    return handle()->data;
+}
+
 std::vector<uint32_t> Variant::getArrayDimensions() const {
     if (!isArray()) {
         return {};

--- a/src/types/Variant.cpp
+++ b/src/types/Variant.cpp
@@ -47,6 +47,16 @@ std::optional<Type> Variant::getVariantType() const noexcept {
     return {};
 }
 
+void* Variant::getScalar() {
+    checkIsScalar();
+    return handle()->data;
+}
+
+const void* Variant::getScalar() const {
+    checkIsScalar();
+    return handle()->data;
+}
+
 size_t Variant::getArrayLength() const noexcept {
     return isArray() ? handle()->arrayLength : 0;
 }

--- a/src/types/Variant.cpp
+++ b/src/types/Variant.cpp
@@ -34,11 +34,13 @@ const UA_DataType* Variant::getDataType() const noexcept {
 }
 
 std::optional<Type> Variant::getVariantType() const noexcept {
-    // UA_DataType typeIndex member was removed in open62541 v1.3
-    // https://github.com/open62541/open62541/pull/4477
-    // https://github.com/open62541/open62541/issues/4960
-    for (size_t typeIndex = 0; typeIndex < detail::builtinTypesCount; ++typeIndex) {
-        if (handle()->type == detail::getUaDataType(typeIndex)) {
+    // UA_DataType::typeIndex member was removed in open62541 v1.3
+    // use typeKind instead: https://github.com/open62541/open62541/issues/4960
+    static_assert(UA_TYPES_BOOLEAN == UA_DATATYPEKIND_BOOLEAN);
+    static_assert(UA_TYPES_VARIANT == UA_DATATYPEKIND_VARIANT);
+    if (getDataType() != nullptr) {
+        const auto typeIndex = getDataType()->typeKind;
+        if (typeIndex <= UA_DATATYPEKIND_DIAGNOSTICINFO) {
             return static_cast<Type>(typeIndex);
         }
     }

--- a/src/types/Variant.cpp
+++ b/src/types/Variant.cpp
@@ -18,15 +18,19 @@ bool Variant::isArray() const noexcept {
 }
 
 bool Variant::isType(const UA_DataType* type) const noexcept {
-    return handle()->type == type;
+    return getDataType() == type;
 }
 
 bool Variant::isType(Type type) const noexcept {
-    return handle()->type == detail::getUaDataType(type);
+    return getDataType() == detail::getUaDataType(type);
 }
 
 bool Variant::isType(const NodeId& id) const noexcept {
     return isType(detail::getUaDataType(id));
+}
+
+const UA_DataType* Variant::getDataType() const noexcept {
+    return handle()->type;
 }
 
 std::optional<Type> Variant::getVariantType() const noexcept {

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -524,6 +524,19 @@ TEST_CASE("Variant") {
         CHECK_THROWS(var.getArrayCopy<bool>());
         CHECK(var.getArrayCopy<std::string>() == value);
     }
+
+    SUBCASE("Set/get custom data types") {
+        using CustomType = UA_ApplicationDescription;
+        const auto& dt = UA_TYPES[UA_TYPES_APPLICATIONDESCRIPTION];
+
+        Variant var;
+        CustomType value{};
+        value.applicationType = UA_APPLICATIONTYPE_CLIENT;
+        var.setScalar(value, dt);
+        CHECK(var.isScalar());
+        CHECK(var.getDataType() == &dt);
+        CHECK(var.getVariantType() == std::nullopt);
+    }
 }
 
 TEST_CASE("DataValue") {

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -532,15 +532,24 @@ TEST_CASE("Variant") {
         Variant var;
         CustomType value{};
         value.applicationType = UA_APPLICATIONTYPE_CLIENT;
-        CHECK_NOTHROW(var.setScalar(value, dt));
-        CHECK_NOTHROW(var.setScalarCopy(value, dt));
-        CHECK(var.isScalar());
-        CHECK(var.getDataType() == &dt);
-        CHECK(var.getVariantType() == std::nullopt);
 
-        CHECK_NOTHROW(var.getScalar<CustomType>());
-        CHECK_NOTHROW(var.getScalarCopy<CustomType>());
-        CHECK(var.getScalar<CustomType>().applicationType == UA_APPLICATIONTYPE_CLIENT);
+        SUBCASE("Scalar") {
+            var.setScalar(value, dt);
+            CHECK(var.isScalar());
+            CHECK(var.getDataType() == &dt);
+
+            CHECK(var.getScalar() == &value);
+            CHECK(var.getScalar<CustomType>().applicationType == UA_APPLICATIONTYPE_CLIENT);
+        }
+
+        SUBCASE("Scalar (copy)") {
+            var.setScalarCopy(value, dt);
+            CHECK(var.isScalar());
+            CHECK(var.getDataType() == &dt);
+
+            CHECK(var.getScalar() != &value);
+            CHECK(var.getScalar<CustomType>().applicationType == UA_APPLICATIONTYPE_CLIENT);
+        }
     }
 }
 

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -525,17 +525,21 @@ TEST_CASE("Variant") {
         CHECK(var.getArrayCopy<std::string>() == value);
     }
 
-    SUBCASE("Set/get custom data types") {
+    SUBCASE("Set/get non-builtin data types") {
         using CustomType = UA_ApplicationDescription;
         const auto& dt = UA_TYPES[UA_TYPES_APPLICATIONDESCRIPTION];
 
         Variant var;
         CustomType value{};
         value.applicationType = UA_APPLICATIONTYPE_CLIENT;
-        var.setScalar(value, dt);
+        CHECK_NOTHROW(var.setScalar(value, dt));
         CHECK(var.isScalar());
         CHECK(var.getDataType() == &dt);
         CHECK(var.getVariantType() == std::nullopt);
+
+        CHECK_NOTHROW(var.getScalar<CustomType>());
+        CHECK_NOTHROW(var.getScalarCopy<CustomType>());
+        CHECK(var.getScalar<CustomType>().applicationType == UA_APPLICATIONTYPE_CLIENT);
     }
 }
 

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -533,6 +533,7 @@ TEST_CASE("Variant") {
         CustomType value{};
         value.applicationType = UA_APPLICATIONTYPE_CLIENT;
         CHECK_NOTHROW(var.setScalar(value, dt));
+        CHECK_NOTHROW(var.setScalarCopy(value, dt));
         CHECK(var.isScalar());
         CHECK(var.getDataType() == &dt);
         CHECK(var.getVariantType() == std::nullopt);

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -461,7 +461,7 @@ TEST_CASE("Variant") {
         CHECK(var.getDataType() == &UA_TYPES[UA_TYPES_FLOAT]);
         CHECK(var.getVariantType().value() == Type::Float);
         CHECK(var.getArrayLength() == array.size());
-        CHECK(var.handle()->data != array.data());
+        CHECK(var.getArray() != array.data());
 
         CHECK_THROWS(var.getArrayCopy<int32_t>());
         CHECK_THROWS(var.getArrayCopy<bool>());
@@ -491,7 +491,7 @@ TEST_CASE("Variant") {
 
         var.setArray<UA_String, Type::String>(array.data(), array.size());
         CHECK(var.getArrayLength() == array.size());
-        CHECK(var.handle()->data == array.data());
+        CHECK(var.getArray() == array.data());
 
         UA_clear(&array[0], &UA_TYPES[UA_TYPES_STRING]);
         UA_clear(&array[1], &UA_TYPES[UA_TYPES_STRING]);
@@ -504,7 +504,7 @@ TEST_CASE("Variant") {
 
         var.setArray(array);
         CHECK(var.getArrayLength() == array.size());
-        CHECK(var.handle()->data == array.data());
+        CHECK(var.getArray() == array.data());
         CHECK(var.getArray<String>() == array.data());
     }
 
@@ -537,7 +537,6 @@ TEST_CASE("Variant") {
             var.setScalar(value, dt);
             CHECK(var.isScalar());
             CHECK(var.getDataType() == &dt);
-
             CHECK(var.getScalar() == &value);
             CHECK(var.getScalar<CustomType>().applicationType == UA_APPLICATIONTYPE_CLIENT);
         }
@@ -546,7 +545,6 @@ TEST_CASE("Variant") {
             var.setScalarCopy(value, dt);
             CHECK(var.isScalar());
             CHECK(var.getDataType() == &dt);
-
             CHECK(var.getScalar() != &value);
             CHECK(var.getScalar<CustomType>().applicationType == UA_APPLICATIONTYPE_CLIENT);
         }
@@ -558,6 +556,8 @@ TEST_CASE("Variant") {
             var.setArray(array.data(), array.size(), dt);
             CHECK(var.isArray());
             CHECK(var.getDataType() == &dt);
+            CHECK(var.getArray() == array.data());
+            CHECK(var.getArray<CustomType>() == array.data());
         }
     }
 }

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -556,8 +556,18 @@ TEST_CASE("Variant") {
             var.setArray(array.data(), array.size(), dt);
             CHECK(var.isArray());
             CHECK(var.getDataType() == &dt);
+            CHECK(var.getArrayLength() == 3);
             CHECK(var.getArray() == array.data());
             CHECK(var.getArray<CustomType>() == array.data());
+        }
+
+        SUBCASE("Array (copy)") {
+            var.setArrayCopy(array.data(), array.size(), dt);
+            CHECK(var.isArray());
+            CHECK(var.getDataType() == &dt);
+            CHECK(var.getArrayLength() == 3);
+            CHECK(var.getArray() != array.data());
+            CHECK(var.getArray<CustomType>() != array.data());
         }
     }
 }

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -550,6 +550,15 @@ TEST_CASE("Variant") {
             CHECK(var.getScalar() != &value);
             CHECK(var.getScalar<CustomType>().applicationType == UA_APPLICATIONTYPE_CLIENT);
         }
+
+        std::vector<CustomType> array(3);
+        array.at(0).applicationType = UA_APPLICATIONTYPE_CLIENT;
+
+        SUBCASE("Array") {
+            var.setArray(array.data(), array.size(), dt);
+            CHECK(var.isArray());
+            CHECK(var.getDataType() == &dt);
+        }
     }
 }
 

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -324,6 +324,7 @@ TEST_CASE("Variant") {
         CHECK(varEmpty.isEmpty());
         CHECK(!varEmpty.isScalar());
         CHECK(!varEmpty.isArray());
+        CHECK(varEmpty.getDataType() == nullptr);
         CHECK(varEmpty.getVariantType() == std::nullopt);
         CHECK(varEmpty.getArrayLength() == 0);
         CHECK(varEmpty.getArrayDimensions().empty());
@@ -398,6 +399,7 @@ TEST_CASE("Variant") {
         CHECK(var.isType(&UA_TYPES[UA_TYPES_INT32]));
         CHECK(var.isType(Type::Int32));
         CHECK(var.isType(NodeId{0, UA_NS0ID_INT32}));
+        CHECK(var.getDataType() == &UA_TYPES[UA_TYPES_INT32]);
         CHECK(var.getVariantType().value() == Type::Int32);
 
         CHECK_THROWS(var.getScalar<bool>());
@@ -456,6 +458,7 @@ TEST_CASE("Variant") {
         CHECK(var.isArray());
         CHECK(var.isType(Type::Float));
         CHECK(var.isType(NodeId{0, UA_NS0ID_FLOAT}));
+        CHECK(var.getDataType() == &UA_TYPES[UA_TYPES_FLOAT]);
         CHECK(var.getVariantType().value() == Type::Float);
         CHECK(var.getArrayLength() == array.size());
         CHECK(var.handle()->data != array.data());
@@ -513,6 +516,7 @@ TEST_CASE("Variant") {
         CHECK(var.isArray());
         CHECK(var.isType(Type::String));
         CHECK(var.isType(NodeId{0, UA_NS0ID_STRING}));
+        CHECK(var.getDataType() == &UA_TYPES[UA_TYPES_STRING]);
         CHECK(var.getVariantType().value() == Type::String);
 
         CHECK_THROWS(var.getScalarCopy<std::string>());


### PR DESCRIPTION
New methods:
- `Variant::getDataType`
- `Variant::getScalar` without template type (returns `void*`)
- `Variant::getArray` without template type (returns `void*`)
- `Variant::setScalar` overload with custom `UA_DataType`
- `Variant::setScalarCopy` overload with custom `UA_DataType`
- `Variant::setArray` overload with custom `UA_DataType`
- `Variant::setArrayCopy` overload with custom `UA_DataType`