### PR TITLE
build: gcc 7 support

### DIFF
--- a/include/open62541pp/types/Builtin.h
+++ b/include/open62541pp/types/Builtin.h
@@ -2,11 +2,20 @@
 
 #include <array>
 #include <cstdint>
-#include <filesystem>
 #include <iosfwd>  // forward declare ostream
 #include <string>
 #include <string_view>
 #include <vector>
+
+// Workaround for GCC 7 with partial C++17 support
+// https://github.com/open62541pp/open62541pp/issues/109
+#if !__has_include(<filesystem>) && __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#else
+#include <filesystem>
+namespace fs = std::filesystem;
+#endif
 
 #include "open62541pp/ErrorHandling.h"
 #include "open62541pp/TypeWrapper.h"
@@ -135,14 +144,14 @@ public:
     explicit ByteString(const std::vector<uint8_t>& bytes);
 
     /// Read ByteString from binary file.
-    static ByteString fromFile(const std::filesystem::path& filepath);
+    static ByteString fromFile(const fs::path& filepath);
 
     /// Parse ByteString from Base64 encoded string.
     /// @note Only supported since open62541 v1.1
     static ByteString fromBase64(std::string_view encoded);
 
     /// Write ByteString to binary file.
-    void toFile(const std::filesystem::path& filepath) const;
+    void toFile(const fs::path& filepath) const;
 
     /// Convert to Base64 encoded string.
     /// @note Only supported since open62541 v1.1

--- a/src/types/Builtin.cpp
+++ b/src/types/Builtin.cpp
@@ -119,7 +119,7 @@ ByteString ByteString::fromBase64([[maybe_unused]] std::string_view encoded) {
 #endif
 }
 
-ByteString ByteString::fromFile(const std::filesystem::path& filepath) {
+ByteString ByteString::fromFile(const fs::path& filepath) {
     std::ifstream fp(filepath, std::ios::binary);
     const std::vector<uint8_t> bytes(
         (std::istreambuf_iterator<char>(fp)), (std::istreambuf_iterator<char>())
@@ -138,7 +138,7 @@ std::string ByteString::toBase64() const {
 #endif
 }
 
-void ByteString::toFile(const std::filesystem::path& filepath) const {
+void ByteString::toFile(const fs::path& filepath) const {
     std::ofstream fp(filepath, std::ios::binary);
     fp.write(reinterpret_cast<char*>(handle()->data), handle()->length);  // NOLINT
 }


### PR DESCRIPTION
Workaround to allow GCC 7 with partial C++ 17 support: https://en.cppreference.com/w/cpp/compiler_support/17

Use `<experimental/filesystem>` instead of `<filesystem>`.