### PR TITLE
feat!: remove deprecated functions to read/write attributes

### DIFF
--- a/include/open62541pp/Node.h
+++ b/include/open62541pp/Node.h
@@ -337,21 +337,9 @@ public:
         return services::readDataValue(connection_, nodeId_);
     }
 
-    /// @copydoc services::readDataValue
-    [[deprecated("No performance benefit to pass DataValue by reference, return by value instead")]]
-    void readDataValue(DataValue& value) {
-        value = services::readDataValue(connection_, nodeId_);
-    }
-
     /// @copydoc services::readValue
     Variant readValue() {
         return services::readValue(connection_, nodeId_);
-    }
-
-    /// @copydoc services::readValue
-    [[deprecated("No performance benefit to pass Variant by reference, return by value instead")]]
-    void readValue(Variant& value) {
-        value = services::readValue(connection_, nodeId_);
     }
 
     /// Read scalar value from variable node.
@@ -360,24 +348,10 @@ public:
         return readValue().template getScalarCopy<T>();
     }
 
-    /// @copydoc readValueScalar
-    template <typename T>
-    [[deprecated("Use Node::readValueScalar<T>() instead")]]
-    T readScalar() {
-        return readValueScalar<T>();
-    }
-
     /// Read array value from variable node.
     template <typename T>
     std::vector<T> readValueArray() {
         return readValue().template getArrayCopy<T>();
-    }
-
-    /// @copydoc readValueArray
-    template <typename T>
-    [[deprecated("Use Node::readValueArray<T>() instead")]]
-    std::vector<T> readArray() {
-        return readValueArray<T>();
     }
 
     /// @copydoc services::readDataType
@@ -487,13 +461,6 @@ public:
         return *this;
     }
 
-    /// @copydoc writeValueScalar
-    template <typename T>
-    [[deprecated("Use Node::writeValueScalar instead")]]
-    Node& writeScalar(const T& value) {
-        return writeValueScalar<T>(value);
-    }
-
     /// Write array value to variable node.
     /// @return Current node instance to chain multiple methods (fluent interface)
     template <typename T>
@@ -514,13 +481,6 @@ public:
     Node& writeValueArray(InputIt first, InputIt last) {
         writeValue(Variant::fromArray(first, last));
         return *this;
-    }
-
-    /// @copydoc  writeValueArray
-    template <typename... Args>
-    [[deprecated("Use Node::writeValueArray instead")]]
-    Node& writeArray(Args&&... args) {
-        return writeValueArray(std::forward<Args>(args)...);
     }
 
     /// @copydoc services::writeDataType

--- a/include/open62541pp/services/Attribute.h
+++ b/include/open62541pp/services/Attribute.h
@@ -207,13 +207,6 @@ inline DataValue readDataValue(T& serverOrClient, const NodeId& id) {
     return readAttribute(serverOrClient, id, AttributeId::Value, TimestampsToReturn::Both);
 }
 
-/// @copydoc readDataValue
-template <typename T>
-[[deprecated("No performance benefit to pass DataValue by reference, return by value instead")]]
-inline void readDataValue(T& serverOrClient, const NodeId& id, DataValue& value) {
-    value = readDataValue(serverOrClient, id);
-}
-
 /**
  * Read the `Value` attribute of a variable node as a Variant object.
  */
@@ -221,13 +214,6 @@ template <typename T>
 inline Variant readValue(T& serverOrClient, const NodeId& id) {
     DataValue dv = readAttribute(serverOrClient, id, AttributeId::Value);
     return std::move(dv.getValue());
-}
-
-/// @copydoc readValue
-template <typename T>
-[[deprecated("No performance benefit to pass Variant by reference, return by value instead.")]]
-inline void readValue(T& serverOrClient, const NodeId& id, Variant& value) {
-    value = readValue(serverOrClient, id);
 }
 
 /**


### PR DESCRIPTION
Remove functions that have been deprecated 6 months ago:

- `Node::readDataValue(DataValue&)`, use `Node::readDataValue()` instead
- `Node::readValue(DataValue&)`, use `Node::readValue()` instead
- `Node::readScalar<T>()`, use `Node::readValueScalar<T>()` instead
- `Node::readArray<T>()`, use `Node::readValueArray<T>()` instead
- `services::readDataValue(T&, const NodeId&, DataValue&)`, use `services::readDataValue(T&, const NodeId&)` instead
- `services::readValue(T&, const NodeId&, Variant&)`, use `services::readValue(T&, const NodeId&)` instead