### PR TITLE
feat: templated Variant::isType overload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `TypeRegistry<T>` to derive the corresponding `UA_DataType` object from template types.
-  Custom data types can be registered with template specializations.
+  Custom data types can be registered with template specializations. (#136)
+- Check `Variant` data type by template type, e.g. `var.isType<int>()` (#139)
 
 ### Changed
 
 - Deprecate `TypeIndexList` (`TypeConverter::ValidTypes`) because it's not required anymore.
   Just remove `TypeConverter<T>::ValidTypes` from your template specializations.
-  The type index / `UA_DataType` is retrieved from the `TypeRegistry<NativeType>` specialization.
+  The `UA_DataType` is retrieved from the `TypeRegistry<NativeType>` specialization. (#136)
 
 ## [0.11.0] - 2023-11-01
 

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -138,21 +138,27 @@ public:
         return variant;
     }
 
-    /// Check if variant is empty.
+    /// Check if the variant is empty.
     bool isEmpty() const noexcept;
-    /// Check if variant is a scalar.
+    /// Check if the variant is a scalar.
     bool isScalar() const noexcept;
-    /// Check if variant is an array.
+    /// Check if the variant is an array.
     bool isArray() const noexcept;
 
-    /// Check if variant type is equal to data type.
+    /// Check if the variant type is equal to the provided data type.
     bool isType(const UA_DataType* dataType) const noexcept;
-    /// Check if variant type is equal to data type.
+    /// Check if the variant type is equal to the provided data type.
     bool isType(const UA_DataType& dataType) const noexcept;
-    /// Check if variant type is equal to type enum.
+    /// Check if the variant type is equal to the provided type enum.
     bool isType(Type type) const noexcept;
-    /// Check if variant type is equal to data type node id.
+    /// Check if the variant type is equal to the provided data type node id.
     bool isType(const NodeId& id) const noexcept;
+
+    /// Check if the variant type is equal to the provided template type.
+    template <typename T>
+    bool isType() const noexcept {
+        return isType(detail::getDataType<T>());
+    }
 
     /// Get data type.
     const UA_DataType* getDataType() const noexcept;

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -424,6 +424,7 @@ TEST_CASE("Variant") {
         CHECK_FALSE(var.isType(UA_TYPES[UA_TYPES_STRING]));
         CHECK_FALSE(var.isType(DataTypeId::String));
         CHECK_FALSE(var.isType(Type::String));
+        CHECK_FALSE(var.isType<String>());
         CHECK(var.getDataType() == nullptr);
         CHECK(var.getVariantType() == std::nullopt);
 
@@ -431,6 +432,7 @@ TEST_CASE("Variant") {
         CHECK(var.isType(UA_TYPES[UA_TYPES_STRING]));
         CHECK(var.isType(DataTypeId::String));
         CHECK(var.isType(Type::String));
+        CHECK(var.isType<String>());
         CHECK(var.getDataType() == &UA_TYPES[UA_TYPES_STRING]);
         CHECK(var.getVariantType().value() == Type::String);
     }


### PR DESCRIPTION
Check variant type by template type, e.g. `variant.isType<int>()`.