### PR TITLE
feat: expose getDataType

### DIFF
--- a/include/open62541pp/DataTypeBuilder.h
+++ b/include/open62541pp/DataTypeBuilder.h
@@ -126,7 +126,7 @@ public:
      */
     template <auto U::*memberUnion, typename TField>
     auto& addUnionField(const char* fieldName) {
-        return addUnionField<memberUnion, TField>(fieldName, detail::getDataType<TField>());
+        return addUnionField<memberUnion, TField>(fieldName, getDataType<TField>());
     }
 
     /**

--- a/include/open62541pp/Node.h
+++ b/include/open62541pp/Node.h
@@ -533,7 +533,7 @@ public:
     /// @return Current node instance to chain multiple methods (fluent interface)
     template <typename T>
     Node& writeDataType() {
-        return writeDataType(asWrapper<NodeId>(detail::getDataType<T>().typeId));
+        return writeDataType(asWrapper<NodeId>(getDataType<T>().typeId));
     }
 
     /// @copydoc services::writeValueRank

--- a/include/open62541pp/TypeRegistry.h
+++ b/include/open62541pp/TypeRegistry.h
@@ -42,18 +42,18 @@ struct IsRegisteredType<T, std::void_t<decltype(TypeRegistry<T>{})>> : std::true
 template <typename T>
 inline constexpr bool isRegisteredType = IsRegisteredType<T>::value;
 
+}  // namespace detail
+
 template <typename T>
 inline const UA_DataType& getDataType() noexcept {
     using ValueType = typename std::remove_cv_t<T>;
     static_assert(
-        isRegisteredType<ValueType>,
+        detail::isRegisteredType<ValueType>,
         "The provided template type is not registered. "
         "Specify the data type manually or add a template specialization for TypeRegistry."
     );
     return TypeRegistry<ValueType>::getDataType();
 }
-
-}  // namespace detail
 
 /* ---------------------------------- Template specializations ---------------------------------- */
 

--- a/include/open62541pp/detail/helper.h
+++ b/include/open62541pp/detail/helper.h
@@ -122,27 +122,6 @@ template <typename T>
     }
 }
 
-/* ------------------------------------------ Data type ----------------------------------------- */
-
-/// Get UA_DataType by type index or enum (template parameter).
-template <auto typeIndexOrEnum>
-inline const UA_DataType& getDataType() noexcept {
-    constexpr auto typeIndex = static_cast<TypeIndex>(typeIndexOrEnum);
-    static_assert(typeIndex < UA_TYPES_COUNT);
-    return UA_TYPES[typeIndex];  // NOLINT
-}
-
-/// Get UA_DataType by type index.
-inline const UA_DataType& getDataType(TypeIndex typeIndex) noexcept {
-    assert(typeIndex < UA_TYPES_COUNT);
-    return UA_TYPES[typeIndex];  // NOLINT
-}
-
-/// Get UA_DataType by type enum.
-inline const UA_DataType& getDataType(Type type) noexcept {
-    return getDataType(static_cast<TypeIndex>(type));
-}
-
 /* ---------------------------------------- String utils ---------------------------------------- */
 
 /// Convert std::string_view to UA_String (no copy)

