### PR TITLE
feat: specific naming of Node methods to read/write scalar/array values

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ int main() {
     myIntegerNode.writeDataType(opcua::Type::Int32)
         .writeDisplayName({"en-US", "the answer"})
         .writeDescription({"en-US", "the answer"})
-        .writeScalar(42);
+        .writeValueScalar(42);
 
     server.run();
 }
@@ -92,7 +92,7 @@ int main() {
     client.connect("opc.tcp://localhost:4840");
 
     opcua::Node node = client.getNode(opcua::VariableId::Server_ServerStatus_CurrentTime);
-    const auto dt = node.readScalar<opcua::DateTime>();
+    const auto dt = node.readValueScalar<opcua::DateTime>();
 
     std::cout << "Server date (UTC): " << dt.format("%Y-%m-%d %H:%M:%S") << std::endl;
 }

--- a/examples/client_connect.cpp
+++ b/examples/client_connect.cpp
@@ -32,7 +32,7 @@ int main(int argc, char* argv[]) {
     }
 
     auto node = client.getNode(opcua::VariableId::Server_ServerStatus_CurrentTime);
-    const auto dt = node.readScalar<opcua::DateTime>();
+    const auto dt = node.readValueScalar<opcua::DateTime>();
     client.disconnect();
 
     std::cout << "Server date (UTC): " << dt.format("%Y-%m-%d %H:%M:%S") << std::endl;

--- a/examples/client_minimal.cpp
+++ b/examples/client_minimal.cpp
@@ -7,7 +7,7 @@ int main() {
     client.connect("opc.tcp://localhost:4840");
 
     opcua::Node node = client.getNode(opcua::VariableId::Server_ServerStatus_CurrentTime);
-    const auto dt = node.readScalar<opcua::DateTime>();
+    const auto dt = node.readValueScalar<opcua::DateTime>();
 
     std::cout << "Server date (UTC): " << dt.format("%Y-%m-%d %H:%M:%S") << std::endl;
 }

--- a/examples/server.cpp
+++ b/examples/server.cpp
@@ -23,10 +23,10 @@ int main() {
     );
 
     // Write a value (attribute) to the node
-    myIntegerNode.writeScalar(42);
+    myIntegerNode.writeValueScalar(42);
 
     // Read the value (attribute) from the node
-    std::cout << "The answer is: " << myIntegerNode.readScalar<int>() << std::endl;
+    std::cout << "The answer is: " << myIntegerNode.readValueScalar<int>() << std::endl;
 
     server.run();
 }

--- a/examples/server_instantiation.cpp
+++ b/examples/server_instantiation.cpp
@@ -63,8 +63,8 @@ int main() {
     );
 
     // Set variables Age and Name
-    nodeBello.browseChild({{1, "Age"}}).writeScalar(3U);
-    nodeBello.browseChild({{1, "Name"}}).writeScalar(opcua::String("Bello"));
+    nodeBello.browseChild({{1, "Age"}}).writeValueScalar(3U);
+    nodeBello.browseChild({{1, "Name"}}).writeValueScalar(opcua::String("Bello"));
 
     server.run();
 }

--- a/examples/server_minimal.cpp
+++ b/examples/server_minimal.cpp
@@ -10,7 +10,7 @@ int main() {
     myIntegerNode.writeDataType(opcua::Type::Int32)
         .writeDisplayName({"en-US", "the answer"})
         .writeDescription({"en-US", "the answer"})
-        .writeScalar(42);
+        .writeValueScalar(42);
 
     server.run();
 }

--- a/examples/server_valuecallback.cpp
+++ b/examples/server_valuecallback.cpp
@@ -12,7 +12,7 @@ int main() {
             .writeDisplayName({"en-US", "Current time"})
             .writeDescription({"en-US", "Current time"})
             .writeDataType<opcua::DateTime>()
-            .writeScalar(opcua::DateTime::now());
+            .writeValueScalar(opcua::DateTime::now());
 
     // set variable value callback to write current time before every read operation
     opcua::ValueCallback valueCallback;
@@ -21,7 +21,7 @@ int main() {
         const auto timeNow = opcua::DateTime::now();
         std::cout << "Time before read: " << timeOld.format("%Y-%m-%d %H:%M:%S") << std::endl;
         std::cout << "Set current time: " << timeNow.format("%Y-%m-%d %H:%M:%S") << std::endl;
-        currentTimeNode.writeScalar(timeNow);
+        currentTimeNode.writeValueScalar(timeNow);
     };
     server.setVariableNodeValueCallback(currentTimeId, valueCallback);
 

--- a/include/open62541pp/Node.h
+++ b/include/open62541pp/Node.h
@@ -322,16 +322,28 @@ public:
         value = services::readValue(connection_, nodeId_);
     }
 
