### PR TITLE
refactor: store Server/Client instance in Node as reference

### DIFF
--- a/include/open62541pp/Node.h
+++ b/include/open62541pp/Node.h
@@ -36,8 +36,8 @@ class Node {
 public:
     /// Create a Node object.
     /// @exception BadStatus (BadNodeIdUnknown) If `checkExists` enabled and `id` not found
-    Node(ServerOrClient connection, NodeId id, bool checkExists = true)
-        : connection_(std::move(connection)),
+    Node(ServerOrClient& connection, NodeId id, bool checkExists = true)
+        : connection_(connection),
           nodeId_(std::move(id)) {
         if (checkExists) {
             services::readNodeId(connection_, nodeId_);
@@ -505,7 +505,7 @@ public:
     }
 
 private:
-    ServerOrClient connection_;
+    ServerOrClient& connection_;
     NodeId nodeId_;
 };
 

--- a/tests/Node.cpp
+++ b/tests/Node.cpp
@@ -35,6 +35,10 @@ TEST_CASE("Node") {
             CHECK_THROWS(Node(serverOrClient, NodeId(0, "DoesNotExist"), true));
         }
 
+        SUBCASE("getConnection") {
+            CHECK(rootNode.getConnection() == serverOrClient);
+        }
+
         SUBCASE("Node class of default nodes") {
             CHECK(serverOrClient.getRootNode().readNodeClass() == NodeClass::Object);
             CHECK(serverOrClient.getObjectsNode().readNodeClass() == NodeClass::Object);


### PR DESCRIPTION
**Goal**: Reduce the memory size of Node. Node has two members: a `NodeId` (24 byte) and a `Server`/`Client` instance (> 16 byte). `Server`/`Client`s only member is a `shared_ptr`. Depending on the the implementation, the memory overhead of a `shared_ptr` compared to a plain reference in > 8 byte.

The only downside is, that the lifetime of the server or client won't be extended by a node instance.

@duca, we have been talking about this and (after some thinking), I totally agree. Thanks for your patience :)