### PR TITLE
feat: deduce data type from template type

### DIFF
--- a/examples/server.cpp
+++ b/examples/server.cpp
@@ -17,7 +17,7 @@ int main() {
         {1, "the.answer"},
         "the answer",
         opcua::VariableAttributes{}
-            .setDataType(opcua::DataTypeId::Int32)
+            .setDataType<int>()
             .setDisplayName({"en-US", "the answer"})
             .setDescription({"en-US", "the answer"})
     );

--- a/examples/server_datasource.cpp
+++ b/examples/server_datasource.cpp
@@ -14,7 +14,7 @@ int main() {
         "Counter",
         opcua::VariableAttributes{}
             .setAccessLevel(UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE)
-            .setDataType(opcua::DataTypeId::Int32)
+            .setDataType<int>()
             .setValueScalar(counter)
     );
 

--- a/examples/server_valuecallback.cpp
+++ b/examples/server_valuecallback.cpp
@@ -9,9 +9,9 @@ int main() {
     auto currentTimeNode =
         server.getObjectsNode()
             .addVariable(currentTimeId, "CurrentTime")
-            .writeDataType(opcua::Type::DateTime)
             .writeDisplayName({"en-US", "Current time"})
             .writeDescription({"en-US", "Current time"})
+            .writeDataType<opcua::DateTime>()
             .writeScalar(opcua::DateTime::now());
 
     // set variable value callback to write current time before every read operation

--- a/include/open62541pp/Node.h
+++ b/include/open62541pp/Node.h
@@ -454,14 +454,7 @@ public:
         return *this;
     }
 
-    /// @copydoc services::writeDataType(T&, const NodeId&, Type)
-    /// @return Current node instance to chain multiple methods (fluent interface)
-    Node& writeDataType(Type type) {
-        services::writeDataType(connection_, nodeId_, type);
-        return *this;
-    }
-
-    /// @copydoc services::writeDataType(T&, const NodeId&, const NodeId&)
+    /// @copydoc services::writeDataType
     /// @return Current node instance to chain multiple methods (fluent interface)
     Node& writeDataType(const NodeId& typeId) {
         services::writeDataType(connection_, nodeId_, typeId);

--- a/include/open62541pp/Node.h
+++ b/include/open62541pp/Node.h
@@ -461,6 +461,14 @@ public:
         return *this;
     }
 
