### PR TITLE
feat: raw view services

### DIFF
--- a/include/open62541pp/services/View.h
+++ b/include/open62541pp/services/View.h
@@ -10,6 +10,7 @@
 // forward declarations
 namespace opcua {
 class ByteString;
+class Client;
 class QualifiedName;
 class Server;
 }  // namespace opcua
@@ -25,6 +26,13 @@ namespace opcua::services {
  */
 
 /**
+ * Discover the references of one or more nodes (client only).
+ * @see https://reference.opcfoundation.org/Core/Part4/v105/docs/5.8.2
+ * @ingroup View
+ */
+BrowseResponse browse(Client& client, const BrowseRequest& request);
+
+/**
  * Discover the references of a specified node.
  * @param serverOrClient Instance of type Server or Client
  * @param bd Browse description
@@ -34,6 +42,13 @@ namespace opcua::services {
  */
 template <typename T>
 BrowseResult browse(T& serverOrClient, const BrowseDescription& bd, uint32_t maxReferences = 0);
+
+/**
+ * Request the next sets of @ref browse / @ref browseNext responses (client only).
+ * @see https://reference.opcfoundation.org/Core/Part4/v105/docs/5.8.3
+ * @ingroup View
+ */
+BrowseNextResponse browseNext(Client& client, const BrowseNextRequest& request);
 
 /**
  * Request the next set of a @ref browse or @ref browseNext response.
@@ -76,6 +91,15 @@ std::vector<ReferenceDescription> browseAll(
  * @ingroup View
  */
 std::vector<ExpandedNodeId> browseRecursive(Server& server, const BrowseDescription& bd);
+
+/**
+ * Translate browse paths to NodeIds (client only).
+ * @see https://reference.opcfoundation.org/Core/Part4/v105/docs/5.8.4
+ * @ingroup View
+ */
+TranslateBrowsePathsToNodeIdsResponse translateBrowsePathsToNodeIds(
+    Client& client, const TranslateBrowsePathsToNodeIdsRequest& request
+);
 
 /**
  * Translate a browse path to NodeIds.

--- a/include/open62541pp/services/View.h
+++ b/include/open62541pp/services/View.h
@@ -128,4 +128,19 @@ BrowsePathResult browseSimplifiedBrowsePath(
     T& serverOrClient, const NodeId& origin, Span<const QualifiedName> browsePath
 );
 
+/**
+ * Register nodes for efficient access operations (client only).
+ * Clients shall unregister unneeded nodes immediately to free up resources.
+ * @see https://reference.opcfoundation.org/Core/Part4/v105/docs/5.8.5
+ * @ingroup View
+ */
+RegisterNodesResponse registerNodes(Client& client, const RegisterNodesRequest& request);
+
+/**
+ * Unregister nodes (client only).
+ * @see https://reference.opcfoundation.org/Core/Part4/v105/docs/5.8.6
+ * @ingroup View
+ */
+UnregisterNodesResponse unregisterNodes(Client& client, const UnregisterNodesRequest& request);
+
 }  // namespace opcua::services

--- a/include/open62541pp/types/Composed.h
+++ b/include/open62541pp/types/Composed.h
@@ -793,6 +793,21 @@ public:
 };
 
 /**
+ * UA_ViewDescription wrapper class.
+ * @ingroup TypeWrapper
+ */
+class ViewDescription : public TypeWrapper<UA_ViewDescription, UA_TYPES_VIEWDESCRIPTION> {
+public:
+    using TypeWrapperBase::TypeWrapperBase;
+
+    ViewDescription(NodeId viewId, DateTime timestamp, uint32_t viewVersion);
+
+    UAPP_COMPOSED_GETTER_WRAPPER(NodeId, getViewId, viewId)
+    UAPP_COMPOSED_GETTER_WRAPPER(DateTime, getTimestamp, timestamp)
+    UAPP_COMPOSED_GETTER(uint32_t, getViewVersion, viewVersion)
+};
+
+/**
  * UA_BrowseDescription wrapper class.
  * @ingroup TypeWrapper
  */
