### PR TITLE
feat: `std::hash` specialization for `NodeId` and `ExpandedNodeId`

### DIFF
--- a/include/open62541pp/types/NodeId.h
+++ b/include/open62541pp/types/NodeId.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>  // hash
 #include <string>
 #include <string_view>
 #include <variant>
@@ -148,3 +149,19 @@ public:
 };
 
 }  // namespace opcua
+
+/* ---------------------------------- std::hash specializations --------------------------------- */
+
+template <>
+struct std::hash<opcua::NodeId> {
+    std::size_t operator()(const opcua::NodeId& id) const noexcept {
+        return id.hash();
+    }
+};
+
+template <>
+struct std::hash<opcua::ExpandedNodeId> {
+    std::size_t operator()(const opcua::ExpandedNodeId& id) const noexcept {
+        return id.hash();
+    }
+};

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -357,6 +357,11 @@ TEST_CASE("NodeId") {
         CHECK(NodeId(1, ByteString("test123")).toString() == "ns=1;b=dGVzdDEyMw==");
 #endif
     }
+
+    SUBCASE("std::hash specialization") {
+        const NodeId id(1, "Test123");
+        CHECK(std::hash<NodeId>{}(id) == id.hash());
+    }
 }
 
 TEST_CASE("ExpandedNodeId") {
@@ -391,6 +396,10 @@ TEST_CASE("ExpandedNodeId") {
             ExpandedNodeId({2, 10157}, "http://test.org/UA/Data/", 1).toString(),
             "svr=1;nsu=http://test.org/UA/Data/;ns=2;i=10157"
         );
+    }
+
+    SUBCASE("std::hash specialization") {
+        CHECK(std::hash<ExpandedNodeId>()(idLocal) == idLocal.hash());
     }
 }
 


### PR DESCRIPTION
Closes #87.