-    /// Read scalar from variable node.
+    /// Read scalar value from variable node.
     template <typename T>
-    T readScalar() {
+    T readValueScalar() {
         return readValue().template getScalarCopy<T>();
     }
 
-    /// Read array from variable node.
+    /// @copydoc readValueScalar
     template <typename T>
-    std::vector<T> readArray() {
+    [[deprecated("Use Node::readValueScalar instead")]] T readScalar() {
+        return readValueScalar<T>();
+    }
+
+    /// Read array value from variable node.
+    template <typename T>
+    std::vector<T> readValueArray() {
         return readValue().template getArrayCopy<T>();
+    }
+
+    /// @copydoc readValueArray
+    template <typename T>
+    [[deprecated("Use Node::readValueArray instead")]] std::vector<T> readArray() {
+        return readValueArray<T>();
     }
 
     /// @copydoc services::readDataType
@@ -430,38 +442,49 @@ public:
     /// Write scalar to variable node.
     /// @return Current node instance to chain multiple methods (fluent interface)
     template <typename T>
-    Node& writeScalar(const T& value) {
+    Node& writeValueScalar(const T& value) {
         // NOLINTNEXTLINE, variant isn't modified, try to avoid copy
         const auto variant = Variant::fromScalar<T>(const_cast<T&>(value));
         writeValue(variant);
         return *this;
     }
 
-    /// Write array (raw) to variable node.
+    /// @copydoc writeValueScalar
+    template <typename T>
+    [[deprecated("Use Node::writeValueScalar instead")]] Node& writeScalar(const T& value) {
+        return writeValueScalar<T>(value);
+    }
+
+    /// Write array value (raw) to variable node.
     /// @return Current node instance to chain multiple methods (fluent interface)
     template <typename T>
-    Node& writeArray(const T* array, size_t size) {
+    Node& writeValueArray(const T* array, size_t size) {
         // NOLINTNEXTLINE, variant isn't modified, try to avoid copy
         const auto variant = Variant::fromArray<T>(const_cast<T*>(array), size);
         writeValue(variant);
         return *this;
     }
 
-    /// Write array (std::vector) to variable node.
+    /// Write array value (std::vector) to variable node.
     /// @return Current node instance to chain multiple methods (fluent interface)
     template <typename T>
-    Node& writeArray(const std::vector<T>& array) {
-        writeArray<T>(array.data(), array.size());
-        return *this;
+    Node& writeValueArray(const std::vector<T>& array) {
+        return writeValueArray<T>(array.data(), array.size());
     }
 
-    /// Write range of elements as array to variable node.
+    /// Write range of elements as array value to variable node.
     /// @return Current node instance to chain multiple methods (fluent interface)
     template <typename InputIt>
-    Node& writeArray(InputIt first, InputIt last) {
+    Node& writeValueArray(InputIt first, InputIt last) {
         const auto variant = Variant::fromArray<InputIt>(first, last);
         writeValue(variant);
         return *this;
+    }
+
+    /// @copydoc  writeValueArray
+    template <typename... Args>
+    [[deprecated("Use Node::writeValueArray instead")]] Node& writeArray(Args&&... args) {
+        return writeValueArray(std::forward<Args>(args)...);
     }
 
     /// @copydoc services::writeDataType

--- a/tests/Node.cpp
+++ b/tests/Node.cpp
@@ -158,54 +158,54 @@ TEST_CASE("Node") {
 
         SUBCASE("Read/write value") {
             SUBCASE("Try read/write node classes other than Variable") {
-                CHECK_THROWS(rootNode.template readScalar<int>());
-                CHECK_THROWS(rootNode.template writeScalar<int>({}));
+                CHECK_THROWS(rootNode.template readValueScalar<int>());
+                CHECK_THROWS(rootNode.template writeValueScalar<int>({}));
             }
 
             SUBCASE("Scalar") {
                 CHECK_NOTHROW(varNode.writeDataType(Type::Float));
 
                 // write with wrong data type
-                CHECK_THROWS(varNode.template writeScalar<bool>({}));
-                CHECK_THROWS(varNode.template writeScalar<int>({}));
+                CHECK_THROWS(varNode.template writeValueScalar<bool>({}));
+                CHECK_THROWS(varNode.template writeValueScalar<int>({}));
 
                 // write with correct data type
                 float value = 11.11f;
-                CHECK_NOTHROW(varNode.writeScalar(value));
-                CHECK(varNode.template readScalar<float>() == value);
+                CHECK_NOTHROW(varNode.writeValueScalar(value));
+                CHECK(varNode.template readValueScalar<float>() == value);
             }
 
             SUBCASE("String") {
                 CHECK_NOTHROW(varNode.writeDataType(Type::String));
 
                 String str("test");
-                CHECK_NOTHROW(varNode.writeScalar(str));
-                CHECK(varNode.template readScalar<std::string>() == "test");
+                CHECK_NOTHROW(varNode.writeValueScalar(str));
+                CHECK(varNode.template readValueScalar<std::string>() == "test");
             }
 
             SUBCASE("Array") {
                 CHECK_NOTHROW(varNode.writeDataType(Type::Double));
 
                 // write with wrong data type
-                CHECK_THROWS(varNode.template writeArray<int>({}));
-                CHECK_THROWS(varNode.template writeArray<float>({}));
+                CHECK_THROWS(varNode.template writeValueArray<int>({}));
+                CHECK_THROWS(varNode.template writeValueArray<float>({}));
 
                 // write with correct data type
                 std::vector<double> array{11.11, 22.22, 33.33};
 
                 SUBCASE("Write as std::vector") {
-                    CHECK_NOTHROW(varNode.writeArray(array));
-                    CHECK(varNode.template readArray<double>() == array);
+                    CHECK_NOTHROW(varNode.writeValueArray(array));
+                    CHECK(varNode.template readValueArray<double>() == array);
                 }
 
                 SUBCASE("Write as raw array") {
-                    CHECK_NOTHROW(varNode.writeArray(array.data(), array.size()));
-                    CHECK(varNode.template readArray<double>() == array);
+                    CHECK_NOTHROW(varNode.writeValueArray(array.data(), array.size()));
+                    CHECK(varNode.template readValueArray<double>() == array);
                 }
 
                 SUBCASE("Write as iterator pair") {
-                    CHECK_NOTHROW(varNode.writeArray(array.begin(), array.end()));
-                    CHECK(varNode.template readArray<double>() == array);
+                    CHECK_NOTHROW(varNode.writeValueArray(array.begin(), array.end()));
+                    CHECK(varNode.template readValueArray<double>() == array);
                 }
             }
         }

--- a/tests/Server.cpp
+++ b/tests/Server.cpp
@@ -129,7 +129,7 @@ TEST_CASE("ValueCallback") {
 
     NodeId id{1, 1000};
     auto node = server.getObjectsNode().addVariable(id, "testVariable");
-    node.writeScalar<int>(1);
+    node.writeValueScalar<int>(1);
 
     bool onBeforeReadCalled = false;
     bool onAfterWriteCalled = false;
@@ -148,14 +148,14 @@ TEST_CASE("ValueCallback") {
     server.setVariableNodeValueCallback(id, valueCallback);
 
     // trigger onBeforeRead callback with read operation
-    const auto valueRead = node.readScalar<int>();
+    const auto valueRead = node.readValueScalar<int>();
     CHECK(onBeforeReadCalled == true);
     CHECK(onAfterWriteCalled == false);
     CHECK(valueBeforeRead == 1);
     CHECK(valueRead == 1);
 
     // trigger onAfterWrite callback with write operation
-    node.writeScalar<int>(2);
+    node.writeValueScalar<int>(2);
     CHECK(onBeforeReadCalled == true);
     CHECK(onAfterWriteCalled == true);
     CHECK(valueAfterWrite == 2);
@@ -184,8 +184,8 @@ TEST_CASE("DataSource") {
 
     CHECK_NOTHROW(server.setVariableNodeValueBackend(id, dataSource));
 
-    CHECK(node.readScalar<int>() == 0);
-    CHECK_NOTHROW(node.writeScalar<int>(1));
+    CHECK(node.readValueScalar<int>() == 0);
+    CHECK_NOTHROW(node.writeValueScalar<int>(1));
     CHECK(data == 1);
 }
 


### PR DESCRIPTION
More specific naming of the `Node` methods to read/write scalar/array values.
The prefix should always be the same, e.g. `Node::writeValue` and the `Node::writeValueScalar` instead of `Node::writeScalar`. It's not clear, that the `Value` attribute of the node is written.

Add methods:
- `Node::readValueScalar`
- `Node::readValueArray`
- `Node::writeValueScalar`
- `Node::writeValueArray`

Deprecate methods:
- `Node::readScalar`
- `Node::readArray`
- `Node::writeScalar`
- `Node::writeArray`