@@ -847,6 +862,80 @@ public:
     UAPP_COMPOSED_GETTER_WRAPPER(ByteString, getContinuationPoint, continuationPoint)
     UAPP_COMPOSED_GETTER_SPAN_WRAPPER(
         ReferenceDescription, getReferences, references, referencesSize
+    )
+};
+
+/**
+ * UA_BrowseRequest wrapper class.
+ * @ingroup TypeWrapper
+ */
+class BrowseRequest : public TypeWrapper<UA_BrowseRequest, UA_TYPES_BROWSEREQUEST> {
+public:
+    using TypeWrapperBase::TypeWrapperBase;
+
+    BrowseRequest(
+        RequestHeader requestHeader,
+        ViewDescription view,
+        uint32_t requestedMaxReferencesPerNode,
+        Span<const BrowseDescription> nodesToBrowse
+    );
+
+    UAPP_COMPOSED_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
+    UAPP_COMPOSED_GETTER_WRAPPER(ViewDescription, getView, view)
+    UAPP_COMPOSED_GETTER(uint32_t, getRequestedMaxReferencesPerNode, requestedMaxReferencesPerNode)
+    UAPP_COMPOSED_GETTER_SPAN_WRAPPER(
+        BrowseDescription, getNodesToBrowse, nodesToBrowse, nodesToBrowseSize
+    )
+};
+
+/**
+ * UA_BrowseResponse wrapper class.
+ * @ingroup TypeWrapper
+ */
+class BrowseResponse : public TypeWrapper<UA_BrowseResponse, UA_TYPES_BROWSERESPONSE> {
+public:
+    using TypeWrapperBase::TypeWrapperBase;
+
+    UAPP_COMPOSED_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
+    UAPP_COMPOSED_GETTER_SPAN_WRAPPER(BrowseResult, getResults, results, resultsSize)
+    UAPP_COMPOSED_GETTER_SPAN_WRAPPER(
+        DiagnosticInfo, getDiagnosticInfos, diagnosticInfos, diagnosticInfosSize
+    )
+};
+
+/**
+ * UA_BrowseNextRequest wrapper class.
+ * @ingroup TypeWrapper
+ */
+class BrowseNextRequest : public TypeWrapper<UA_BrowseNextRequest, UA_TYPES_BROWSENEXTREQUEST> {
+public:
+    using TypeWrapperBase::TypeWrapperBase;
+
+    BrowseNextRequest(
+        RequestHeader requestHeader,
+        bool releaseContinuationPoints,
+        Span<const ByteString> continuationPoints
+    );
+
+    UAPP_COMPOSED_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
+    UAPP_COMPOSED_GETTER(bool, getReleaseContinuationPoints, releaseContinuationPoints)
+    UAPP_COMPOSED_GETTER_SPAN_WRAPPER(
+        ByteString, getContinuationPoints, continuationPoints, continuationPointsSize
+    )
+};
+
+/**
+ * UA_BrowseNextResponse wrapper class.
+ * @ingroup TypeWrapper
+ */
+class BrowseNextResponse : public TypeWrapper<UA_BrowseNextResponse, UA_TYPES_BROWSENEXTRESPONSE> {
+public:
+    using TypeWrapperBase::TypeWrapperBase;
+
+    UAPP_COMPOSED_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
+    UAPP_COMPOSED_GETTER_SPAN_WRAPPER(BrowseResult, getResults, results, resultsSize)
+    UAPP_COMPOSED_GETTER_SPAN_WRAPPER(
+        DiagnosticInfo, getDiagnosticInfos, diagnosticInfos, diagnosticInfosSize
     )
 };
 
@@ -919,6 +1008,43 @@ public:
 
     UAPP_COMPOSED_GETTER(StatusCode, getStatusCode, statusCode)
     UAPP_COMPOSED_GETTER_SPAN_WRAPPER(BrowsePathTarget, getTargets, targets, targetsSize)
