### PR TITLE
feat!: ArrayView

### DIFF
--- a/examples/typeconversion.cpp
+++ b/examples/typeconversion.cpp
@@ -49,7 +49,8 @@ int main() {
 
     // Write array of bytes to variant
     std::array<std::byte, 3> array{};
-    variant.setArrayCopy(array.data(), array.size());  // use raw array and size
+    variant.setArrayCopy(array);  // use array container
+    variant.setArrayCopy(opcua::ArrayView{array.data(), array.size()});  // use raw array and size
     variant.setArrayCopy(array.begin(), array.end());  // use iterator pair
 
     std::cout << "Array size: " << variant.getArrayLength() << std::endl;

--- a/include/open62541pp/ArrayView.h
+++ b/include/open62541pp/ArrayView.h
@@ -178,6 +178,18 @@ ArrayView(Container&) -> ArrayView<typename Container::value_type>;
 template <typename Container>
 ArrayView(const Container&) -> ArrayView<const typename Container::value_type>;
 
+/* ------------------------------------------- Helper ------------------------------------------- */
+
+namespace detail {
+
+template <typename>
+struct IsArrayView : std::false_type {};
+
+template <typename T>
+struct IsArrayView<ArrayView<T>> : std::true_type {};
+
+}  // namespace detail
+
 /* ----------------------------------------- Comparison ----------------------------------------- */
 
 namespace detail {

--- a/include/open62541pp/ArrayView.h
+++ b/include/open62541pp/ArrayView.h
@@ -1,0 +1,180 @@
+#pragma once
+
+#include <cstdint>
+#include <initializer_list>
+#include <iterator>
+#include <limits>
+#include <type_traits>
+#include <utility>  // swap
+
+namespace opcua {
+
+/**
+ * View to a contiguous sequence of objects, similar to `std::span` in C++20.
+ *
+ * ArrayViews are used to return open62541 arrays without copy and to use them with the standard
+ * library algorithms. The view just holds two members: the pointer to `T` and the size, so it's
+ * lightweight and trivially copyable.
+ *
+ * @tparam T Type of the array object, use `const T` for an immutable view
+ *
+ * @see https://en.cppreference.com/w/cpp/container/span
+ */
+template <typename T>
+class ArrayView {
+public:
+    // clang-format off
+    using element_type           = T;
+    using value_type             = std::remove_cv_t<T>;
+    using size_type              = size_t;
+    using difference_type        = std::ptrdiff_t;
+    using pointer                = T*;
+    using const_pointer          = const T*;
+    using reference              = T&;
+    using const_reference        = const T&;
+    using iterator               = pointer;
+    using const_iterator         = const_pointer;
+    using reverse_iterator       = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+    // clang-format on
+
+    constexpr ArrayView() noexcept = default;
+
+    constexpr ArrayView(element_type* data, size_t size) noexcept
+        : size_(size),
+          data_(data) {}
+
+    /**
+     * Implicit constructor from a container like `std::array` or `std::vector`.
+     */
+    template <typename Container>
+    constexpr ArrayView(Container& container) noexcept  // NOLINT
+        : ArrayView(container.data(), container.size()) {}
+
+    /**
+     * Implicit constructor from a container like `std::array` or `std::vector` (const).
+     */
+    template <typename Container>
+    constexpr ArrayView(const Container& container) noexcept  // NOLINT
+        : ArrayView(container.data(), container.size()) {}
+
+    /**
+     * Implicit constructor from an initializer list.
+     *
+     * Only safe to use if `std::initializer_list` itself outlives the ArrayView:
+     * @code{.cpp}
+     * void takeView(ArrayView<const int> values);
+     * // ok
+     * takeView({1, 2, 3});
+     * // not ok
+     * ArrayView<const int> values = {1, 2, 3};
+     * takeView(values);
+     * @endcode
+     */
+    constexpr ArrayView(std::initializer_list<value_type> values) noexcept  // NOLINT
+        : ArrayView(values.begin(), values.size()) {}
+
+    constexpr void swap(ArrayView& other) noexcept {
+        std::swap(data_, other.data_);
+        std::swap(size_, other.size_);
+    }
+
+    [[nodiscard]] constexpr size_t size() const noexcept {
+        return size_;
+    }
+
+    [[nodiscard]] constexpr bool empty() const noexcept {
+        return size() == 0;
+    }
+
+    [[nodiscard]] constexpr pointer data() const noexcept {
+        return data_;
+    }
+
+    [[nodiscard]] constexpr reference operator[](size_t index) const noexcept {
+        return data()[index];
+    }
+
+    [[nodiscard]] constexpr reference front() const noexcept {
+        return *data();
+    }
+
+    [[nodiscard]] constexpr reference back() const noexcept {
+        return *(data() + size() - 1);
+    }
+
+    [[nodiscard]] constexpr iterator begin() const noexcept {
+        return {data()};
+    }
+
+    [[nodiscard]] constexpr iterator end() const noexcept {
+        return {data() + size()};
+    }
+
+    [[nodiscard]] constexpr const_iterator cbegin() const noexcept {
+        return {data()};
+    }
+
+    [[nodiscard]] constexpr const_iterator cend() const noexcept {
+        return {data() + size()};
+    }
+
+    [[nodiscard]] constexpr reverse_iterator rbegin() const noexcept {
+        return reverse_iterator(end());
+    }
+
+    [[nodiscard]] constexpr reverse_iterator rend() const noexcept {
+        return reverse_iterator(begin());
+    }
+
+    [[nodiscard]] constexpr const_reverse_iterator crbegin() const noexcept {
+        return const_reverse_iterator(cend());
+    }
+
+    [[nodiscard]] constexpr const_reverse_iterator crend() const noexcept {
+        return const_reverse_iterator(cbegin());
+    }
+
+    /// Obtain a view over `count` elements of this ArrayView starting at offset `offset`.
+    [[nodiscard]] constexpr ArrayView subview(
+        size_t offset, size_t count = std::numeric_limits<std::size_t>::max()
+    ) const noexcept {
+        if (offset >= size()) {
+            return {};
+        }
+        if (count > size() - offset) {
+            count = size() - offset;
+        }
+        return {data() + offset, count};
+    }
+
+    /// Obtain a view over the first `count` elements of this ArrayView.
+    [[nodiscard]] constexpr ArrayView first(size_t count) const noexcept {
+        if (count >= size()) {
+            return *this;
+        }
+        return {data(), count};
+    }
+
+    /// Obtain a view over the last `count` elements of this ArrayView.
+    [[nodiscard]] constexpr ArrayView last(size_t count) const noexcept {
+        if (count >= size()) {
+            return *this;
+        }
+        return {data() + (size() - count), count};
+    }
+
+private:
+    size_t size_{0};
+    T* data_{nullptr};
+};
+
+/* -------------------------------------- Deduction guides -------------------------------------- */
+
+template <typename Container>
+ArrayView(Container&) -> ArrayView<typename Container::value_type>;
+
+template <typename Container>
+ArrayView(const Container&) -> ArrayView<const typename Container::value_type>;
+
+}  // namespace opcua

--- a/include/open62541pp/ArrayView.h
+++ b/include/open62541pp/ArrayView.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <initializer_list>
 #include <iterator>
@@ -176,5 +177,26 @@ ArrayView(Container&) -> ArrayView<typename Container::value_type>;
 
 template <typename Container>
 ArrayView(const Container&) -> ArrayView<const typename Container::value_type>;
+
+/* ----------------------------------------- Comparison ----------------------------------------- */
+
+namespace detail {
+
+template <typename T, typename U>
+using EnableIfEqualityComparable = typename std::enable_if_t<
+    std::is_invocable_v<std::equal_to<>, const T&, const U&> &&
+    std::is_invocable_v<std::not_equal_to<>, const T&, const U&>>;
+
+}  // namespace detail
+
+template <typename T, typename U, typename = detail::EnableIfEqualityComparable<T, U>>
+constexpr bool operator==(ArrayView<T> lhs, ArrayView<U> rhs) {
+    return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end());
+}
+
+template <typename T, typename U, typename = detail::EnableIfEqualityComparable<T, U>>
+constexpr bool operator!=(ArrayView<T> lhs, ArrayView<U> rhs) {
+    return !(lhs == rhs);
+}
 
 }  // namespace opcua

