### PR TITLE
fix: Variant::setArrayCopy

### DIFF
--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -623,6 +623,26 @@ TEST_CASE("Variant") {
         var.setArrayCopy<const int>({1, 2, 3});  // TODO: avoid manual template types
     }
 
+    SUBCASE("Set/get array with std::vector<bool> (copy") {
+        // std::vector<bool> is a possibly space optimized template specialization which caused
+        // several problems. (See https://github.com/open62541pp/open62541pp/issues/164)
+        Variant var;
+        std::vector<bool> array{true, false, true};
+
+        SUBCASE("Copy from iterator") {
+            var.setArrayCopy(array.begin(), array.end());
+        }
+
+        SUBCASE("Copy directly") {
+            var.setArrayCopy(array);
+        }
+
+        CHECK(var.isType(Type::Boolean));
+        CHECK(var.getArrayLength() == array.size());
+
+        CHECK(var.getArrayCopy<bool>() == array);
+    }
+
     SUBCASE("Set/get non-builtin data types") {
         using CustomType = UA_WriteValue;
         const auto& dt = UA_TYPES[UA_TYPES_WRITEVALUE];


### PR DESCRIPTION
This PR fixes some problems that can be observed, when using one of the following overloads with `std::vector<bool>` due to its specialization.

1. `void setArrayCopy(ArrayLike&& array)`
2. `void setArrayCopy(ArrayLike&& array, const UA_DataType& dataType)`
3. `void setArrayCopy(InputIt first, InputIt last)`
4. `void setArrayCopy(InputIt first, InputIt last, const UA_DataType& dataType)`

See #164 for details.