### PR TITLE
feat: StatusCode class

### DIFF
--- a/include/open62541pp/ErrorHandling.h
+++ b/include/open62541pp/ErrorHandling.h
@@ -52,11 +52,15 @@ public:
 namespace detail {
 
 [[nodiscard]] inline constexpr bool isGoodStatus(UA_StatusCode code) noexcept {
-    return code == UA_STATUSCODE_GOOD;
+    return (code >> 30U) == 0x00;
+}
+
+[[nodiscard]] inline constexpr bool isUncertainStatus(UA_StatusCode code) noexcept {
+    return (code >> 30U) == 0x01;
 }
 
 [[nodiscard]] inline constexpr bool isBadStatus(UA_StatusCode code) noexcept {
-    return code != UA_STATUSCODE_GOOD;
+    return (code >> 30U) >= 0x02;
 }
 
 inline void throwOnBadStatus(UA_StatusCode code) {

--- a/include/open62541pp/ValueBackend.h
+++ b/include/open62541pp/ValueBackend.h
@@ -59,11 +59,10 @@ struct ValueBackendDataSource {
      * @param range If not empty, then the data source shall return only a selection of the
      *              (nonscalar) data.
      *              Set `UA_STATUSCODE_BADINDEXRANGEINVALID` in `value` if this does not apply
-     * @param includeSourceTimestamp Set the source timestamp of `value` if `true`
+     * @param timestamp Set the source timestamp of `value` if `true`
+     * @return StatusCode
      */
-    std::function<
-        UA_StatusCode(DataValue& value, const NumericRange& range, bool includeSourceTimestamp)>
-        read;
+    std::function<StatusCode(DataValue& value, const NumericRange& range, bool timestamp)> read;
 
     /**
      * Callback to write the value into a data source.
@@ -72,8 +71,9 @@ struct ValueBackendDataSource {
      * @param value The DataValue that has been written by the writer
      * @param range If not empty, then only this selection of (non-scalar) data should be written
      *              into the data source
+     * @return StatusCode
      */
-    std::function<UA_StatusCode(const DataValue& value, const NumericRange& range)> write;
+    std::function<StatusCode(const DataValue& value, const NumericRange& range)> write;
 };
 
 }  // namespace opcua

--- a/include/open62541pp/types/Builtin.h
+++ b/include/open62541pp/types/Builtin.h
@@ -73,6 +73,22 @@ private:
     UA_StatusCode code_{};
 };
 
+constexpr bool operator==(StatusCode lhs, UA_StatusCode rhs) noexcept {
+    return lhs.get() == rhs;
+}
+
+constexpr bool operator==(UA_StatusCode lhs, StatusCode rhs) noexcept {
+    return lhs == rhs.get();
+}
+
+constexpr bool operator!=(StatusCode lhs, UA_StatusCode rhs) noexcept {
+    return !(lhs == rhs);
+}
+
+constexpr bool operator!=(UA_StatusCode lhs, StatusCode rhs) noexcept {
+    return !(lhs == rhs);
+}
+
 /**
  * UA_String wrapper class.
  * @ingroup TypeWrapper

--- a/include/open62541pp/types/Composed.h
+++ b/include/open62541pp/types/Composed.h
@@ -406,7 +406,7 @@ class BrowseResult : public TypeWrapper<UA_BrowseResult, UA_TYPES_BROWSERESULT> 
 public:
     using TypeWrapperBase::TypeWrapperBase;
 
-    UAPP_COMPOSED_GETTER(UA_StatusCode, getStatusCode, statusCode)
+    UAPP_COMPOSED_GETTER(StatusCode, getStatusCode, statusCode)
     UAPP_COMPOSED_GETTER_WRAPPER(ByteString, getContinuationPoint, continuationPoint)
     UAPP_COMPOSED_GETTER_ARRAY(ReferenceDescription, getReferences, references, referencesSize)
 };
@@ -481,7 +481,7 @@ class BrowsePathResult : public TypeWrapper<UA_BrowsePathResult, UA_TYPES_BROWSE
 public:
     using TypeWrapperBase::TypeWrapperBase;
 
-    UAPP_COMPOSED_GETTER(UA_StatusCode, getStatusCode, statusCode)
+    UAPP_COMPOSED_GETTER(StatusCode, getStatusCode, statusCode)
     UAPP_COMPOSED_GETTER_ARRAY(BrowsePathTarget, getTargets, targets, targetsSize)
 };
 

--- a/include/open62541pp/types/DataValue.h
+++ b/include/open62541pp/types/DataValue.h
@@ -6,6 +6,7 @@
 
 #include "open62541pp/TypeWrapper.h"
 #include "open62541pp/open62541.h"
+#include "open62541pp/types/Builtin.h"
 #include "open62541pp/types/DateTime.h"
 #include "open62541pp/types/Variant.h"
 
@@ -27,7 +28,7 @@ public:
         std::optional<DateTime> serverTimestamp,  // NOLINT
         std::optional<uint16_t> sourcePicoseconds,
         std::optional<uint16_t> serverPicoseconds,
-        std::optional<UA_StatusCode> statusCode
+        std::optional<StatusCode> statusCode
     );
 
     /// Create Variant from scalar value.
@@ -65,7 +66,7 @@ public:
     /// Get picoseconds interval added to the server timestamp.
     uint16_t getServerPicoseconds() const noexcept;
     /// Get status code.
-    UA_StatusCode getStatusCode() const noexcept;
+    StatusCode getStatusCode() const noexcept;
 
     /// Set value (copy).
     void setValue(const Variant& value);
@@ -80,7 +81,7 @@ public:
     /// Set picoseconds interval added to the server timestamp.
     void setServerPicoseconds(uint16_t serverPicoseconds);
     /// Set status code.
-    void setStatusCode(UA_StatusCode statusCode);
+    void setStatusCode(StatusCode statusCode);
 };
 
 /* --------------------------------------- Implementation --------------------------------------- */

