### PR TITLE
feat: add overloads to return `Variant`/`DataValue` by value from read functions

### DIFF
--- a/examples/custom_datatypes/client_custom_datatypes.cpp
+++ b/examples/custom_datatypes/client_custom_datatypes.cpp
@@ -22,7 +22,7 @@ int main() {
     // Read custom variables
     opcua::Variant variant;
 
-    client.getNode({1, "Point"}).readValue(variant);
+    variant = client.getNode({1, "Point"}).readValue();
     if (variant.isType(dataTypePoint)) {
         const auto* p = static_cast<Point*>(variant.getScalar());
         std::cout << "Point:\n";
@@ -31,7 +31,7 @@ int main() {
         std::cout << "- z = " << p->z << "\n";
     }
 
-    client.getNode({1, "PointVec"}).readValue(variant);
+    variant = client.getNode({1, "PointVec"}).readValue();
     // Variants store non-builtin data types as ExtensionObjects. If the data type is known to the
     // client/server, open62541 unwraps scalar objects transparently in the encoding layer:
     // https://www.open62541.org/doc/master/types.html#variant
@@ -49,7 +49,7 @@ int main() {
         }
     }
 
-    client.getNode({1, "Measurements"}).readValue(variant);
+    variant = client.getNode({1, "Measurements"}).readValue();
     if (variant.isType(dataTypeMeasurements)) {
         const auto* m = static_cast<Measurements*>(variant.getScalar());
         std::cout << "Measurements:\n";
@@ -59,7 +59,7 @@ int main() {
         }
     }
 
-    client.getNode({1, "Opt"}).readValue(variant);
+    variant = client.getNode({1, "Opt"}).readValue();
     auto formatOptional = [](const auto* ptr) {
         return ptr == nullptr ? "NULL" : std::to_string(*ptr);
     };
@@ -71,7 +71,7 @@ int main() {
         std::cout << "- c = " << formatOptional(opt->c) << "\n";
     }
 
-    client.getNode({1, "Uni"}).readValue(variant);
+    variant = client.getNode({1, "Uni"}).readValue();
     if (variant.isType(dataTypeUni)) {
         const auto* uni = static_cast<Uni*>(variant.getScalar());
         std::cout << "Uni:\n";

--- a/include/open62541pp/Node.h
+++ b/include/open62541pp/Node.h
@@ -299,29 +299,39 @@ public:
     }
 
     /// @copydoc services::readDataValue
-    void readDataValue(DataValue& value) {
-        services::readDataValue(connection_, nodeId_, value);
+    DataValue readDataValue() {
+        return services::readDataValue(connection_, nodeId_);
+    }
+
+    /// @copydoc services::readDataValue
+    [[deprecated("No performance benefit to pass DataValue by reference, return by value instead"
+    )]] void
+    readDataValue(DataValue& value) {
+        value = services::readDataValue(connection_, nodeId_);
     }
 
     /// @copydoc services::readValue
-    void readValue(Variant& value) {
-        services::readValue(connection_, nodeId_, value);
+    Variant readValue() {
+        return services::readValue(connection_, nodeId_);
+    }
+
+    /// @copydoc services::readValue
+    [[deprecated("No performance benefit to pass Variant by reference, return by value instead"
+    )]] void
+    readValue(Variant& value) {
+        value = services::readValue(connection_, nodeId_);
     }
 
     /// Read scalar from variable node.
     template <typename T>
     T readScalar() {
-        Variant variant;
-        readValue(variant);
-        return variant.getScalarCopy<T>();
+        return readValue().template getScalarCopy<T>();
     }
 
     /// Read array from variable node.
     template <typename T>
     std::vector<T> readArray() {
-        Variant variant;
-        readValue(variant);
-        return variant.getArrayCopy<T>();
+        return readValue().template getArrayCopy<T>();
     }
 
     /// @copydoc services::readDataType

--- a/include/open62541pp/services/Attribute.h
+++ b/include/open62541pp/services/Attribute.h
@@ -184,8 +184,16 @@ inline LocalizedText readInverseName(T& serverOrClient, const NodeId& id) {
  * @ingroup Attribute
  */
 template <typename T>
-inline void readDataValue(T& serverOrClient, const NodeId& id, DataValue& value) {
-    value = readAttribute(serverOrClient, id, AttributeId::Value, TimestampsToReturn::Both);
+inline DataValue readDataValue(T& serverOrClient, const NodeId& id) {
+    return readAttribute(serverOrClient, id, AttributeId::Value, TimestampsToReturn::Both);
+}
+
+/// @copydoc readDataValue
+template <typename T>
+[[deprecated("No performance benefit to pass DataValue by reference, return by value instead"
+)]] inline void
+readDataValue(T& serverOrClient, const NodeId& id, DataValue& value) {
+    value = readDataValue(serverOrClient, id);
 }
 
 /**
@@ -193,9 +201,19 @@ inline void readDataValue(T& serverOrClient, const NodeId& id, DataValue& value)
  * @ingroup Attribute
  */
 template <typename T>
-inline void readValue(T& serverOrClient, const NodeId& id, Variant& value) {
+inline Variant readValue(T& serverOrClient, const NodeId& id) {
     DataValue dv = readAttribute(serverOrClient, id, AttributeId::Value);
-    value.swap(dv->value);
+    Variant var;
+    var.swap(dv->value);
+    return var;
+}
+
+/// @copydoc readValue
+template <typename T>
+[[deprecated("No performance benefit to pass Variant by reference, return by value instead."
+)]] inline void
+readValue(T& serverOrClient, const NodeId& id, Variant& value) {
+    value = readValue(serverOrClient, id);
 }
 
 /**

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -349,9 +349,8 @@ bool Client::isConnected() noexcept {
 }
 
 std::vector<std::string> Client::getNamespaceArray() {
-    Variant variant;
-    services::readValue(*this, {0, UA_NS0ID_SERVER_NAMESPACEARRAY}, variant);
-    return variant.getArrayCopy<std::string>();
+    return services::readValue(*this, {0, UA_NS0ID_SERVER_NAMESPACEARRAY})
+        .getArrayCopy<std::string>();
 }
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -229,9 +229,8 @@ std::vector<Session> Server::getSessions() const {
 }
 
 std::vector<std::string> Server::getNamespaceArray() {
-    Variant variant;
-    services::readValue(*this, {0, UA_NS0ID_SERVER_NAMESPACEARRAY}, variant);
-    return variant.getArrayCopy<std::string>();
+    return services::readValue(*this, {0, UA_NS0ID_SERVER_NAMESPACEARRAY})
+        .getArrayCopy<std::string>();
 }
 
 uint16_t Server::registerNamespace(std::string_view uri) {

--- a/tests/Server.cpp
+++ b/tests/Server.cpp
@@ -197,7 +197,7 @@ TEST_CASE("DataSource with empty callbacks") {
     server.setVariableNodeValueBackend(id, ValueBackendDataSource{});
 
     Variant variant;
-    CHECK_THROWS_AS_MESSAGE(node.readValue(variant), BadStatus, "BadInternalError");
+    CHECK_THROWS_AS_MESSAGE(node.readValue(), BadStatus, "BadInternalError");
     CHECK_THROWS_AS_MESSAGE(node.writeValue(variant), BadStatus, "BadInternalError");
 }
 
@@ -213,7 +213,7 @@ TEST_CASE("DataSource with exception in callback") {
         };
         server.setVariableNodeValueBackend(id, dataSource);
         Variant variant;
-        CHECK_THROWS_AS_MESSAGE(node.readValue(variant), BadStatus, "BadUnexpectedError");
+        CHECK_THROWS_AS_MESSAGE(node.readValue(), BadStatus, "BadUnexpectedError");
     }
 
     SUBCASE("Other exception types") {
@@ -223,6 +223,6 @@ TEST_CASE("DataSource with exception in callback") {
         };
         server.setVariableNodeValueBackend(id, dataSource);
         Variant variant;
-        CHECK_THROWS_AS_MESSAGE(node.readValue(variant), BadStatus, "BadInternalError");
+        CHECK_THROWS_AS_MESSAGE(node.readValue(), BadStatus, "BadInternalError");
     }
 }

--- a/tests/Services.cpp
+++ b/tests/Services.cpp
@@ -258,8 +258,7 @@ TEST_CASE("Attribute service set (server)") {
         variantWrite.setScalarCopy(11.11);
         services::writeValue(server, id, variantWrite);
 
-        Variant variantRead;
-        services::readValue(server, id, variantRead);
+        Variant variantRead = services::readValue(server, id);
         CHECK(variantRead.getScalar<double>() == 11.11);
     }
 
@@ -272,8 +271,7 @@ TEST_CASE("Attribute service set (server)") {
         DataValue valueWrite(variant, {}, DateTime::now(), {}, uint16_t{1}, UA_STATUSCODE_GOOD);
         services::writeDataValue(server, id, valueWrite);
 
-        DataValue valueRead;
-        services::readDataValue(server, id, valueRead);
+        DataValue valueRead = services::readDataValue(server, id);
 
         CHECK_EQ(valueRead->hasValue, true);
         CHECK_EQ(valueRead->hasServerTimestamp, true);
@@ -330,14 +328,11 @@ TEST_CASE("Attribute service set (server & client)") {
         const std::vector<double> array{1, 2, 3};
         const auto variant = Variant::fromArray(array);
         CHECK_NOTHROW(services::writeValue(writer, id, variant));
-        Variant variantRead;
-        CHECK_NOTHROW(services::readValue(reader, id, variantRead));
-        CHECK(variantRead.getArrayCopy<double>() == array);
+        CHECK(services::readValue(reader, id).template getArrayCopy<double>() == array);
 
         const auto dataValue = DataValue::fromArray(array);
         CHECK_NOTHROW(services::writeDataValue(writer, id, dataValue));
-        DataValue dataValueRead;
-        CHECK_NOTHROW(services::readDataValue(reader, id, dataValueRead));
+        DataValue dataValueRead = services::readDataValue(reader, id);
         CHECK_EQ(dataValueRead->hasValue, true);
         CHECK_EQ(dataValueRead->hasSourceTimestamp, true);
         CHECK_EQ(dataValueRead->hasServerTimestamp, true);


### PR DESCRIPTION
New overloads:
- `DataValue readDataValue(T& serverOrClient, const NodeId& id)`
- `Variant readValue(T& serverOrClient, const NodeId& id)`
- `DataValue Node::readDataValue()`
- `Variant Node::readValue()`

**Deprecate** original function signature. No performance benefit to pass `Variant`/`DataValue` by reference. The original functions will be removed in the future for the sake of simplicity.