### PR TITLE
feat: add logger to constructor of Client

### DIFF
--- a/include/open62541pp/Client.h
+++ b/include/open62541pp/Client.h
@@ -46,7 +46,7 @@ public:
      * @param logger Custom log function. If the passed function is empty, the default logger is
      * used.
      */
-    Client(Logger logger = nullptr);
+    explicit Client(Logger logger = nullptr);
 
 #ifdef UA_ENABLE_ENCRYPTION
     /**

--- a/include/open62541pp/Client.h
+++ b/include/open62541pp/Client.h
@@ -43,8 +43,10 @@ public:
      * Create client with default configuration (no encryption).
      * Security policies:
      * - [None](http://opcfoundation.org/UA/SecurityPolicy#None)
+     * @param logger Custom log function. If the passed function is empty, the default logger is
+     * used.
      */
-    Client();
+    Client(Logger logger = nullptr);
 
 #ifdef UA_ENABLE_ENCRYPTION
     /**

--- a/tests/Client.cpp
+++ b/tests/Client.cpp
@@ -17,6 +17,13 @@ using namespace opcua;
 
 constexpr std::string_view localServerUrl{"opc.tcp://localhost:4840"};
 
+TEST_CASE("Client with custom logger") {
+    bool gotMessage = false;
+    Client client([&gotMessage](auto&&...) { gotMessage = true; });
+    log(client, LogLevel::Error, LogCategory::Client, "Message");
+    CHECK(gotMessage);
+}
+
 TEST_CASE("Client discovery") {
     Server server;
     ServerRunner serverRunner(server);


### PR DESCRIPTION
Allows constructing the Client directly with a custom logger. 
See #149  and #150 