+};
+
+/**
+ * UA_TranslateBrowsePathsToNodeIdsRequest wrapper class.
+ * @ingroup TypeWrapper
+ */
+class TranslateBrowsePathsToNodeIdsRequest
+    : public TypeWrapper<
+          UA_TranslateBrowsePathsToNodeIdsRequest,
+          UA_TYPES_TRANSLATEBROWSEPATHSTONODEIDSREQUEST> {
+public:
+    using TypeWrapperBase::TypeWrapperBase;
+
+    TranslateBrowsePathsToNodeIdsRequest(
+        RequestHeader requestHeader, Span<const BrowsePath> browsePaths
+    );
+
+    UAPP_COMPOSED_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
+    UAPP_COMPOSED_GETTER_SPAN_WRAPPER(BrowsePath, getBrowsePaths, browsePaths, browsePathsSize)
+};
+
+/**
+ * UA_TranslateBrowsePathsToNodeIdsResponse wrapper class.
+ * @ingroup TypeWrapper
+ */
+class TranslateBrowsePathsToNodeIdsResponse
+    : public TypeWrapper<
+          UA_TranslateBrowsePathsToNodeIdsResponse,
+          UA_TYPES_TRANSLATEBROWSEPATHSTONODEIDSRESPONSE> {
+public:
+    using TypeWrapperBase::TypeWrapperBase;
+
+    UAPP_COMPOSED_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
+    UAPP_COMPOSED_GETTER_SPAN_WRAPPER(BrowsePathResult, getResults, results, resultsSize)
+    UAPP_COMPOSED_GETTER_SPAN_WRAPPER(
+        DiagnosticInfo, getDiagnosticInfos, diagnosticInfos, diagnosticInfosSize
+    )
 };
 
 /**

--- a/include/open62541pp/types/Composed.h
+++ b/include/open62541pp/types/Composed.h
@@ -1048,6 +1048,67 @@ public:
 };
 
 /**
+ * UA_RegisterNodesRequest wrapper class.
+ * @ingroup TypeWrapper
+ */
+class RegisterNodesRequest
+    : public TypeWrapper<UA_RegisterNodesRequest, UA_TYPES_REGISTERNODESREQUEST> {
+public:
+    using TypeWrapperBase::TypeWrapperBase;
+
+    RegisterNodesRequest(RequestHeader requestHeader, Span<const NodeId> nodesToRegister);
+
+    UAPP_COMPOSED_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
+    UAPP_COMPOSED_GETTER_SPAN_WRAPPER(
+        NodeId, getNodesToRegister, nodesToRegister, nodesToRegisterSize
+    )
+};
+
+/**
+ * UA_RegisterNodesResponse wrapper class.
+ * @ingroup TypeWrapper
+ */
+class RegisterNodesResponse
+    : public TypeWrapper<UA_RegisterNodesResponse, UA_TYPES_REGISTERNODESRESPONSE> {
+public:
+    using TypeWrapperBase::TypeWrapperBase;
+
+    UAPP_COMPOSED_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
+    UAPP_COMPOSED_GETTER_SPAN_WRAPPER(
+        NodeId, getRegisteredNodeIds, registeredNodeIds, registeredNodeIdsSize
+    )
+};
+
+/**
+ * UA_UnregisterNodesRequest wrapper class.
+ * @ingroup TypeWrapper
+ */
+class UnregisterNodesRequest
+    : public TypeWrapper<UA_UnregisterNodesRequest, UA_TYPES_UNREGISTERNODESREQUEST> {
+public:
+    using TypeWrapperBase::TypeWrapperBase;
+
+    UnregisterNodesRequest(RequestHeader requestHeader, Span<const NodeId> nodesToUnregister);
+
+    UAPP_COMPOSED_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
+    UAPP_COMPOSED_GETTER_SPAN_WRAPPER(
+        NodeId, getNodesToUnregister, nodesToUnregister, nodesToUnregisterSize
+    )
+};
+
+/**
+ * UA_UnregisterNodesResponse wrapper class.
+ * @ingroup TypeWrapper
+ */
+class UnregisterNodesResponse
+    : public TypeWrapper<UA_UnregisterNodesResponse, UA_TYPES_UNREGISTERNODESRESPONSE> {
+public:
+    using TypeWrapperBase::TypeWrapperBase;
+
+    UAPP_COMPOSED_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
+};
+
+/**
  * UA_ReadValueId wrapper class.
  * @see https://reference.opcfoundation.org/Core/Part4/v105/docs/7.29
  * @ingroup TypeWrapper

--- a/src/services/View.cpp
+++ b/src/services/View.cpp
@@ -171,6 +171,18 @@ BrowsePathResult browseSimplifiedBrowsePath(
     return translateBrowsePathToNodeIds(serverOrClient, bp);
 }
 
+RegisterNodesResponse registerNodes(Client& client, const RegisterNodesRequest& request) {
+    RegisterNodesResponse response = UA_Client_Service_registerNodes(client.handle(), request);
+    detail::throwOnBadStatus(response->responseHeader.serviceResult);
+    return response;
+}
+
+UnregisterNodesResponse unregisterNodes(Client& client, const UnregisterNodesRequest& request) {
+    UnregisterNodesResponse response = UA_Client_Service_unregisterNodes(client.handle(), request);
+    detail::throwOnBadStatus(response->responseHeader.serviceResult);
+    return response;
+}
+
 // explicit template instantiations
 // clang-format off
 

--- a/src/types/Composed.cpp
+++ b/src/types/Composed.cpp
@@ -255,6 +255,20 @@ TranslateBrowsePathsToNodeIdsRequest::TranslateBrowsePathsToNodeIdsRequest(
     copyArray(browsePaths, &handle()->browsePaths, handle()->browsePathsSize);
 }
 
+RegisterNodesRequest::RegisterNodesRequest(
+    RequestHeader requestHeader, Span<const NodeId> nodesToRegister
+) {
+    assign(std::move(requestHeader), handle()->requestHeader);
+    copyArray(nodesToRegister, &handle()->nodesToRegister, handle()->nodesToRegisterSize);
+}
+
+UnregisterNodesRequest::UnregisterNodesRequest(
+    RequestHeader requestHeader, Span<const NodeId> nodesToUnregister
+) {
+    assign(std::move(requestHeader), handle()->requestHeader);
+    copyArray(nodesToUnregister, &handle()->nodesToUnregister, handle()->nodesToUnregisterSize);
+}
+
 ReadValueId::ReadValueId(
     NodeId nodeId, AttributeId attributeId, std::string_view indexRange, QualifiedName dataEncoding
 ) {

--- a/tests/Services.cpp
+++ b/tests/Services.cpp
@@ -475,6 +475,16 @@ TEST_CASE("View service set (server & client)") {
     SUBCASE("Server") { testBrowse(server); };
     SUBCASE("Client") { testBrowse(client); };
     // clang-format on
+
+    SUBCASE("Register/unregister nodes") {
+        const auto response = services::registerNodes(
+            client, RegisterNodesRequest({}, {{1, 1000}})
+        );
+        CHECK(response.getRegisteredNodeIds().size() == 1);
+        CHECK(response.getRegisteredNodeIds()[0] == NodeId(1, 1000));
+
+        CHECK_NOTHROW(services::unregisterNodes(client, UnregisterNodesRequest({}, {{1, 1000}})));
+    }
 }
 
 TEST_CASE("View service set (server)") {

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -1027,6 +1027,20 @@ TEST_CASE("TranslateBrowsePathsToNodeIdsRequest") {
     CHECK(request.getBrowsePaths().empty());
 }
 
+TEST_CASE("RegisterNodesRequest") {
+    const RegisterNodesRequest request({}, {{1, 1000}});
+    CHECK_NOTHROW(request.getRequestHeader());
+    CHECK(request.getNodesToRegister().size() == 1);
+    CHECK(request.getNodesToRegister()[0] == NodeId(1, 1000));
+}
+
+TEST_CASE("UnregisterNodesRequest") {
+    const UnregisterNodesRequest request({}, {{1, 1000}});
+    CHECK_NOTHROW(request.getRequestHeader());
+    CHECK(request.getNodesToUnregister().size() == 1);
+    CHECK(request.getNodesToUnregister()[0] == NodeId(1, 1000));
+}
+
 TEST_CASE("ReadValueId") {
     const ReadValueId rvid(NodeId(1, 1000), AttributeId::Value);
     CHECK(rvid.getNodeId() == NodeId(1, 1000));

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -960,6 +960,13 @@ TEST_CASE("DeleteReferencesItem / DeleteReferencesRequest") {
     CHECK(request.getReferencesToDelete().size() == 1);
 }
 
+TEST_CASE("ViewDescription") {
+    const ViewDescription vd({1, 1000}, 12345U, 2U);
+    CHECK(vd.getViewId() == NodeId(1, 1000));
+    CHECK(vd.getTimestamp() == 12345U);
+    CHECK(vd.getViewVersion() == 2U);
+}
+
 TEST_CASE("BrowseDescription") {
     const BrowseDescription bd(NodeId(1, 1000), BrowseDirection::Forward);
     CHECK(bd.getNodeId() == NodeId(1, 1000));
@@ -991,10 +998,33 @@ TEST_CASE("RelativePath") {
 
 TEST_CASE("BrowsePath") {
     const BrowsePath bp(
-        {0, UA_NS0ID_OBJECTSFOLDER}, {{ReferenceTypeId::HasComponent, false, false, {0, "child"}}}
+        ObjectId::ObjectsFolder, {{ReferenceTypeId::HasComponent, false, false, {0, "child"}}}
     );
     CHECK(bp.getStartingNode() == NodeId(0, UA_NS0ID_OBJECTSFOLDER));
     CHECK(bp.getRelativePath().getElements().size() == 1);
+}
+
+TEST_CASE("BrowseRequest") {
+    const BrowseRequest request({}, {{1, 1000}, {}, 1}, 11U, {});
+    CHECK_NOTHROW(request.getRequestHeader());
+    CHECK(request.getView().getViewId() == NodeId(1, 1000));
+    CHECK(request.getView().getViewVersion() == 1);
+    CHECK(request.getRequestedMaxReferencesPerNode() == 11U);
+    CHECK(request.getNodesToBrowse().empty());
+}
+
+TEST_CASE("BrowseNextRequest") {
+    const BrowseNextRequest request({}, true, {ByteString("123")});
+    CHECK_NOTHROW(request.getRequestHeader());
+    CHECK(request.getReleaseContinuationPoints() == true);
+    CHECK(request.getContinuationPoints().size() == 1);
+    CHECK(request.getContinuationPoints()[0] == ByteString("123"));
+}
+
+TEST_CASE("TranslateBrowsePathsToNodeIdsRequest") {
+    const TranslateBrowsePathsToNodeIdsRequest request({}, {});
+    CHECK_NOTHROW(request.getRequestHeader());
+    CHECK(request.getBrowsePaths().empty());
 }
 
 TEST_CASE("ReadValueId") {


### PR DESCRIPTION
Expose raw view services (client only):

- `services::browse`
- `services::browseNext`
- `services::translateBrowsePathsToNodeIds`
- `services::registerNodes`
- `services::unregisterNodes`