--- a/src/types/DataValue.cpp
+++ b/src/types/DataValue.cpp
@@ -9,7 +9,7 @@ static UA_DataValue fromOptionals(
     const std::optional<DateTime>& serverTimestamp,
     const std::optional<uint16_t>& sourcePicoseconds,
     const std::optional<uint16_t>& serverPicoseconds,
-    const std::optional<UA_StatusCode>& statusCode
+    const std::optional<StatusCode>& statusCode
 ) {
     return {
         {},
@@ -17,7 +17,7 @@ static UA_DataValue fromOptionals(
         serverTimestamp.value_or(DateTime{}),
         sourcePicoseconds.value_or(uint16_t{}),
         serverPicoseconds.value_or(uint16_t{}),
-        statusCode.value_or(UA_StatusCode{}),
+        statusCode.value_or(StatusCode{}),
         false,
         sourceTimestamp.has_value(),
         serverTimestamp.has_value(),
@@ -33,7 +33,7 @@ DataValue::DataValue(
     std::optional<DateTime> serverTimestamp,  // NOLINT
     std::optional<uint16_t> sourcePicoseconds,
     std::optional<uint16_t> serverPicoseconds,
-    std::optional<UA_StatusCode> statusCode
+    std::optional<StatusCode> statusCode
 )
     : DataValue(fromOptionals(
           sourceTimestamp, serverTimestamp, sourcePicoseconds, serverPicoseconds, statusCode
@@ -89,7 +89,7 @@ uint16_t DataValue::getServerPicoseconds() const noexcept {
     return handle()->serverPicoseconds;
 }
 
-uint32_t DataValue::getStatusCode() const noexcept {
+StatusCode DataValue::getStatusCode() const noexcept {
     return handle()->status;
 }
 
@@ -123,7 +123,7 @@ void DataValue::setServerPicoseconds(uint16_t serverPicoseconds) {
     handle()->hasServerPicoseconds = true;
 }
 
-void DataValue::setStatusCode(UA_StatusCode statusCode) {
+void DataValue::setStatusCode(StatusCode statusCode) {
     handle()->status = statusCode;
     handle()->hasStatus = true;
 }

--- a/tests/Server.cpp
+++ b/tests/Server.cpp
@@ -208,7 +208,7 @@ TEST_CASE("DataSource with exception in callback") {
 
     SUBCASE("BadStatus exception") {
         ValueBackendDataSource dataSource;
-        dataSource.read = [&](DataValue&, const NumericRange&, bool) -> UA_StatusCode {
+        dataSource.read = [&](DataValue&, const NumericRange&, bool) -> StatusCode {
             throw BadStatus(UA_STATUSCODE_BADUNEXPECTEDERROR);
         };
         server.setVariableNodeValueBackend(id, dataSource);
@@ -218,7 +218,7 @@ TEST_CASE("DataSource with exception in callback") {
 
     SUBCASE("Other exception types") {
         ValueBackendDataSource dataSource;
-        dataSource.read = [&](DataValue&, const NumericRange&, bool) -> UA_StatusCode {
+        dataSource.read = [&](DataValue&, const NumericRange&, bool) -> StatusCode {
             throw std::runtime_error("test");
         };
         server.setVariableNodeValueBackend(id, dataSource);

--- a/tests/Services.cpp
+++ b/tests/Services.cpp
@@ -367,7 +367,7 @@ TEST_CASE("View service set (server & client)") {
             const BrowseDescription bd(id, BrowseDirection::Both);
             const auto result = services::browse(serverOrClient, bd);
 
-            CHECK(result.getStatusCode() == UA_STATUSCODE_GOOD);
+            CHECK(result.getStatusCode().isGood());
             CHECK(result.getContinuationPoint().empty());
 
             const auto refs = result.getReferences();
@@ -390,7 +390,7 @@ TEST_CASE("View service set (server & client)") {
             // restrict browse result to max 1 reference, more with browseNext
             auto resultBrowse = services::browse(serverOrClient, bd, 1);
 
-            CHECK(resultBrowse.getStatusCode() == UA_STATUSCODE_GOOD);
+            CHECK(resultBrowse.getStatusCode().isGood());
             CHECK(resultBrowse.getContinuationPoint().empty() == false);
             CHECK(resultBrowse.getReferences().size() == 1);
 
@@ -398,7 +398,7 @@ TEST_CASE("View service set (server & client)") {
             resultBrowse = services::browseNext(
                 serverOrClient, false, resultBrowse.getContinuationPoint()
             );
-            CHECK(resultBrowse.getStatusCode() == UA_STATUSCODE_GOOD);
+            CHECK(resultBrowse.getStatusCode().isGood());
             CHECK(resultBrowse.getContinuationPoint().empty() == false);
             CHECK(resultBrowse.getReferences().size() == 1);
 
@@ -406,7 +406,7 @@ TEST_CASE("View service set (server & client)") {
             resultBrowse = services::browseNext(
                 serverOrClient, true, resultBrowse.getContinuationPoint()
             );
-            CHECK(resultBrowse.getStatusCode() == UA_STATUSCODE_GOOD);
+            CHECK(resultBrowse.getStatusCode().isGood());
             CHECK(resultBrowse.getContinuationPoint().empty());
             CHECK(resultBrowse.getReferences().size() == 0);
         }
@@ -421,7 +421,7 @@ TEST_CASE("View service set (server & client)") {
             const auto result = services::browseSimplifiedBrowsePath(
                 serverOrClient, {0, UA_NS0ID_ROOTFOLDER}, {{0, "Objects"}, {1, "Variable"}}
             );
-            CHECK(result.getStatusCode() == UA_STATUSCODE_GOOD);
+            CHECK(result.getStatusCode().isGood());
             const auto targets = result.getTargets();
             CHECK(targets.size() == 1);
             // https://reference.opcfoundation.org/Core/Part4/v105/docs/5.8

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -19,6 +19,41 @@
 
 using namespace opcua;
 
+TEST_CASE("StatusCode") {
+    SUBCASE("Good") {
+        StatusCode code;
+        CHECK(code == UA_STATUSCODE_GOOD);
+        CHECK(code.get() == UA_STATUSCODE_GOOD);
+        CHECK(code.name() == "Good");
+        CHECK(code.isGood());
+        CHECK(!code.isUncertain());
+        CHECK(!code.isBad());
+        CHECK_NOTHROW(code.throwIfBad());
+    }
+
+    SUBCASE("Uncertain") {
+        StatusCode code(UA_STATUSCODE_UNCERTAIN);
+        CHECK(code == UA_STATUSCODE_UNCERTAIN);
+        CHECK(code.get() == UA_STATUSCODE_UNCERTAIN);
+        CHECK(code.name() == "Uncertain");
+        CHECK(!code.isGood());
+        CHECK(code.isUncertain());
+        CHECK(!code.isBad());
+        CHECK_NOTHROW(code.throwIfBad());
+    }
+
+    SUBCASE("Bad") {
+        StatusCode code(UA_STATUSCODE_BADTIMEOUT);
+        CHECK(code == UA_STATUSCODE_BADTIMEOUT);
+        CHECK(code.get() == UA_STATUSCODE_BADTIMEOUT);
+        CHECK(code.name() == "BadTimeout");
+        CHECK(!code.isGood());
+        CHECK(!code.isUncertain());
+        CHECK(code.isBad());
+        CHECK_THROWS_AS_MESSAGE(code.throwIfBad(), BadStatus, "BadTimeout");
+    }
+}
+
 TEST_CASE_TEMPLATE("StringLike", T, String, ByteString, XmlElement) {
     SUBCASE("Construct with const char*") {
         T wrapper("test");

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -31,6 +31,7 @@ TEST_CASE("StatusCode") {
         CHECK_NOTHROW(code.throwIfBad());
     }
 
+#ifdef UA_STATUSCODE_UNCERTAIN
     SUBCASE("Uncertain") {
         StatusCode code(UA_STATUSCODE_UNCERTAIN);
         CHECK(code == UA_STATUSCODE_UNCERTAIN);
@@ -41,6 +42,7 @@ TEST_CASE("StatusCode") {
         CHECK(!code.isBad());
         CHECK_NOTHROW(code.throwIfBad());
     }
+#endif
 
     SUBCASE("Bad") {
         StatusCode code(UA_STATUSCODE_BADTIMEOUT);


### PR DESCRIPTION
Simple wrapper of `UA_StatusCode`.

`StatusCode` can be used interchangeably with `UA_StatusCode` due to implicit conversions (without any overhead) but provides some methods to simplify the handling with status codes.

Methods:
- `StatusCode::name`
- `StatusCode::isGood`
- `StatusCode::isUncertain`
- `StatusCode::isBad`
- `StatusCode::throwIfBad`