### PR TITLE
feat!: check if node id exists

### DIFF
--- a/include/open62541pp/Node.h
+++ b/include/open62541pp/Node.h
@@ -34,14 +34,9 @@ template <typename ServerOrClient>
 class Node {
 public:
     /// Create a Node object.
-    /// @exception BadStatus (BadNodeIdUnknown) If `checkExists` enabled and `id` not found
-    Node(ServerOrClient& connection, NodeId id, bool checkExists = true)
+    Node(ServerOrClient& connection, NodeId id)
         : connection_(connection),
-          nodeId_(std::move(id)) {
-        if (checkExists) {
-            services::readNodeId(connection_, nodeId_);
-        }
-    }
+          nodeId_(std::move(id)) {}
 
     /// Get the server/client instance.
     ServerOrClient& getConnection() noexcept {
@@ -66,7 +61,7 @@ public:
         const NodeId& referenceType = ReferenceTypeId::HasComponent
     ) {
         services::addFolder(connection_, nodeId_, id, browseName, attributes, referenceType);
-        return {connection_, id, false};
+        return {connection_, id};
     }
 
     /// @copydoc services::addObject
@@ -80,7 +75,7 @@ public:
         services::addObject(
             connection_, nodeId_, id, browseName, attributes, objectType, referenceType
         );
-        return {connection_, id, false};
+        return {connection_, id};
     }
 
     /// @copydoc services::addVariable
@@ -94,7 +89,7 @@ public:
         services::addVariable(
             connection_, nodeId_, id, browseName, attributes, variableType, referenceType
         );
-        return {connection_, id, false};
+        return {connection_, id};
     }
 
     /// @copydoc services::addProperty
@@ -102,7 +97,7 @@ public:
         const NodeId& id, std::string_view browseName, const VariableAttributes& attributes = {}
     ) {
         services::addProperty(connection_, nodeId_, id, browseName, attributes);
-        return {connection_, id, false};
+        return {connection_, id};
     }
 
 #ifdef UA_ENABLE_METHODCALLS
@@ -127,7 +122,7 @@ public:
             attributes,
             referenceType
         );
-        return {connection_, id, false};
+        return {connection_, id};
     }
 #endif
 
@@ -139,7 +134,7 @@ public:
         const NodeId& referenceType = ReferenceTypeId::HasSubtype
     ) {
         services::addObjectType(connection_, nodeId_, id, browseName, attributes, referenceType);
-        return {connection_, id, false};
+        return {connection_, id};
     }
 
     /// @copydoc services::addVariableType
@@ -153,7 +148,7 @@ public:
         services::addVariableType(
             connection_, nodeId_, id, browseName, attributes, variableType, referenceType
         );
-        return {connection_, id, false};
+        return {connection_, id};
     }
 
     /// @copydoc services::addReferenceType
@@ -164,7 +159,7 @@ public:
         const NodeId& referenceType = ReferenceTypeId::HasSubtype
     ) {
         services::addReferenceType(connection_, nodeId_, id, browseName, attributes, referenceType);
-        return {connection_, id, false};
+        return {connection_, id};
     }
 
     /// @copydoc services::addDataType
@@ -175,7 +170,7 @@ public:
         const NodeId& referenceType = ReferenceTypeId::HasSubtype
     ) {
         services::addDataType(connection_, nodeId_, id, browseName, attributes, referenceType);
-        return {connection_, id, false};
+        return {connection_, id};
     }
 
     /// @copydoc services::addView
@@ -186,7 +181,7 @@ public:
         const NodeId& referenceType = ReferenceTypeId::Organizes
     ) {
         services::addView(connection_, nodeId_, id, browseName, attributes, referenceType);
-        return {connection_, id, false};
+        return {connection_, id};
     }
 
     /// @copydoc services::addReference

--- a/include/open62541pp/Node.h
+++ b/include/open62541pp/Node.h
@@ -53,6 +53,11 @@ public:
         return nodeId_;
     }
 
