### PR TITLE
perf: variant setter for natives and wrappers

### DIFF
--- a/include/open62541pp/TypeConverter.h
+++ b/include/open62541pp/TypeConverter.h
@@ -85,12 +85,6 @@ constexpr const UA_DataType& guessDataType() {
     return detail::getDataType(typeIndex);
 }
 
-template <typename It>
-constexpr const UA_DataType& guessDataTypeFromIterator() {
-    using ValueType = typename std::iterator_traits<It>::value_type;
-    return guessDataType<ValueType>();
-}
-
 /* ------------------------------------- Converter functions ------------------------------------ */
 
 /// Convert and copy from native type.
@@ -172,7 +166,7 @@ template <typename InputIt>
     using ValueType = typename std::iterator_traits<InputIt>::value_type;
     using NativeType = typename TypeConverter<ValueType>::NativeType;
     const size_t size = std::distance(first, last);
-    auto* result = allocNativeArray<NativeType>(size, guessDataTypeFromIterator<InputIt>());
+    auto* result = allocNativeArray<NativeType>(size, guessDataType<ValueType>());
     for (size_t i = 0; i < size; ++i) {
         TypeConverter<ValueType>::toNative(*first++, result[i]);  // NOLINT
     }

--- a/include/open62541pp/TypeConverter.h
+++ b/include/open62541pp/TypeConverter.h
@@ -214,8 +214,9 @@ struct TypeConverterNative {
 };
 
 template <typename T>
-inline constexpr bool isNativeType =
-    std::is_same_v<typename TypeConverter<T>::ValueType, typename TypeConverter<T>::NativeType>;
+inline constexpr bool isNativeType = std::is_same_v<
+    typename TypeConverter<UnqualifiedT<T>>::ValueType,
+    typename TypeConverter<UnqualifiedT<T>>::NativeType>;
 
 }  // namespace detail
 

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -432,8 +432,8 @@ void Variant::setArray(Span<T> array, const UA_DataType& dataType) noexcept {
 
 template <typename T>
 void Variant::setArrayCopy(Span<T> array) {
-    assertNoVariant<T>();
-    if constexpr (detail::isBuiltinType<T>) {
+    if constexpr (isConvertibleToNative<T>()) {
+        assertNoVariant<T>();
         setArrayCopyImpl(array.data(), array.size(), detail::guessDataType<T>());
     } else {
         setArrayCopy(array.begin(), array.end());

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -454,7 +454,7 @@ void Variant::setArrayCopy(InputIt first, InputIt last) {
     setArrayImpl(
         detail::toNativeArrayAlloc(first, last),
         std::distance(first, last),
-        detail::guessDataTypeFromIterator<InputIt>(),
+        detail::guessDataType<ValueType>(),
         true  // move ownership
     );
 }

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -218,15 +218,14 @@ public:
 
 private:
     template <typename T>
-    static constexpr bool isConvertibleToNative() {
-        // TypeWrapper<T> is pointer-interconvertible with T
+    static constexpr bool isPointerInterconvertibleWithNative() {
         return detail::isNativeType<T> || detail::isTypeWrapper<T>;
     }
 
     template <typename T>
     static constexpr void assertGetNoCopy() {
         static_assert(
-            isConvertibleToNative<T>(),
+            isPointerInterconvertibleWithNative<T>(),
             "Template type must be a native or wrapper type to get scalar/array without copy"
         );
     }
@@ -234,7 +233,7 @@ private:
     template <typename T>
     static constexpr void assertSetNoCopy() {
         static_assert(
-            isConvertibleToNative<T>(),
+            isPointerInterconvertibleWithNative<T>(),
             "Template type must be a native or wrapper type to assign scalar/array without copy"
         );
     }
@@ -278,7 +277,7 @@ private:
 template <typename T>
 Variant Variant::fromScalar(T& value) {
     Variant variant;
-    if constexpr (isConvertibleToNative<T>()) {
+    if constexpr (isPointerInterconvertibleWithNative<T>()) {
         variant.setScalar(value);
     } else {
         variant.setScalarCopy(value);
@@ -310,7 +309,7 @@ Variant Variant::fromScalar(const T& value, const UA_DataType& dataType) {
 template <typename T>
 Variant Variant::fromArray(Span<T> array) {
     Variant variant;
-    if constexpr (isConvertibleToNative<T>()) {
+    if constexpr (isPointerInterconvertibleWithNative<T>()) {
         variant.setArray(array);
     } else {
         variant.setArrayCopy(array);
@@ -408,7 +407,7 @@ void Variant::setScalar(T& value, const UA_DataType& dataType) noexcept {
 template <typename T>
 void Variant::setScalarCopy(const T& value) {
     assertNoVariant<T>();
-    if constexpr (isConvertibleToNative<T>()) {
+    if constexpr (isPointerInterconvertibleWithNative<T>()) {
         setScalarCopyImpl(&value, detail::guessDataType<T>());
     } else {
         setScalarCopyConvertImpl(value);
@@ -437,7 +436,7 @@ void Variant::setArray(Span<T> array, const UA_DataType& dataType) noexcept {
 
 template <typename T>
 void Variant::setArrayCopy(Span<T> array) {
-    if constexpr (isConvertibleToNative<T>()) {
+    if constexpr (isPointerInterconvertibleWithNative<T>()) {
         assertNoVariant<T>();
         setArrayCopyImpl(array.data(), array.size(), detail::guessDataType<T>());
     } else {


### PR DESCRIPTION
Improve `Variant::setScalarCopy` and `Variant::setArrayCopy` performance for native and wrapper types.