--- a/include/open62541pp/DataType.h
+++ b/include/open62541pp/DataType.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <vector>
 
+#include "open62541pp/ArrayView.h"
 #include "open62541pp/Common.h"
 #include "open62541pp/open62541.h"
 
@@ -67,9 +68,8 @@ public:
     bool getOverlayable() const noexcept;
     void setOverlayable(bool overlayable) noexcept;
 
-    uint8_t getMembersSize() const noexcept;
-    std::vector<DataTypeMember> getMembers() const;
-    void setMembers(const std::vector<DataTypeMember>& members);
+    ArrayView<const DataTypeMember> getMembers() const noexcept;
+    void setMembers(ArrayView<const DataTypeMember> members);
 
     constexpr UA_DataType* handle() noexcept {
         return &data_;

--- a/include/open62541pp/Node.h
+++ b/include/open62541pp/Node.h
@@ -431,26 +431,23 @@ public:
     /// Write array (raw) to variable node.
     /// @return Current node instance to chain multiple methods (fluent interface)
     template <typename T>
-    Node& writeArray(const T* array, size_t size) {
-        // NOLINTNEXTLINE, variant isn't modified, try to avoid copy
-        const auto variant = Variant::fromArray<T>(ArrayView{const_cast<T*>(array), size});
+    Node& writeArray(ArrayView<T> array) {
+        const auto variant = Variant::fromArray(array);
         writeValue(variant);
         return *this;
     }
 
-    /// Write array (std::vector) to variable node.
-    /// @return Current node instance to chain multiple methods (fluent interface)
-    template <typename T>
-    Node& writeArray(const std::vector<T>& array) {
-        writeArray<T>(array.data(), array.size());
-        return *this;
+    /// @overload
+    template <typename ArrayLike>
+    Node& writeArray(ArrayLike&& array) {
+        return writeArray(ArrayView{std::forward<ArrayLike>(array)});
     }
 
     /// Write range of elements as array to variable node.
     /// @return Current node instance to chain multiple methods (fluent interface)
     template <typename InputIt>
     Node& writeArray(InputIt first, InputIt last) {
-        const auto variant = Variant::fromArray<InputIt>(first, last);
+        const auto variant = Variant::fromArray(first, last);
         writeValue(variant);
         return *this;
     }

--- a/include/open62541pp/Node.h
+++ b/include/open62541pp/Node.h
@@ -5,6 +5,7 @@
 #include <utility>  // move
 #include <vector>
 
+#include "open62541pp/ArrayView.h"
 #include "open62541pp/Common.h"
 #include "open62541pp/Config.h"
 #include "open62541pp/services/Attribute.h"
@@ -432,7 +433,7 @@ public:
     template <typename T>
     Node& writeArray(const T* array, size_t size) {
         // NOLINTNEXTLINE, variant isn't modified, try to avoid copy
-        const auto variant = Variant::fromArray<T>(const_cast<T*>(array), size);
+        const auto variant = Variant::fromArray<T>(ArrayView{const_cast<T*>(array), size});
         writeValue(variant);
         return *this;
     }

--- a/include/open62541pp/open62541pp.h
+++ b/include/open62541pp/open62541pp.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "open62541pp/ArrayView.h"
 #include "open62541pp/Auth.h"
 #include "open62541pp/Client.h"
 #include "open62541pp/Common.h"

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -191,7 +191,7 @@ public:
         setArray(ArrayView{std::forward<ArrayLike>(array)}, dataType);
     }
 
-    /// Copy array (to variant.
+    /// Copy array to variant.
     template <typename T>
     void setArrayCopy(ArrayView<T> array);
 

--- a/src/DataType.cpp
+++ b/src/DataType.cpp
@@ -166,21 +166,11 @@ void DataType::setOverlayable(bool overlayable) noexcept {
     handle()->overlayable = overlayable;
 }
 
-uint8_t DataType::getMembersSize() const noexcept {
-    return handle()->membersSize;
+ArrayView<const DataTypeMember> DataType::getMembers() const noexcept {
+    return {handle()->members, handle()->membersSize};
 }
 
-std::vector<DataTypeMember> DataType::getMembers() const {
-    std::vector<DataTypeMember> result(handle()->membersSize);
-    std::copy(
-        handle()->members,
-        handle()->members + handle()->membersSize,  // NOLINT
-        result.begin()
-    );
-    return result;
-}
-
-void DataType::setMembers(const std::vector<DataTypeMember>& members) {
+void DataType::setMembers(ArrayView<const DataTypeMember> members) {
     assert(members.size() < (1U << 8U));
     clearMembers(handle());
     copyMembers(members.data(), members.size(), handle());

--- a/tests/ArrayView.cpp
+++ b/tests/ArrayView.cpp
@@ -1,0 +1,106 @@
+#include <array>
+#include <vector>
+
+#include <doctest/doctest.h>
+
+#include "open62541pp/ArrayView.h"
+
+using namespace opcua;
+
+TEST_CASE("ArrayView") {
+    SUBCASE("Empty") {
+        constexpr ArrayView<int> view;
+        CHECK(view.size() == 0);
+        CHECK(view.empty());
+        CHECK(view.data() == nullptr);
+    }
+
+    SUBCASE("From array") {
+        constexpr std::array<int, 3> arr{0, 1, 2};
+        ArrayView view(arr);
+        CHECK(view.size() == arr.size());
+        CHECK(!view.empty());
+        CHECK(view.data() == arr.data());
+    }
+
+    SUBCASE("From vector") {
+        std::vector<int> vec{0, 1, 2};
+        ArrayView view(vec);
+        CHECK(view.size() == vec.size());
+        CHECK(!view.empty());
+        CHECK(view.data() == vec.data());
+    }
+
+    SUBCASE("Element access") {
+        std::vector<int> vec{0, 1, 2};
+        ArrayView view(vec);
+
+        CHECK(view.front() == 0);
+        CHECK(view.back() == 2);
+        CHECK(view.data() == vec.data());
+
+        CHECK(view[2] == 2);
+        view[2] = 20;
+        CHECK(view[2] == 20);
+        CHECK(vec[2] == 20);
+    }
+
+    SUBCASE("Iterators") {
+        const std::vector<int> vec{0, 1, 2};
+        ArrayView view(vec);
+
+        CHECK(std::vector<int>(view.begin(), view.end()) == std::vector{0, 1, 2});
+        CHECK(std::vector<int>(view.cbegin(), view.cend()) == std::vector{0, 1, 2});
+        CHECK(std::vector<int>(view.rbegin(), view.rend()) == std::vector{2, 1, 0});
+        CHECK(std::vector<int>(view.crbegin(), view.crend()) == std::vector{2, 1, 0});
+    }
+
+    SUBCASE("Subviews") {
+        const std::vector<int> vec{0, 1, 2};
+        ArrayView view(vec);
+
+        CHECK(view.subview(0).size() == 3);
+        CHECK(view.subview(0).data() == view.begin());
+
+        CHECK(view.subview(1).size() == 2);
+        CHECK(view.subview(1).data() == view.begin() + 1);
+
+        CHECK(view.subview(1, 1).size() == 1);
+        CHECK(view.subview(1, 1).data() == view.begin() + 1);
+
+        CHECK(view.subview(1, 10).size() == 2);
+        CHECK(view.subview(1, 10).data() == view.begin() + 1);
+
+        CHECK(view.subview(10).size() == 0);
+        CHECK(view.subview(10).data() == nullptr);
+
+        CHECK(view.first(2).size() == 2);
+        CHECK(view.first(2).data() == view.begin());
+
+        CHECK(view.first(10).size() == 3);
+        CHECK(view.first(10).data() == view.begin());
+
+        CHECK(view.last(1).size() == 1);
+        CHECK(view.last(1).data() == view.begin() + 2);
+
+        CHECK(view.last(10).size() == 3);
+        CHECK(view.last(10).data() == view.begin());
+    }
+}
+
+TEST_CASE("ArrayView as generic function parameter") {
+    auto getSize = [](ArrayView<const int> view) { return view.size(); };
+
+    const std::vector vec{0, 1, 2};
+    const std::array arr{0, 1, 2};
+
+    CHECK(getSize({vec.data(), vec.size()}) == 3);
+
+    CHECK(getSize(vec) == 3);
+    CHECK(getSize(arr) == 3);
+
+    CHECK(getSize(std::vector{0, 1, 2}) == 3);
+    CHECK(getSize(std::array{0, 1, 2}) == 3);
+
+    CHECK(getSize({0, 1, 2}) == 3);
+}

--- a/tests/ArrayView.cpp
+++ b/tests/ArrayView.cpp
@@ -104,3 +104,29 @@ TEST_CASE("ArrayView as generic function parameter") {
 
     CHECK(getSize({0, 1, 2}) == 3);
 }
+
+TEST_CASE("ArrayView comparison") {
+    std::vector<int> vec1{0, 1, 2};
+    std::vector<int> vec2{3, 4, 5};
+    std::vector<double> vec1Double{0, 1, 2};
+    std::vector<double> vec2Double{3, 4, 5};
+
+    CHECK(ArrayView(vec1) == ArrayView(vec1));
+    CHECK(ArrayView(vec2) == ArrayView(vec2));
+    CHECK(ArrayView(vec1) != ArrayView(vec2));
+    CHECK(ArrayView(vec2) != ArrayView(vec1));
+
+    SUBCASE("Mix non-const/const") {
+        CHECK(ArrayView<int>(vec1) == ArrayView<const int>(vec1));
+        CHECK(ArrayView<const int>(vec1) == ArrayView<int>(vec1));
+        CHECK(ArrayView<int>(vec1) != ArrayView<const int>(vec2));
+        CHECK(ArrayView<const int>(vec2) != ArrayView<int>(vec1));
+    }
+
+    SUBCASE("Mix comparable types") {
+        CHECK(ArrayView(vec1) == ArrayView(vec1Double));
+        CHECK(ArrayView(vec1Double) == ArrayView(vec1));
+        CHECK(ArrayView(vec1) != ArrayView(vec2Double));
+        CHECK(ArrayView(vec2Double) != ArrayView(vec1));
+    }
+}

--- a/tests/ArrayView.cpp
+++ b/tests/ArrayView.cpp
@@ -31,6 +31,14 @@ TEST_CASE("ArrayView") {
         CHECK(view.data() == vec.data());
     }
 
+    SUBCASE("From initializer list") {
+        std::initializer_list<int> values{0, 1, 2};
+        ArrayView<const int> view(values);
+        CHECK(view.size() == values.size());
+        CHECK(!view.empty());
+        CHECK(view.data() == values.begin());
+    }
+
     SUBCASE("Element access") {
         std::vector<int> vec{0, 1, 2};
         ArrayView view(vec);

--- a/tests/ArrayView.cpp
+++ b/tests/ArrayView.cpp
@@ -97,20 +97,38 @@ TEST_CASE("ArrayView") {
 }
 
 TEST_CASE("ArrayView as generic function parameter") {
-    auto getSize = [](ArrayView<const int> view) { return view.size(); };
+    SUBCASE("Const") {
+        auto getSize = [](ArrayView<const int> view) { return view.size(); };
 
-    const std::vector vec{0, 1, 2};
-    const std::array arr{0, 1, 2};
+        const std::vector vec{0, 1, 2};
+        const std::array arr{0, 1, 2};
 
-    CHECK(getSize({vec.data(), vec.size()}) == 3);
+        CHECK(getSize({vec.data(), vec.size()}) == 3);
 
-    CHECK(getSize(vec) == 3);
-    CHECK(getSize(arr) == 3);
+        CHECK(getSize(vec) == 3);
+        CHECK(getSize(arr) == 3);
 
-    CHECK(getSize(std::vector{0, 1, 2}) == 3);
-    CHECK(getSize(std::array{0, 1, 2}) == 3);
+        CHECK(getSize(std::vector{0, 1, 2}) == 3);
+        CHECK(getSize(std::array{0, 1, 2}) == 3);
+        CHECK(getSize({0, 1, 2}) == 3);
+    }
 
-    CHECK(getSize({0, 1, 2}) == 3);
+    SUBCASE("Non-const") {
+        auto getSize = [](ArrayView<int> view) { return view.size(); };
+
+        std::vector vec{0, 1, 2};
+        std::array arr{0, 1, 2};
+
+        CHECK(getSize({vec.data(), vec.size()}) == 3);
+
+        CHECK(getSize(vec) == 3);
+        CHECK(getSize(arr) == 3);
+
+        // rvalue references will fail
+        // CHECK(getSize(std::vector{0, 1, 2}) == 3);
+        // CHECK(getSize(std::array{0, 1, 2}) == 3);
+        // CHECK(getSize({0, 1, 2}) == 3);
+    }
 }
 
 TEST_CASE("ArrayView comparison") {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(${PROJECT_SOURCE_DIR}/3rdparty/doctest doctest EXCLUDE_FROM_ALL
 add_executable(
     open62541pp_tests
     main.cpp
+    ArrayView.cpp
     Client.cpp
     Crypto.cpp
     CustomDataTypes.cpp

--- a/tests/DataType.cpp
+++ b/tests/DataType.cpp
@@ -70,10 +70,10 @@ TEST_CASE("DataType") {
         CHECK(dt.getTypeKind() == UA_DATATYPEKIND_STRUCTURE);
         CHECK(dt.getPointerFree() == true);
         CHECK(dt.getOverlayable() == false);
-        CHECK(dt.getMembersSize() == 3);
-        CHECK(dt.getMembers().at(0) == pointMembers[0]);
-        CHECK(dt.getMembers().at(1) == pointMembers[1]);
-        CHECK(dt.getMembers().at(2) == pointMembers[2]);
+        CHECK(dt.getMembers().size() == 3);
+        CHECK(dt.getMembers()[0] == pointMembers[0]);
+        CHECK(dt.getMembers()[1] == pointMembers[1]);
+        CHECK(dt.getMembers()[2] == pointMembers[2]);
     }
 
     SUBCASE("Construct from type index") {
@@ -136,10 +136,9 @@ static void checkDataTypeEqual(const DataType& dt, const UA_DataType& expected) 
     CHECK(dt.getTypeKind() == expected.typeKind);
     CHECK(dt.getPointerFree() == static_cast<bool>(expected.pointerFree));
     CHECK(dt.getOverlayable() == static_cast<bool>(expected.overlayable));
-    CHECK(dt.getMembersSize() == expected.membersSize);
-    for (uint8_t i = 0; i < dt.getMembersSize(); ++i) {
+    for (uint8_t i = 0; i < dt.getMembers().size(); ++i) {
         CAPTURE(i);
-        auto m = dt.getMembers().at(i);
+        auto m = dt.getMembers()[i];
 #if UAPP_OPEN62541_VER_GE(1, 3)
         CHECK(m.memberType == expected.members[i].memberType);
 #else

--- a/tests/Node.cpp
+++ b/tests/Node.cpp
@@ -154,8 +154,8 @@ TEST_CASE("Node") {
             CHECK_NOTHROW(varNode.writeDataType(Type::Double));
 
             // write with wrong data type
-            CHECK_THROWS(varNode.template writeArray<int>({}));
-            CHECK_THROWS(varNode.template writeArray<float>({}));
+            CHECK_THROWS(varNode.template writeArray(std::vector<int>{}));
+            CHECK_THROWS(varNode.template writeArray(std::vector<float>{}));
 
             // write with correct data type
             std::vector<double> array{11.11, 22.22, 33.33};
@@ -166,7 +166,7 @@ TEST_CASE("Node") {
             }
 
             SUBCASE("Write as raw array") {
-                CHECK_NOTHROW(varNode.writeArray(array.data(), array.size()));
+                CHECK_NOTHROW(varNode.writeArray(ArrayView{array.data(), array.size()}));
                 CHECK(varNode.template readArray<double>() == array);
             }
 

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -459,15 +459,13 @@ TEST_CASE("Variant") {
     SUBCASE("Create from array") {
         SUBCASE("Assign if possible") {
             std::vector<double> vec{1.1, 2.2, 3.3};
-            const auto var = Variant::fromArray(vec.data(), vec.size());
+            const auto var = Variant::fromArray(vec);
             CHECK(var.isArray());
             CHECK(var->data == vec.data());
         }
         SUBCASE("Assign with custom data type") {
             std::vector<UA_WriteValue> vec{{}, {}};
-            const auto var = Variant::fromArray(
-                vec.data(), vec.size(), UA_TYPES[UA_TYPES_WRITEVALUE]
-            );
+            const auto var = Variant::fromArray(vec, UA_TYPES[UA_TYPES_WRITEVALUE]);
             CHECK(var.isArray());
             CHECK(var->data == vec.data());
         }
@@ -485,9 +483,7 @@ TEST_CASE("Variant") {
         }
         SUBCASE("Copy with custom data type") {
             const std::vector<UA_WriteValue> vec{{}, {}};
-            const auto var = Variant::fromArray(
-                vec.data(), vec.size(), UA_TYPES[UA_TYPES_WRITEVALUE]
-            );
+            const auto var = Variant::fromArray(vec, UA_TYPES[UA_TYPES_WRITEVALUE]);
             CHECK(var.isArray());
             CHECK(var->data != vec.data());
         }
@@ -592,7 +588,7 @@ TEST_CASE("Variant") {
             detail::allocUaString("item3"),
         };
 
-        var.setArray<UA_String>(array.data(), array.size(), UA_TYPES[UA_TYPES_STRING]);
+        var.setArray(ArrayView{array.data(), array.size()}, UA_TYPES[UA_TYPES_STRING]);
         CHECK(var.getArrayLength() == array.size());
         CHECK(var.getArray() == array.data());
 
@@ -614,7 +610,7 @@ TEST_CASE("Variant") {
     SUBCASE("Set/get array of strings") {
         Variant var;
         std::vector<std::string> value{"a", "b", "c"};
-        var.setArrayCopy<std::string>(value);
+        var.setArrayCopy(value);
 
         CHECK(var.isArray());
         CHECK(var.isType(Type::String));
@@ -655,7 +651,6 @@ TEST_CASE("Variant") {
         std::vector<CustomType> array(3);
 
         SUBCASE("Array") {
-            var.setArray(array.data(), array.size(), dt);
             var.setArray(array, dt);
             CHECK(var.isArray());
             CHECK(var.getDataType() == &dt);
@@ -665,7 +660,6 @@ TEST_CASE("Variant") {
         }
 
         SUBCASE("Array (copy)") {
-            var.setArrayCopy(array.data(), array.size(), dt);
             var.setArrayCopy(array, dt);
             CHECK(var.isArray());
             CHECK(var.getDataType() == &dt);

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -624,6 +624,11 @@ TEST_CASE("Variant") {
         CHECK(var.getArrayCopy<std::string>() == value);
     }
 
+    SUBCASE("Set array from initializer list") {
+        Variant var;
+        var.setArrayCopy<const int>({1, 2, 3});  // TODO: avoid manual template types
+    }
+
     SUBCASE("Set/get non-builtin data types") {
         using CustomType = UA_WriteValue;
         const auto& dt = UA_TYPES[UA_TYPES_WRITEVALUE];


### PR DESCRIPTION
View a contiguous sequence of objects, similar to `std::span` in C++20.

ArrayViews are used to return open62541 arrays without copy and to use them with the standard library algorithms. The view just holds two members: the pointer to `T` and the size, so it's lightweight and trivially copyable.