+    /// Check if the Node exists in the most efficient manner.
+    /// If the instance is of type `Node<Server>`, the internal node store is searched.
+    /// If the instance is of type `Node<Client>`, an actual read request to the server is made.
+    bool exists() noexcept;
+
     /// @copydoc services::addFolder
     Node addFolder(
         const NodeId& id,

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -393,23 +393,23 @@ bool Client::isRunning() const noexcept {
 }
 
 Node<Client> Client::getNode(const NodeId& id) {
-    return {*this, id, true};
+    return {*this, id};
 }
 
 Node<Client> Client::getRootNode() {
-    return {*this, {0, UA_NS0ID_ROOTFOLDER}, false};
+    return {*this, {0, UA_NS0ID_ROOTFOLDER}};
 }
 
 Node<Client> Client::getObjectsNode() {
-    return {*this, {0, UA_NS0ID_OBJECTSFOLDER}, false};
+    return {*this, {0, UA_NS0ID_OBJECTSFOLDER}};
 }
 
 Node<Client> Client::getTypesNode() {
-    return {*this, {0, UA_NS0ID_TYPESFOLDER}, false};
+    return {*this, {0, UA_NS0ID_TYPESFOLDER}};
 }
 
 Node<Client> Client::getViewsNode() {
-    return {*this, {0, UA_NS0ID_VIEWSFOLDER}, false};
+    return {*this, {0, UA_NS0ID_VIEWSFOLDER}};
 }
 
 UA_Client* Client::handle() noexcept {

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -1,6 +1,7 @@
 #include "open62541pp/Node.h"
 
 #include "open62541pp/Client.h"
+#include "open62541pp/Config.h"
 #include "open62541pp/ErrorHandling.h"
 #include "open62541pp/Server.h"
 #include "open62541pp/services/View.h"
@@ -35,13 +36,9 @@ bool Node<Client>::exists() noexcept {
 
 template <>
 bool Node<Server>::exists() noexcept {
-    auto* config = UA_Server_getConfig(getConnection().handle());
-    const auto* node = config->nodestore.getNode(config->nodestore.context, getNodeId().handle());
-    const bool exists = (node != nullptr);
-    if (node != nullptr) {
-        config->nodestore.releaseNode(config->nodestore.context, node);
-    }
-    return exists;
+    void* context{};
+    const auto status = UA_Server_getNodeContext(getConnection().handle(), getNodeId(), &context);
+    return (status == UA_STATUSCODE_GOOD);
 }
 
 template <typename T>

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -46,7 +46,7 @@ std::vector<Node<T>> Node<T>::browseReferencedNodes(
     nodes.reserve(refs.size());
     for (const auto& ref : refs) {
         if (ref.getNodeId().isLocal()) {
-            nodes.emplace_back(connection_, ref.getNodeId().getNodeId(), false);
+            nodes.emplace_back(connection_, ref.getNodeId().getNodeId());
         }
     }
     return nodes;
@@ -57,7 +57,7 @@ Node<T> Node<T>::browseChild(const std::vector<QualifiedName>& path) {
     const auto result = services::browseSimplifiedBrowsePath(connection_, nodeId_, path);
     for (auto&& target : result.getTargets()) {
         if (target.getTargetId().isLocal()) {
-            return {connection_, target.getTargetId().getNodeId(), false};
+            return {connection_, target.getTargetId().getNodeId()};
         }
     }
     throw BadStatus(UA_STATUSCODE_BADNOMATCH);

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -362,23 +362,23 @@ bool Server::isRunning() const noexcept {
 }
 
 Node<Server> Server::getNode(const NodeId& id) {
-    return {*this, id, true};
+    return {*this, id};
 }
 
 Node<Server> Server::getRootNode() {
-    return {*this, {0, UA_NS0ID_ROOTFOLDER}, false};
+    return {*this, {0, UA_NS0ID_ROOTFOLDER}};
 }
 
 Node<Server> Server::getObjectsNode() {
-    return {*this, {0, UA_NS0ID_OBJECTSFOLDER}, false};
+    return {*this, {0, UA_NS0ID_OBJECTSFOLDER}};
 }
 
 Node<Server> Server::getTypesNode() {
-    return {*this, {0, UA_NS0ID_TYPESFOLDER}, false};
+    return {*this, {0, UA_NS0ID_TYPESFOLDER}};
 }
 
 Node<Server> Server::getViewsNode() {
-    return {*this, {0, UA_NS0ID_VIEWSFOLDER}, false};
+    return {*this, {0, UA_NS0ID_VIEWSFOLDER}};
 }
 
 UA_Server* Server::handle() noexcept {

--- a/tests/Node.cpp
+++ b/tests/Node.cpp
@@ -29,15 +29,13 @@ TEST_CASE("Node") {
         auto varNode = serverOrClient.getNode(varId);
         auto refNode = serverOrClient.getNode(ReferenceTypeId::References);
 
-        SUBCASE("Constructor") {
-            CHECK_NOTHROW(Node(serverOrClient, NodeId(0, UA_NS0ID_BOOLEAN), false));
-            CHECK_NOTHROW(Node(serverOrClient, NodeId(0, UA_NS0ID_BOOLEAN), true));
-            CHECK_NOTHROW(Node(serverOrClient, NodeId(0, "DoesNotExist"), false));
-            CHECK_THROWS(Node(serverOrClient, NodeId(0, "DoesNotExist"), true));
-        }
-
         SUBCASE("getConnection") {
             CHECK(rootNode.getConnection() == serverOrClient);
+        }
+
+        SUBCASE("getNodeId") {
+            const NodeId id(0, UA_NS0ID_OBJECTSFOLDER);
+            CHECK(Node(serverOrClient, id).getNodeId() == id);
         }
 
         SUBCASE("Node class of default nodes") {

--- a/tests/Node.cpp
+++ b/tests/Node.cpp
@@ -38,6 +38,11 @@ TEST_CASE("Node") {
             CHECK(Node(serverOrClient, id).getNodeId() == id);
         }
 
+        SUBCASE("exists") {
+            CHECK(Node(serverOrClient, NodeId(0, UA_NS0ID_OBJECTSFOLDER)).exists());
+            CHECK_FALSE(Node(serverOrClient, NodeId(0, "DoesNotExist")).exists());
+        }
+
         SUBCASE("Node class of default nodes") {
             CHECK(serverOrClient.getRootNode().readNodeClass() == NodeClass::Object);
             CHECK(serverOrClient.getObjectsNode().readNodeClass() == NodeClass::Object);


### PR DESCRIPTION
Closes #88.

Initial ideas was to add following methods:
- `bool NodeId::exists(Server&)`
- `bool NodeId::exists(Client&)`

This would introduce client and server logic to the `NodeId` data type, which is by definition agnostic to the actual server-client-connection. Instead, the `Node` class seems to be a better place, because it couples `Server`/`Client` and the actual `NodeId`.

Following changes are proposed:
- Remove the optional existance check in the `Node` constructor with the `checkExists` flag
- Add a method `Node::exists` to explicitly check the existance of a node

If just the existance of a `NodeId` should be checked, a `Node` object must be created. BUT the construction is very cheap.

@johanneskopf: Any remarks/ideas?