+    /// @overload
+    /// Deduce the `typeId` from the template type.
+    /// @return Current node instance to chain multiple methods (fluent interface)
+    template <typename T>
+    Node& writeDataType() {
+        return writeDataType(asWrapper<NodeId>(detail::guessDataType<T>().typeId));
+    }
+
     /// @copydoc services::writeValueRank
     /// @return Current node instance to chain multiple methods (fluent interface)
     Node& writeValueRank(ValueRank valueRank) {

--- a/include/open62541pp/services/Attribute.h
+++ b/include/open62541pp/services/Attribute.h
@@ -375,17 +375,6 @@ inline void writeValue(T& serverOrClient, const NodeId& id, const Variant& value
  * @ingroup Attribute
  */
 template <typename T>
-inline void writeDataType(T& serverOrClient, const NodeId& id, Type type) {
-    const auto typeId = ::opcua::detail::getUaDataType(type).typeId;
-    writeAttribute(serverOrClient, id, AttributeId::DataType, DataValue::fromScalar(typeId));
-}
-
-/**
- * Write the `DataType` attribute of a variable (type) node by node id.
- * @copydetails readDataType
- * @ingroup Attribute
- */
-template <typename T>
 inline void writeDataType(T& serverOrClient, const NodeId& id, const NodeId& typeId) {
     writeAttribute(serverOrClient, id, AttributeId::DataType, DataValue::fromScalar(typeId));
 }

--- a/include/open62541pp/types/Composed.h
+++ b/include/open62541pp/types/Composed.h
@@ -221,6 +221,14 @@ public:
     }
 
     UAPP_NODEATTR_WRAPPER(NodeId, DataType, dataType, UA_NODEATTRIBUTESMASK_DATATYPE)
+
+    /// @overload
+    /// Deduce the `dataType` from the template type.
+    template <typename T>
+    auto& setDataType() {
+        return setDataType(asWrapper<NodeId>(detail::guessDataType<T>().typeId));
+    }
+
     UAPP_NODEATTR_CAST(ValueRank, ValueRank, valueRank, UA_NODEATTRIBUTESMASK_VALUERANK)
     UAPP_NODEATTR_ARRAY(
         uint32_t,
@@ -300,6 +308,14 @@ public:
     }
 
     UAPP_NODEATTR_WRAPPER(NodeId, DataType, dataType, UA_NODEATTRIBUTESMASK_DATATYPE)
+
+    /// @overload
+    /// Deduce the `dataType` from the template type.
+    template <typename T>
+    auto& setDataType() {
+        return setDataType(asWrapper<NodeId>(detail::guessDataType<T>().typeId));
+    }
+
     UAPP_NODEATTR_CAST(ValueRank, ValueRank, valueRank, UA_NODEATTRIBUTESMASK_VALUERANK)
     UAPP_NODEATTR_ARRAY(
         uint32_t,

--- a/include/open62541pp/types/NodeId.h
+++ b/include/open62541pp/types/NodeId.h
@@ -7,6 +7,7 @@
 
 #include "open62541pp/NodeIds.h"
 #include "open62541pp/TypeWrapper.h"
+#include "open62541pp/detail/helper.h"
 #include "open62541pp/open62541.h"
 #include "open62541pp/types/Builtin.h"
 
@@ -46,6 +47,10 @@ public:
 
     /// Create NodeId with ByteString identifier.
     NodeId(uint16_t namespaceIndex, const ByteString& identifier);
+
+    /// Create NodeId from Type (type id).
+    NodeId(Type type) noexcept  // NOLINT, implicit wanted
+        : NodeId(detail::getUaDataType(type).typeId) {}
 
     /// Create NodeId from DataTypeId.
     NodeId(DataTypeId id) noexcept  // NOLINT, implicit wanted

--- a/tests/Node.cpp
+++ b/tests/Node.cpp
@@ -124,55 +124,67 @@ TEST_CASE("Node") {
             CHECK_EQ(objNode.browseParent(), rootNode);
         }
 
-        SUBCASE("Try read/write with node classes other than Variable") {
-            CHECK_THROWS(rootNode.template readScalar<int>());
-            CHECK_THROWS(rootNode.template writeScalar<int>({}));
+        SUBCASE("Read/write attributes") {
+            CHECK_EQ(
+                varNode.writeDataType(DataTypeId::Boolean).readDataType(),
+                NodeId(DataTypeId::Boolean)
+            );
+            CHECK_EQ(
+                varNode.template writeDataType<double>().readDataType(), NodeId(DataTypeId::Double)
+            );
         }
 
-        SUBCASE("Read/write scalar") {
-            CHECK_NOTHROW(varNode.writeDataType(Type::Float));
-
-            // write with wrong data type
-            CHECK_THROWS(varNode.template writeScalar<bool>({}));
-            CHECK_THROWS(varNode.template writeScalar<int>({}));
-
-            // write with correct data type
-            float value = 11.11f;
-            CHECK_NOTHROW(varNode.writeScalar(value));
-            CHECK(varNode.template readScalar<float>() == value);
-        }
-
-        SUBCASE("Read/write string") {
-            CHECK_NOTHROW(varNode.writeDataType(Type::String));
-
-            String str("test");
-            CHECK_NOTHROW(varNode.writeScalar(str));
-            CHECK(varNode.template readScalar<std::string>() == "test");
-        }
-
-        SUBCASE("Read/write array") {
-            CHECK_NOTHROW(varNode.writeDataType(Type::Double));
-
-            // write with wrong data type
-            CHECK_THROWS(varNode.template writeArray<int>({}));
-            CHECK_THROWS(varNode.template writeArray<float>({}));
-
-            // write with correct data type
-            std::vector<double> array{11.11, 22.22, 33.33};
-
-            SUBCASE("Write as std::vector") {
-                CHECK_NOTHROW(varNode.writeArray(array));
-                CHECK(varNode.template readArray<double>() == array);
+        SUBCASE("Read/write value") {
+            SUBCASE("Try read/write node classes other than Variable") {
+                CHECK_THROWS(rootNode.template readScalar<int>());
+                CHECK_THROWS(rootNode.template writeScalar<int>({}));
             }
 
-            SUBCASE("Write as raw array") {
-                CHECK_NOTHROW(varNode.writeArray(array.data(), array.size()));
-                CHECK(varNode.template readArray<double>() == array);
+            SUBCASE("Scalar") {
+                CHECK_NOTHROW(varNode.writeDataType(Type::Float));
+
+                // write with wrong data type
+                CHECK_THROWS(varNode.template writeScalar<bool>({}));
+                CHECK_THROWS(varNode.template writeScalar<int>({}));
+
+                // write with correct data type
+                float value = 11.11f;
+                CHECK_NOTHROW(varNode.writeScalar(value));
+                CHECK(varNode.template readScalar<float>() == value);
             }
 
-            SUBCASE("Write as iterator pair") {
-                CHECK_NOTHROW(varNode.writeArray(array.begin(), array.end()));
-                CHECK(varNode.template readArray<double>() == array);
+            SUBCASE("String") {
+                CHECK_NOTHROW(varNode.writeDataType(Type::String));
+
+                String str("test");
+                CHECK_NOTHROW(varNode.writeScalar(str));
+                CHECK(varNode.template readScalar<std::string>() == "test");
+            }
+
+            SUBCASE("Array") {
+                CHECK_NOTHROW(varNode.writeDataType(Type::Double));
+
+                // write with wrong data type
+                CHECK_THROWS(varNode.template writeArray<int>({}));
+                CHECK_THROWS(varNode.template writeArray<float>({}));
+
+                // write with correct data type
+                std::vector<double> array{11.11, 22.22, 33.33};
+
+                SUBCASE("Write as std::vector") {
+                    CHECK_NOTHROW(varNode.writeArray(array));
+                    CHECK(varNode.template readArray<double>() == array);
+                }
+
+                SUBCASE("Write as raw array") {
+                    CHECK_NOTHROW(varNode.writeArray(array.data(), array.size()));
+                    CHECK(varNode.template readArray<double>() == array);
+                }
+
+                SUBCASE("Write as iterator pair") {
+                    CHECK_NOTHROW(varNode.writeArray(array.begin(), array.end()));
+                    CHECK(varNode.template readArray<double>() == array);
+                }
             }
         }
 

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -858,6 +858,11 @@ TEST_CASE("NodeAttributes fluent interface") {
     CHECK(attr.getWriteMask() == 0xFFFFFFFF);
 }
 
+TEST_CASE_TEMPLATE("NodeAttributes setDataType", T, VariableAttributes, VariableTypeAttributes) {
+    CHECK(T{}.setDataType(DataTypeId::Boolean).getDataType() == NodeId(DataTypeId::Boolean));
+    CHECK(T{}.template setDataType<bool>().getDataType() == NodeId(DataTypeId::Boolean));
+}
+
 TEST_CASE("BrowseDescription") {
     BrowseDescription bd(NodeId(1, 1000), BrowseDirection::Forward);
     CHECK(bd.getNodeId() == NodeId(1, 1000));

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -262,6 +262,7 @@ TEST_CASE("DateTime") {
 
 TEST_CASE("NodeId") {
     SUBCASE("Create from ids") {
+        CHECK(NodeId(Type::Boolean) == NodeId(0, UA_NS0ID_BOOLEAN));
         CHECK(NodeId(DataTypeId::Boolean) == NodeId(0, UA_NS0ID_BOOLEAN));
         CHECK(NodeId(ReferenceTypeId::References) == NodeId(0, UA_NS0ID_REFERENCES));
         CHECK(NodeId(ObjectTypeId::BaseObjectType) == NodeId(0, UA_NS0ID_BASEOBJECTTYPE));


### PR DESCRIPTION
As discussed in #59.
Provide overloads to deduce the data type id of `Variable` or `VariableType` nodes from the template type `T`:
- `Node::writeDataType<T>()`
- `VariableAttributes::setDataType<T>()`
- `VariableTypeAttributes::setDataType<T>()`