### PR TITLE
refactor!: remove type/typeIndex template parameters

### DIFF
--- a/include/open62541pp/DataTypeBuilder.h
+++ b/include/open62541pp/DataTypeBuilder.h
@@ -15,17 +15,6 @@ namespace opcua {
 
 namespace detail {
 
-template <typename T>
-constexpr const UA_DataType& guessDataType() {
-    using ValueType = typename detail::UnqualifiedT<T>;
-    static_assert(
-        TypeConverter<ValueType>::ValidTypes::size() == 1,
-        "Ambiguous data type, please specify data type manually"
-    );
-    constexpr auto typeIndex = TypeConverter<ValueType>::ValidTypes::toArray().at(0);
-    return detail::getUaDataType(typeIndex);
-}
-
 template <auto memberPtr>
 constexpr const UA_DataType& guessMemberDataType() {
     return guessDataType<detail::MemberTypeT<decltype(memberPtr)>>();

--- a/include/open62541pp/Node.h
+++ b/include/open62541pp/Node.h
@@ -7,7 +7,6 @@
 
 #include "open62541pp/Common.h"
 #include "open62541pp/Config.h"
-#include "open62541pp/TypeConverter.h"  // guessType
 #include "open62541pp/services/Attribute.h"
 #include "open62541pp/services/Method.h"
 #include "open62541pp/services/NodeManagement.h"
@@ -420,37 +419,37 @@ public:
 
     /// Write scalar to variable node.
     /// @return Current node instance to chain multiple methods (fluent interface)
-    template <typename T, Type type = detail::guessType<T>()>
+    template <typename T>
     Node& writeScalar(const T& value) {
         // NOLINTNEXTLINE, variant isn't modified, try to avoid copy
-        const auto variant = Variant::fromScalar<T, type>(const_cast<T&>(value));
+        const auto variant = Variant::fromScalar<T>(const_cast<T&>(value));
         writeValue(variant);
         return *this;
     }
 
     /// Write array (raw) to variable node.
     /// @return Current node instance to chain multiple methods (fluent interface)
-    template <typename T, Type type = detail::guessType<T>()>
+    template <typename T>
     Node& writeArray(const T* array, size_t size) {
         // NOLINTNEXTLINE, variant isn't modified, try to avoid copy
-        const auto variant = Variant::fromArray<T, type>(const_cast<T*>(array), size);
+        const auto variant = Variant::fromArray<T>(const_cast<T*>(array), size);
         writeValue(variant);
         return *this;
     }
 
     /// Write array (std::vector) to variable node.
     /// @return Current node instance to chain multiple methods (fluent interface)
-    template <typename T, Type type = detail::guessType<T>()>
+    template <typename T>
     Node& writeArray(const std::vector<T>& array) {
-        writeArray<T, type>(array.data(), array.size());
+        writeArray<T>(array.data(), array.size());
         return *this;
     }
 
     /// Write range of elements as array to variable node.
     /// @return Current node instance to chain multiple methods (fluent interface)
-    template <typename InputIt, Type type = detail::guessTypeFromIterator<InputIt>()>
+    template <typename InputIt>
     Node& writeArray(InputIt first, InputIt last) {
-        const auto variant = Variant::fromArray<InputIt, type>(first, last);
+        const auto variant = Variant::fromArray<InputIt>(first, last);
         writeValue(variant);
         return *this;
     }

--- a/include/open62541pp/TypeConverter.h
+++ b/include/open62541pp/TypeConverter.h
@@ -60,16 +60,6 @@ struct TypeConverter {
 namespace detail {
 
 template <typename T>
-constexpr bool isValidTypeCombination(TypeIndex typeIndex) {
-    return TypeConverter<T>::ValidTypes::contains(typeIndex);
-}
-
-template <typename T>
-constexpr bool isValidTypeCombination(Type type) {
-    return TypeConverter<T>::ValidTypes::contains(type);
-}
-
-template <typename T>
 constexpr bool isValidTypeCombination(const UA_DataType* dataType) {
     for (auto typeIndex : TypeConverter<T>::ValidTypes::toArray()) {
         // compare pointer
@@ -84,45 +74,21 @@ constexpr bool isValidTypeCombination(const UA_DataType* dataType) {
     return false;
 }
 
-template <typename T, auto typeOrTypeIndex>
-constexpr void assertTypeCombination() {
-    static_assert(
-        isValidTypeCombination<T>(typeOrTypeIndex), "Invalid template type / type index combination"
-    );
-}
-
 template <typename T>
-constexpr TypeIndex guessTypeIndex() {
+constexpr const UA_DataType& guessDataType() {
     using ValueType = typename detail::UnqualifiedT<T>;
     static_assert(
         TypeConverter<ValueType>::ValidTypes::size() == 1,
-        "Ambiguous template type, please specify type index (UA_TYPES_*) manually"
+        "Ambiguous data type, please specify data type manually"
     );
-    return TypeConverter<ValueType>::ValidTypes::toArray().at(0);
-}
-
-template <typename T>
-constexpr Type guessType() {
-    using ValueType = typename detail::UnqualifiedT<T>;
-    static_assert(
-        TypeConverter<ValueType>::ValidTypes::size() == 1,
-        "Ambiguous template type, please specify type enum (opcua::Type) manually"
-    );
-    constexpr auto typeIndexGuess = TypeConverter<ValueType>::ValidTypes::toArray().at(0);
-    static_assert(typeIndexGuess < builtinTypesCount, "T doesn't seem to be a builtin type");
-    return static_cast<Type>(typeIndexGuess);
+    constexpr auto typeIndex = TypeConverter<ValueType>::ValidTypes::toArray().at(0);
+    return detail::getUaDataType(typeIndex);
 }
 
 template <typename It>
-constexpr TypeIndex guessTypeIndexFromIterator() {
+constexpr const UA_DataType& guessDataTypeFromIterator() {
     using ValueType = typename std::iterator_traits<It>::value_type;
-    return guessTypeIndex<ValueType>();
-}
-
-template <typename It>
-constexpr Type guessTypeFromIterator() {
-    using ValueType = typename std::iterator_traits<It>::value_type;
-    return guessType<ValueType>();
+    return guessDataType<ValueType>();
 }
 
 /* ------------------------------------- Converter functions ------------------------------------ */
@@ -137,8 +103,9 @@ template <typename T, typename NativeType = typename TypeConverter<T>::NativeTyp
 
 /// Convert and copy from native type.
 /// @warning Type erased version, use with caution.
-template <typename T, typename NativeType = typename TypeConverter<T>::NativeType>
+template <typename T>
 [[nodiscard]] T fromNative(void* value, [[maybe_unused]] const UA_DataType& dataType) {
+    using NativeType = typename TypeConverter<T>::NativeType;
     assert(isValidTypeCombination<T>(&dataType));  // NOLINT
     return fromNative<T>(static_cast<NativeType*>(value));
 }
@@ -159,19 +126,20 @@ template <typename T, typename NativeType = typename TypeConverter<T>::NativeTyp
 
 /// Create and convert vector from native array.
 /// @warning Type erased version, use with caution.
-template <typename T, typename NativeType = typename TypeConverter<T>::NativeType>
+template <typename T>
 [[nodiscard]] std::vector<T> fromNativeArray(
     void* array, size_t size, [[maybe_unused]] const UA_DataType& dataType
 ) {
+    using NativeType = typename TypeConverter<T>::NativeType;
     assert(isValidTypeCombination<T>(&dataType));  // NOLINT
     return fromNativeArray<T>(static_cast<NativeType*>(array), size);
 }
 
 /// Allocate native type.
-template <typename TNative, TypeIndex typeIndex = guessTypeIndex<TNative>()>
-[[nodiscard]] TNative* allocNative() {
-    assertTypeCombination<TNative, typeIndex>();
-    auto* result = static_cast<TNative*>(UA_new(&getUaDataType<typeIndex>()));
+template <typename TNative>
+[[nodiscard]] TNative* allocNative(const UA_DataType& dataType) {
+    assert(isValidTypeCombination<TNative>(&dataType));  // NOLINT
+    auto* result = static_cast<TNative*>(UA_new(&dataType));
     if (result == nullptr) {
         throw std::bad_alloc();
     }
@@ -179,20 +147,19 @@ template <typename TNative, TypeIndex typeIndex = guessTypeIndex<TNative>()>
 }
 
 /// Allocate and copy to native type.
-template <typename T, TypeIndex typeIndex = guessTypeIndex<T>()>
+template <typename T>
 [[nodiscard]] auto* toNativeAlloc(const T& value) {
-    assertTypeCombination<T, typeIndex>();
     using NativeType = typename TypeConverter<T>::NativeType;
-    auto* result = allocNative<NativeType, typeIndex>();
+    auto* result = allocNative<NativeType>(guessDataType<T>());
     TypeConverter<T>::toNative(value, *result);
     return result;
 }
 
 /// Allocate native array
-template <typename TNative, TypeIndex typeIndex = guessTypeIndex<TNative>()>
-[[nodiscard]] auto* allocNativeArray(size_t size) {
-    assertTypeCombination<TNative, typeIndex>();
-    auto* result = static_cast<TNative*>(UA_Array_new(size, &getUaDataType<typeIndex>()));
+template <typename TNative>
+[[nodiscard]] auto* allocNativeArray(size_t size, const UA_DataType& dataType) {
+    assert(isValidTypeCombination<TNative>(&dataType));  // NOLINT
+    auto* result = static_cast<TNative*>(UA_Array_new(size, &dataType));
     if (result == nullptr) {
         throw std::bad_alloc();
     }
@@ -200,13 +167,12 @@ template <typename TNative, TypeIndex typeIndex = guessTypeIndex<TNative>()>
 }
 
 /// Allocate and copy iterator range to native array.
-template <typename InputIt, TypeIndex typeIndex = guessTypeIndexFromIterator<InputIt>()>
+template <typename InputIt>
 [[nodiscard]] auto* toNativeArrayAlloc(InputIt first, InputIt last) {
     using ValueType = typename std::iterator_traits<InputIt>::value_type;
     using NativeType = typename TypeConverter<ValueType>::NativeType;
-    assertTypeCombination<ValueType, typeIndex>();
     const size_t size = std::distance(first, last);
-    auto* result = allocNativeArray<NativeType, typeIndex>(size);
+    auto* result = allocNativeArray<NativeType>(size, guessDataTypeFromIterator<InputIt>());
     for (size_t i = 0; i < size; ++i) {
         TypeConverter<ValueType>::toNative(*first++, result[i]);  // NOLINT
     }
@@ -214,9 +180,9 @@ template <typename InputIt, TypeIndex typeIndex = guessTypeIndexFromIterator<Inp
 }
 
 /// Allocate and copy to native array.
-template <typename T, TypeIndex typeIndex = guessTypeIndex<T>()>
+template <typename T>
 [[nodiscard]] auto* toNativeArrayAlloc(const T* array, size_t size) {
-    return toNativeArrayAlloc<const T*, typeIndex>(array, array + size);  // NOLINT
+    return toNativeArrayAlloc(array, array + size);  // NOLINT
 }
 
 }  // namespace detail

--- a/include/open62541pp/types/Composed.h
+++ b/include/open62541pp/types/Composed.h
@@ -147,9 +147,7 @@ public:
     auto& set##suffix(const std::vector<Type>& memberArray) {                                      \
         handle()->specifiedAttributes |= flag;                                                     \
         UA_Array_delete(                                                                           \
-            handle()->memberArray,                                                                 \
-            handle()->memberSize,                                                                  \
-            &detail::getUaDataType(detail::guessTypeIndex<Type>())                                 \
+            handle()->memberArray, handle()->memberSize, &detail::guessDataType<Type>()            \
         );                                                                                         \
         handle()->memberArray = detail::toNativeArrayAlloc(                                        \
             memberArray.begin(), memberArray.end()                                                 \

--- a/include/open62541pp/types/ExtensionObject.h
+++ b/include/open62541pp/types/ExtensionObject.h
@@ -45,7 +45,7 @@ public:
     /// Create an ExtensionObject from a decoded object (assign).
     /// The data will *not* be deleted when the ExtensionObject is destructed.
     /// @param data Decoded data
-    template <typename T, TypeIndex typeIndex = detail::guessTypeIndex<T>()>
+    template <typename T>
     static ExtensionObject fromDecoded(T& data) noexcept;
 
     /// Create an ExtensionObject from a decoded object (assign).
@@ -58,7 +58,7 @@ public:
     /// Create an ExtensionObject from a decoded object (copy).
     /// Set the "decoded" data to a copy of the given object.
     /// @param data Decoded data
-    template <typename T, TypeIndex typeIndex = detail::guessTypeIndex<T>()>
+    template <typename T>
     static ExtensionObject fromDecodedCopy(const T& data);
 
     /// Create an ExtensionObject from a decoded object (copy).
@@ -87,11 +87,11 @@ public:
 
     /// Get pointer to the encoded data with given template type. Returns `nullptr` if the
     /// ExtensionObject is either encoded or the decoded data not of type `T`.
-    template <typename T, TypeIndex typeIndex = detail::guessTypeIndex<T>()>
+    template <typename T>
     T* getDecodedData() noexcept;
 
     /// @copydoc getDecodedData
-    template <typename T, TypeIndex typeIndex = detail::guessTypeIndex<T>()>
+    template <typename T>
     const T* getDecodedData() const noexcept;
 
     /// Get pointer to the encoded data. Returns `nullptr` if the ExtensionObject is encoded.
@@ -115,36 +115,33 @@ constexpr bool isAssignableToExtensionObject() {
 
 /* --------------------------------------- Implementation --------------------------------------- */
 
-template <typename T, TypeIndex typeIndex>
+template <typename T>
 T* ExtensionObject::getDecodedData() noexcept {
-    detail::assertTypeCombination<T, typeIndex>();
-    if (getDecodedDataType() == &detail::getUaDataType(typeIndex)) {
+    if (getDecodedDataType() == &detail::guessDataType<T>()) {
         return static_cast<T*>(getDecodedData());
     }
     return nullptr;
 }
 
-template <typename T, TypeIndex typeIndex>
+template <typename T>
 ExtensionObject ExtensionObject::fromDecoded(T& data) noexcept {
-    detail::assertTypeCombination<T, typeIndex>();
     static_assert(
         detail::isAssignableToExtensionObject<T>(),
         "Template type must be convertible to native type to assign data without copy"
     );
     if constexpr (detail::IsTypeWrapper<T>::value) {
-        return fromDecoded(data.handle(), detail::getUaDataType<typeIndex>());
+        return fromDecoded(data.handle(), detail::guessDataType<T>());
     } else {
-        return fromDecoded(&data, detail::getUaDataType<typeIndex>());
+        return fromDecoded(&data, detail::guessDataType<T>());
     }
 }
 
-template <typename T, TypeIndex typeIndex>
+template <typename T>
 ExtensionObject ExtensionObject::fromDecodedCopy(const T& data) {
-    detail::assertTypeCombination<T, typeIndex>();
     if constexpr (detail::IsTypeWrapper<T>::value) {
-        return fromDecodedCopy(data.handle(), detail::getUaDataType<typeIndex>());
+        return fromDecodedCopy(data.handle(), detail::guessDataType<T>());
     } else {
-        return fromDecodedCopy(&data, detail::getUaDataType<typeIndex>());
+        return fromDecodedCopy(&data, detail::guessDataType<T>());
     }
 }
 

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -29,7 +29,7 @@ public:
     using TypeWrapperBase::TypeWrapperBase;  // inherit constructors
 
     /// Create Variant from scalar value (no copy if assignable without conversion).
-    template <typename T, Type type = detail::guessType<T>()>
+    template <typename T>
     [[nodiscard]] static Variant fromScalar(T& value);
 
     /// Create Variant from scalar value with custom data type.
@@ -37,7 +37,7 @@ public:
     [[nodiscard]] static Variant fromScalar(T& value, const UA_DataType& dataType);
 
     /// Create Variant from scalar value (copy).
-    template <typename T, Type type = detail::guessType<T>()>
+    template <typename T>
     [[nodiscard]] static Variant fromScalar(const T& value);
 
     /// Create Variant from scalar value with custom data type (copy).
@@ -45,7 +45,7 @@ public:
     [[nodiscard]] static Variant fromScalar(const T& value, const UA_DataType& dataType);
 
     /// Create Variant from array (no copy if assignable without conversion).
-    template <typename T, Type type = detail::guessType<T>()>
+    template <typename T>
     [[nodiscard]] static Variant fromArray(T* array, size_t size);
 
     /// Create Variant from array with custom data type.
@@ -53,13 +53,13 @@ public:
     [[nodiscard]] static Variant fromArray(T* array, size_t size, const UA_DataType& dataType);
 
     /// Create Variant from std::vector (no copy if assignable without conversion).
-    template <typename T, Type type = detail::guessType<T>()>
+    template <typename T>
     [[nodiscard]] static Variant fromArray(std::vector<T>& array) {
-        return fromArray<T, type>(array.data(), array.size());
+        return fromArray<T>(array.data(), array.size());
     }
 
     /// Create Variant from array (copy).
-    template <typename T, Type type = detail::guessType<T>()>
+    template <typename T>
     [[nodiscard]] static Variant fromArray(const T* array, size_t size);
 
     /// Create Variant from array with custom data type (copy).
@@ -69,9 +69,9 @@ public:
     );
 
     /// Create Variant from std::vector (copy).
-    template <typename T, Type type = detail::guessType<T>()>
+    template <typename T>
     [[nodiscard]] static Variant fromArray(const std::vector<T>& array) {
-        return fromArray<T, type>(array.data(), array.size());
+        return fromArray<T>(array.data(), array.size());
     }
 
     /// Create Variant from std::vector with custom data type (copy).
@@ -83,7 +83,7 @@ public:
     }
 
     /// Create Variant from range of elements (copy).
-    template <typename InputIt, Type type = detail::guessTypeFromIterator<InputIt>()>
+    template <typename InputIt>
     [[nodiscard]] static Variant fromArray(InputIt first, InputIt last);
 
     /// Check if variant is empty.
@@ -161,7 +161,7 @@ public:
     std::vector<T> getArrayCopy() const;
 
     /// Assign scalar value to variant.
-    template <typename T, Type type = detail::guessType<T>()>
+    template <typename T>
     void setScalar(T& value) noexcept;
 
     /// Assign scalar value to variant with custom data type.
@@ -169,7 +169,7 @@ public:
     void setScalar(T& value, const UA_DataType& dataType) noexcept;
 
     /// Copy scalar value to variant.
-    template <typename T, Type type = detail::guessType<T>()>
+    template <typename T>
     void setScalarCopy(const T& value);
 
     /// Copy scalar value to variant with custom data type.
@@ -177,7 +177,7 @@ public:
     void setScalarCopy(const T& value, const UA_DataType& dataType);
 
     /// Assign array (raw) to variant.
-    template <typename T, Type type = detail::guessType<T>()>
+    template <typename T>
     void setArray(T* array, size_t size) noexcept;
 
     /// Assign array (raw) to variant with custom data type.
@@ -185,9 +185,9 @@ public:
     void setArray(T* array, size_t size, const UA_DataType& dataType) noexcept;
 
     /// Assign array (std::vector) to variant.
-    template <typename T, Type type = detail::guessType<T>()>
+    template <typename T>
     void setArray(std::vector<T>& array) noexcept {
-        setArray<T, type>(array.data(), array.size());
+        setArray<T>(array.data(), array.size());
     }
 
     /// Assign array (std::vector) to variant with custom data type.
@@ -197,7 +197,7 @@ public:
     }
 
     /// Copy array (raw) to variant.
-    template <typename T, Type type = detail::guessType<T>()>
+    template <typename T>
     void setArrayCopy(const T* array, size_t size);
 
     /// Copy array (raw) to variant with custom data type.
@@ -205,9 +205,9 @@ public:
     void setArrayCopy(const T* array, size_t size, const UA_DataType& dataType);
 
     /// Copy array (std::vector) to variant.
-    template <typename T, Type type = detail::guessType<T>()>
+    template <typename T>
     void setArrayCopy(const std::vector<T>& array) {
-        setArrayCopy<T, type>(array.data(), array.size());
+        setArrayCopy<T>(array.data(), array.size());
     }
 
     /// Copy array (std::vector) to variant with custom data type.
@@ -217,7 +217,7 @@ public:
     }
 
     /// Copy range of elements as array to variant.
-    template <typename InputIt, Type type = detail::guessTypeFromIterator<InputIt>()>
+    template <typename InputIt>
     void setArrayCopy(InputIt first, InputIt last);
 
 private:
@@ -274,13 +274,13 @@ private:
 
 /* --------------------------------------- Implementation --------------------------------------- */
 
-template <typename T, Type type>
+template <typename T>
 Variant Variant::fromScalar(T& value) {
     Variant variant;
     if constexpr (isConvertibleToNative<T>()) {
-        variant.setScalar<T, type>(value);
+        variant.setScalar<T>(value);
     } else {
-        variant.setScalarCopy<T, type>(value);
+        variant.setScalarCopy<T>(value);
     }
     return variant;
 }
@@ -292,10 +292,10 @@ Variant Variant::fromScalar(T& value, const UA_DataType& dataType) {
     return variant;
 }
 
-template <typename T, Type type>
+template <typename T>
 Variant Variant::fromScalar(const T& value) {
     Variant variant;
-    variant.setScalarCopy<T, type>(value);
+    variant.setScalarCopy<T>(value);
     return variant;
 }
 
@@ -306,13 +306,13 @@ Variant Variant::fromScalar(const T& value, const UA_DataType& dataType) {
     return variant;
 }
 
-template <typename T, Type type>
+template <typename T>
 Variant Variant::fromArray(T* array, size_t size) {
     Variant variant;
     if constexpr (isConvertibleToNative<T>()) {
-        variant.setArray<T, type>(array, size);  // NOLINT, variant isn't modified
+        variant.setArray<T>(array, size);  // NOLINT, variant isn't modified
     } else {
-        variant.setArrayCopy<T, type>(array, size);
+        variant.setArrayCopy<T>(array, size);
     }
     return variant;
 }
@@ -324,10 +324,10 @@ Variant Variant::fromArray(T* array, size_t size, const UA_DataType& dataType) {
     return variant;
 }
 
-template <typename T, Type type>
+template <typename T>
 Variant Variant::fromArray(const T* array, size_t size) {
     Variant variant;
-    variant.setArrayCopy<T, type>(array, size);
+    variant.setArrayCopy<T>(array, size);
     return variant;
 }
 
@@ -338,10 +338,10 @@ Variant Variant::fromArray(const T* array, size_t size, const UA_DataType& dataT
     return variant;
 }
 
-template <typename InputIt, Type type>
+template <typename InputIt>
 Variant Variant::fromArray(InputIt first, InputIt last) {
     Variant variant;
-    variant.setArrayCopy<InputIt, type>(first, last);
+    variant.setArrayCopy<InputIt>(first, last);
     return variant;
 }
 
@@ -387,12 +387,11 @@ std::vector<T> Variant::getArrayCopy() const {
     return detail::fromNativeArray<T>(handle()->data, handle()->arrayLength, *getDataType());
 }
 
-template <typename T, Type type>
+template <typename T>
 void Variant::setScalar(T& value) noexcept {
     assertNoVariant<T>();
     assertSetNoCopy<T>();
-    detail::assertTypeCombination<T, type>();
-    setScalarImpl(&value, detail::getUaDataType<type>());
+    setScalarImpl(&value, detail::guessDataType<T>());
 }
 
 template <typename T>
@@ -402,13 +401,12 @@ void Variant::setScalar(T& value, const UA_DataType& dataType) noexcept {
     setScalarImpl(&value, dataType);
 }
 
-template <typename T, Type type>
+template <typename T>
 void Variant::setScalarCopy(const T& value) {
     assertNoVariant<T>();
-    detail::assertTypeCombination<T, type>();
     setScalarImpl(
-        detail::toNativeAlloc<T, static_cast<TypeIndex>(type)>(value),
-        detail::getUaDataType<type>(),
+        detail::toNativeAlloc(value),
+        detail::guessDataType<T>(),
         true  // move ownership
     );
 }
@@ -420,12 +418,11 @@ void Variant::setScalarCopy(const T& value, const UA_DataType& dataType) {
     setScalarCopyImpl(&value, dataType);
 }
 
-template <typename T, Type type>
+template <typename T>
 void Variant::setArray(T* array, size_t size) noexcept {
     assertNoVariant<T>();
     assertSetNoCopy<T>();
-    detail::assertTypeCombination<T, type>();
-    setArrayImpl(array, size, detail::getUaDataType<type>());
+    setArrayImpl(array, size, detail::guessDataType<T>());
 }
 
 template <typename T>
@@ -435,14 +432,13 @@ void Variant::setArray(T* array, size_t size, const UA_DataType& dataType) noexc
     setArrayImpl(array, size, dataType);
 }
 
-template <typename T, Type type>
+template <typename T>
 void Variant::setArrayCopy(const T* array, size_t size) {
     assertNoVariant<T>();
-    detail::assertTypeCombination<T, type>();
     if constexpr (detail::isBuiltinType<T>()) {
-        setArrayCopyImpl(array, size, detail::getUaDataType<type>());
+        setArrayCopyImpl(array, size, detail::guessDataType<T>());
     } else {
-        setArrayCopy<const T*, type>(array, array + size);  // NOLINT
+        setArrayCopy<const T*>(array, array + size);  // NOLINT
     }
 }
 
@@ -453,15 +449,14 @@ void Variant::setArrayCopy(const T* array, size_t size, const UA_DataType& dataT
     setArrayCopyImpl(array, size, dataType);
 }
 
-template <typename InputIt, Type type>
+template <typename InputIt>
 void Variant::setArrayCopy(InputIt first, InputIt last) {
     using ValueType = typename std::iterator_traits<InputIt>::value_type;
     assertNoVariant<ValueType>();
-    detail::assertTypeCombination<ValueType, type>();
     setArrayImpl(
-        detail::toNativeArrayAlloc<InputIt, static_cast<TypeIndex>(type)>(first, last),
+        detail::toNativeArrayAlloc(first, last),
         std::distance(first, last),
-        detail::getUaDataType<type>(),
+        detail::guessDataTypeFromIterator<InputIt>(),
         true  // move ownership
     );
 }

--- a/tests/TypeConverter.cpp
+++ b/tests/TypeConverter.cpp
@@ -6,12 +6,9 @@ using namespace opcua;
 
 TEST_CASE("TypeConverter checks") {
     SUBCASE("isValidTypeCombination") {
-        CHECK(detail::isValidTypeCombination<bool>(Type::Boolean));
-        CHECK_FALSE(detail::isValidTypeCombination<bool>(Type::Float));
-
         using ReadRequest = TypeWrapper<UA_ReadRequest, UA_TYPES_READREQUEST>;
-        CHECK(detail::isValidTypeCombination<ReadRequest>(UA_TYPES_READREQUEST));
-        CHECK_FALSE(detail::isValidTypeCombination<ReadRequest>(UA_TYPES_WRITEREQUEST));
+        CHECK(detail::isValidTypeCombination<ReadRequest>(&UA_TYPES[UA_TYPES_READREQUEST]));
+        CHECK_FALSE(detail::isValidTypeCombination<ReadRequest>(&UA_TYPES[UA_TYPES_WRITEREQUEST]));
     }
 }
 

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -444,7 +444,7 @@ TEST_CASE("Variant") {
         }
         SUBCASE("Copy if not assignable (const or conversion check failed)") {
             std::string value{"test"};
-            const auto var = Variant::fromScalar<std::string, Type::String>(value);
+            const auto var = Variant::fromScalar<std::string>(value);
             CHECK(var.isScalar());
             CHECK(var->data != &value);
         }
@@ -592,7 +592,7 @@ TEST_CASE("Variant") {
             detail::allocUaString("item3"),
         };
 
-        var.setArray<UA_String, Type::String>(array.data(), array.size());
+        var.setArray<UA_String>(array.data(), array.size(), UA_TYPES[UA_TYPES_STRING]);
         CHECK(var.getArrayLength() == array.size());
         CHECK(var.getArray() == array.data());
 
@@ -614,7 +614,7 @@ TEST_CASE("Variant") {
     SUBCASE("Set/get array of strings") {
         Variant var;
         std::vector<std::string> value{"a", "b", "c"};
-        var.setArrayCopy<std::string, Type::String>(value);
+        var.setArrayCopy<std::string>(value);
 
         CHECK(var.isArray());
         CHECK(var.isType(Type::String));


### PR DESCRIPTION
Remove `type`/`typeIndex` template parameters with `guessType<T>()`/`guessTypeIndex<T>()` as default.

Instead, the data type is inferred in the function body.
Ambiguous types have to be specified in overloaded methods with UA_DataType parameter, e.g.:

```cpp
opcua::Variant var;
UA_String str;  // ambiguous type due to UA_ByteString and UA_XmlElement type aliases

// previously
var.setScalar<UA_String, opcua.:Types::String>(str);

// now
var.setScalar(str, UA_TYPES[UA_TYPES_STRING]);
```