--- a/include/open62541pp/types/Composed.h
+++ b/include/open62541pp/types/Composed.h
@@ -227,7 +227,7 @@ public:
 #define UAPP_NODEATTR_ARRAY(Type, suffix, member, memberSize, flag)                                \
     UAPP_COMPOSED_GETTER_SPAN(Type, get##suffix, member, memberSize)                               \
     auto& set##suffix(Span<const Type> member) {                                                   \
-        const auto& dataType = detail::getDataType<Type>();                                        \
+        const auto& dataType = opcua::getDataType<Type>();                                         \
         handle()->specifiedAttributes |= flag;                                                     \
         detail::deallocateArray(handle()->member, handle()->memberSize, dataType);                 \
         handle()->member = detail::copyArray(member.data(), member.size(), dataType);              \
@@ -305,7 +305,7 @@ public:
     /// Deduce the `dataType` from the template type.
     template <typename T>
     auto& setDataType() {
-        return setDataType(asWrapper<NodeId>(detail::getDataType<T>().typeId));
+        return setDataType(asWrapper<NodeId>(opcua::getDataType<T>().typeId));
     }
 
     UAPP_NODEATTR_CAST(ValueRank, ValueRank, valueRank, UA_NODEATTRIBUTESMASK_VALUERANK)
@@ -392,7 +392,7 @@ public:
     /// Deduce the `dataType` from the template type.
     template <typename T>
     auto& setDataType() {
-        return setDataType(asWrapper<NodeId>(detail::getDataType<T>().typeId));
+        return setDataType(asWrapper<NodeId>(opcua::getDataType<T>().typeId));
     }
 
     UAPP_NODEATTR_CAST(ValueRank, ValueRank, valueRank, UA_NODEATTRIBUTESMASK_VALUERANK)

--- a/include/open62541pp/types/ExtensionObject.h
+++ b/include/open62541pp/types/ExtensionObject.h
@@ -47,7 +47,7 @@ public:
     /// @param data Decoded data
     template <typename T>
     [[nodiscard]] static ExtensionObject fromDecoded(T& data) noexcept {
-        return fromDecoded(&data, detail::getDataType<T>());
+        return fromDecoded(&data, getDataType<T>());
     }
 
     /// Create an ExtensionObject from a decoded object (assign).
@@ -62,7 +62,7 @@ public:
     /// @param data Decoded data
     template <typename T>
     [[nodiscard]] static ExtensionObject fromDecodedCopy(const T& data) {
-        return fromDecodedCopy(&data, detail::getDataType<T>());
+        return fromDecodedCopy(&data, getDataType<T>());
     }
 
     /// Create an ExtensionObject from a decoded object (copy).
@@ -94,7 +94,7 @@ public:
     /// ExtensionObject is either encoded or the decoded data not of type `T`.
     template <typename T>
     T* getDecodedData() noexcept {
-        if (getDecodedDataType() == &detail::getDataType<T>()) {
+        if (getDecodedDataType() == &getDataType<T>()) {
             return static_cast<T*>(getDecodedData());
         }
         return nullptr;
@@ -103,7 +103,7 @@ public:
     /// @copydoc getDecodedData
     template <typename T>
     const T* getDecodedData() const noexcept {
-        if (getDecodedDataType() == &detail::getDataType<T>()) {
+        if (getDecodedDataType() == &getDataType<T>()) {
             return static_cast<const T*>(getDecodedData());
         }
         return nullptr;

--- a/include/open62541pp/types/NodeId.h
+++ b/include/open62541pp/types/NodeId.h
@@ -53,7 +53,7 @@ public:
 
     /// Create NodeId from Type (type id).
     NodeId(Type type) noexcept  // NOLINT, implicit wanted
-        : NodeId(detail::getDataType(type).typeId) {}
+        : NodeId(UA_TYPES[static_cast<TypeIndex>(type)].typeId) {}  // NOLINT
 
     /// Create NodeId from DataTypeId.
     NodeId(DataTypeId id) noexcept  // NOLINT, implicit wanted

--- a/src/types/Composed.cpp
+++ b/src/types/Composed.cpp
@@ -40,9 +40,9 @@ template <typename T, typename Native>
 static void assignArray(Span<const T> src, Native*& dst, size_t& dstSize) {
     static_assert(sizeof(T) == sizeof(Native));
     if constexpr (detail::isTypeWrapper<T>) {
-        dst = detail::copyArray(asNative(src.data()), src.size(), detail::getDataType<T>());
+        dst = detail::copyArray(asNative(src.data()), src.size(), getDataType<T>());
     } else {
-        dst = detail::copyArray(src.data(), src.size(), detail::getDataType<T>());
+        dst = detail::copyArray(src.data(), src.size(), getDataType<T>());
     }
     dstSize = src.size();
 }

--- a/src/types/Variant.cpp
+++ b/src/types/Variant.cpp
@@ -34,7 +34,7 @@ bool Variant::isType(const UA_DataType& dataType) const noexcept {
 }
 
 bool Variant::isType(Type type) const noexcept {
-    return isType(&detail::getDataType(type));
+    return isType(UA_TYPES[static_cast<TypeIndex>(type)]);  // NOLINT
 }
 
 bool Variant::isType(const NodeId& id) const noexcept {

--- a/tests/TypeRegistry.cpp
+++ b/tests/TypeRegistry.cpp
@@ -28,24 +28,24 @@ TEST_CASE("TypeRegistry") {
         CHECK_FALSE(detail::isRegisteredType<float&>);
 
         CHECK(&TypeRegistry<float>::getDataType() == &UA_TYPES[UA_TYPES_FLOAT]);
-        CHECK(&detail::getDataType<float>() == &UA_TYPES[UA_TYPES_FLOAT]);
-        CHECK(&detail::getDataType<const volatile float>() == &UA_TYPES[UA_TYPES_FLOAT]);
+        CHECK(&getDataType<float>() == &UA_TYPES[UA_TYPES_FLOAT]);
+        CHECK(&getDataType<const volatile float>() == &UA_TYPES[UA_TYPES_FLOAT]);
     }
 
     SUBCASE("Generated") {
         CHECK(&TypeRegistry<UA_AddNodesItem>::getDataType() == &UA_TYPES[UA_TYPES_ADDNODESITEM]);
-        CHECK(&detail::getDataType<UA_AddNodesItem>() == &UA_TYPES[UA_TYPES_ADDNODESITEM]);
+        CHECK(&getDataType<UA_AddNodesItem>() == &UA_TYPES[UA_TYPES_ADDNODESITEM]);
     }
 
     SUBCASE("TypeWrapper") {
         class Wrapper : public TypeWrapper<float, UA_TYPES_FLOAT> {};
 
         CHECK(&TypeRegistry<Wrapper>::getDataType() == &UA_TYPES[UA_TYPES_FLOAT]);
-        CHECK(&detail::getDataType<Wrapper>() == &UA_TYPES[UA_TYPES_FLOAT]);
+        CHECK(&getDataType<Wrapper>() == &UA_TYPES[UA_TYPES_FLOAT]);
     }
 
     SUBCASE("Custom") {
         CHECK(&TypeRegistry<Custom>::getDataType() == &UA_TYPES[UA_TYPES_STRING]);
-        CHECK(&detail::getDataType<Custom>() == &UA_TYPES[UA_TYPES_STRING]);
+        CHECK(&getDataType<Custom>() == &UA_TYPES[UA_TYPES_STRING]);
     }
 }

--- a/tests/helper.cpp
+++ b/tests/helper.cpp
@@ -49,14 +49,6 @@ TEST_CASE("Allocate array as unique_ptr") {
     CHECK(ptr.get() != nullptr);
 }
 
-TEST_CASE("getDataType") {
-    const auto* expected = &UA_TYPES[UA_TYPES_BOOLEAN];
-    CHECK(&detail::getDataType(UA_TYPES_BOOLEAN) == expected);
-    CHECK(&detail::getDataType(Type::Boolean) == expected);
-    CHECK(&detail::getDataType<UA_TYPES_BOOLEAN>() == expected);
-    CHECK(&detail::getDataType<Type::Boolean>() == expected);
-}
-
 TEST_CASE("UA_String from string_view") {
     SUBCASE("Test string") {
         std::string_view sv("test123");


### PR DESCRIPTION
Retrieve the data type (`UA_DataType`) by the provided template type.
Types must be registered with `TypeRegistry` specializations.

Example:

```cpp
auto& dt = opcua::getDataType<int32_t>();
assert(&dt == &UA_TYPES[UA_TYPES_INT32]);
```