### PR TITLE
feat: conversions from `string_view`, `const char*`, `char[N]` to `UA_String`

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,33 +142,33 @@ struct TypeConverter<std::string> {
 
 ### Type map of built-in types
 
-| Type Enum `opcua::Type`  | Type                 | Typedef     | Wrapper                           | Conversions               |
-| ------------------------ | -------------------- | ----------- | --------------------------------- | ------------------------- |
-| Boolean                  | `UA_Boolean`         | `bool`      |                                   |                           |
-| SByte                    | `UA_SByte`           | `int8_t`    |                                   |                           |
-| Byte                     | `UA_Byte`            | `uint8_t`   |                                   |                           |
-| Int16                    | `UA_Int16`           | `int16_t`   |                                   |                           |
-| UInt16                   | `UA_UInt16`          | `uint16_t`  |                                   |                           |
-| Int32                    | `UA_Int32`           | `int32_t`   |                                   |                           |
-| UInt32                   | `UA_UInt32`          | `uint32_t`  |                                   |                           |
-| Int64                    | `UA_Int64`           | `int64_t`   |                                   |                           |
-| UInt64                   | `UA_UInt64`          | `uint64_t`  |                                   |                           |
-| Float                    | `UA_Float`           | `float`     |                                   |                           |
-| Double                   | `UA_Double`          | `double`    |                                   |                           |
-| String                   | `UA_String`          |             | `opcua::String`                   | `std::string`             |
-| DateTime                 | `UA_DateTime`        | `int64_t`   | `opcua::DateTime`                 | `std::chrono::time_point` |
-| Guid                     | `UA_Guid`            |             | `opcua::Guid`                     |                           |
-| ByteString               | `UA_ByteString`      | `UA_String` | `opcua::ByteString`               |                           |
-| XmlElement               | `UA_XmlElement`      | `UA_String` | `opcua::XmlElement`               |                           |
-| NodeId                   | `UA_NodeId`          |             | `opcua::NodeId`                   |                           |
-| ExpandedNodeId           | `UA_ExpandedNodeId`  |             | `opcua::ExpandedNodeId`           |                           |
-| StatusCode               | `UA_StatusCode`      | `uint32_t`  | `opcua::StatusCode`               |                           |
-| QualifiedName            | `UA_QualifiedName`   |             | `opcua::QualifiedName`            |                           |
-| LocalizedText            | `UA_LocalizedText`   |             | `opcua::LocalizedText`            |                           |
-| ExtensionObjectDataValue | `UA_ExtensionObject` |             | `opcua::ExtensionObjectDataValue` |                           |
-| DataValue                | `UA_DataValue`       |             | `opcua::DataValue`                |                           |
-| Variant                  | `UA_Variant`         |             | `opcua::Variant`                  |                           |
-| DiagnosticInfo           | `UA_DiagnosticInfo`  |             | `opcua::DiagnosticInfo`           |                           |
+| Type Enum `opcua::Type`  | Type                 | Typedef     | Wrapper                           | Conversions                                                 |
+| ------------------------ | -------------------- | ----------- | --------------------------------- | ----------------------------------------------------------- |
+| Boolean         | `UA_Boolean`         | `bool`      |                          |                                                             |
+| SByte           | `UA_SByte`           | `int8_t`    |                          |                                                             |
+| Byte            | `UA_Byte`            | `uint8_t`   |                          |                                                             |
+| Int16           | `UA_Int16`           | `int16_t`   |                          |                                                             |
+| UInt16          | `UA_UInt16`          | `uint16_t`  |                          |                                                             |
+| Int32           | `UA_Int32`           | `int32_t`   |                          |                                                             |
+| UInt32          | `UA_UInt32`          | `uint32_t`  |                          |                                                             |
+| Int64           | `UA_Int64`           | `int64_t`   |                          |                                                             |
+| UInt64          | `UA_UInt64`          | `uint64_t`  |                          |                                                             |
+| Float           | `UA_Float`           | `float`     |                          |                                                             |
+| Double          | `UA_Double`          | `double`    |                          |                                                             |
+| String          | `UA_String`          |             | `opcua::String`          | `std::string`, `std::string_view`, `const char*`, `char[N]` |
+| DateTime        | `UA_DateTime`        | `int64_t`   | `opcua::DateTime`        | `std::chrono::time_point`                                   |
+| Guid            | `UA_Guid`            |             | `opcua::Guid`            |                                                             |
+| ByteString      | `UA_ByteString`      | `UA_String` | `opcua::ByteString`      |                                                             |
+| XmlElement      | `UA_XmlElement`      | `UA_String` | `opcua::XmlElement`      |                                                             |
+| NodeId          | `UA_NodeId`          |             | `opcua::NodeId`          |                                                             |
+| ExpandedNodeId  | `UA_ExpandedNodeId`  |             | `opcua::ExpandedNodeId`  |                                                             |
+| StatusCode      | `UA_StatusCode`      | `uint32_t`  | `opcua::StatusCode`      |                                                             |
+| QualifiedName   | `UA_QualifiedName`   |             | `opcua::QualifiedName`   |                                                             |
+| LocalizedText   | `UA_LocalizedText`   |             | `opcua::LocalizedText`   |                                                             |
+| ExtensionObject | `UA_ExtensionObject` |             | `opcua::ExtensionObject` |                                                             |
+| DataValue       | `UA_DataValue`       |             | `opcua::DataValue`       |                                                             |
+| Variant         | `UA_Variant`         |             | `opcua::Variant`         |                                                             |
+| DiagnosticInfo  | `UA_DiagnosticInfo`  |             | `opcua::DiagnosticInfo`  |                                                             |
 
 ## 🚀 Getting started
 

--- a/examples/client_method.cpp
+++ b/examples/client_method.cpp
@@ -14,7 +14,7 @@ int main() {
 
     // Call method from parent node (Objects)
     const auto outputs = objNode.callMethod(
-        greetMethodNode.getNodeId(), {opcua::Variant::fromScalar(opcua::String("World"))}
+        greetMethodNode.getNodeId(), {opcua::Variant::fromScalar("World")}
     );
-    std::cout << outputs.at(0).getScalarCopy<opcua::String>() << std::endl;
+    std::cout << outputs.at(0).getScalar<opcua::String>() << std::endl;
 }

--- a/examples/server_instantiation.cpp
+++ b/examples/server_instantiation.cpp
@@ -44,7 +44,7 @@ int main() {
             opcua::VariableAttributes{}
                 .setDisplayName({"en-US", "Name"})
                 .setDescription({"en-US", "This dogs name"})
-                .setValueScalar(opcua::String("unnamed dog"))  // default name
+                .setValueScalar("unnamed dog")  // default name
         )
         .addModellingRule(opcua::ModellingRule::Mandatory);  // create on new instance
 
@@ -64,7 +64,7 @@ int main() {
 
     // Set variables Age and Name
     nodeBello.browseChild({{1, "Age"}}).writeValueScalar(3U);
-    nodeBello.browseChild({{1, "Name"}}).writeValueScalar(opcua::String("Bello"));
+    nodeBello.browseChild({{1, "Name"}}).writeValueScalar("Bello");
 
     server.run();
 }

--- a/examples/server_method.cpp
+++ b/examples/server_method.cpp
@@ -14,7 +14,7 @@ int main() {
         [](const std::vector<opcua::Variant>& input, std::vector<opcua::Variant>& output) {
             const auto& name = input.at(0).getScalar<opcua::String>();
             const auto greeting = std::string("Hello ").append(name.get());
-            output.at(0).setScalarCopy(opcua::String(greeting));
+            output.at(0).setScalarCopy(greeting);
         },
         {{"name", {"en-US", "your name"}, opcua::DataTypeId::String, opcua::ValueRank::Scalar}},
         {{"greeting", {"en-US", "greeting"}, opcua::DataTypeId::String, opcua::ValueRank::Scalar}}

--- a/tests/TypeConverter.cpp
+++ b/tests/TypeConverter.cpp
@@ -83,7 +83,7 @@ TEST_CASE_TEMPLATE("TypeConverter string", T, std::string, std::string_view) {
         T dst;
 
         TypeConverter<T>::fromNative(src, dst);
-        CHECK(dst == "Test123");
+        CHECK(std::string(dst) == "Test123");
 
         UA_clear(&src, &UA_TYPES[UA_TYPES_STRING]);
     }

--- a/tests/TypeConverter.cpp
+++ b/tests/TypeConverter.cpp
@@ -1,6 +1,7 @@
 #include <doctest/doctest.h>
 
 #include "open62541pp/TypeConverter.h"
+#include "open62541pp/detail/traits.h"
 
 using namespace opcua;
 
@@ -76,22 +77,46 @@ TEST_CASE_TEMPLATE("TypeConverter native strings", T, UA_String, UA_ByteString, 
     UA_clear(&dst, &UA_TYPES[UA_TYPES_STRING]);
 }
 
-TEST_CASE("TypeConverter std::string") {
+TEST_CASE_TEMPLATE("TypeConverter string", T, std::string, std::string_view) {
     SUBCASE("fromNative") {
         UA_String src = detail::allocUaString("Test123");
-        std::string dst;
+        T dst;
 
-        TypeConverter<std::string>::fromNative(src, dst);
+        TypeConverter<T>::fromNative(src, dst);
         CHECK(dst == "Test123");
 
         UA_clear(&src, &UA_TYPES[UA_TYPES_STRING]);
     }
 
     SUBCASE("toNative") {
-        std::string src{"Test123"};
+        T src{"Test123"};
         UA_String dst{};
 
-        TypeConverter<std::string>::toNative(src, dst);
+        TypeConverter<T>::toNative(src, dst);
+        CHECK(detail::toString(dst) == "Test123");
+
+        UA_clear(&dst, &UA_TYPES[UA_TYPES_STRING]);
+    }
+}
+
+TEST_CASE("TypeConverter const char*") {
+    SUBCASE("toNative") {
+        const char* src = "Test123";
+        UA_String dst{};
+
+        TypeConverter<const char*>::toNative(src, dst);
+        CHECK(detail::toString(dst) == "Test123");
+
+        UA_clear(&dst, &UA_TYPES[UA_TYPES_STRING]);
+    }
+}
+
+TEST_CASE("TypeConverter char[N]") {
+    SUBCASE("toNative") {
+        char src[7] = {'T', 'e', 's', 't', '1', '2', '3'};
+        UA_String dst{};
+
+        TypeConverter<char[7]>::toNative(src, dst);
         CHECK(detail::toString(dst) == "Test123");
 
         UA_clear(&dst, &UA_TYPES[UA_TYPES_STRING]);


### PR DESCRIPTION
Add template specializations for `TypeConverter` to allow following string conversions:
- `TypeConverter<std::string_view>`: convert to and from native `UA_String`
- `TypeConverter<const char*>`: convert to native `UA_String`
- `TypeConverter<char[N]>`: convert to native `UA_String`