### PR TITLE
feat: read/write attributes ContainsNoLoops, EventNotifier, Historizing, Executable, UserExecutable

### DIFF
--- a/include/open62541pp/Node.h
+++ b/include/open62541pp/Node.h
@@ -385,6 +385,16 @@ public:
         return services::readInverseName(connection_, nodeId_);
     }
 
+    /// @copydoc services::readContainsNoLoops
+    bool readContainsNoLoops() {
+        return services::readContainsNoLoops(connection_, nodeId_);
+    }
+
+    /// @copydoc services::readEventNotifier
+    Bitmask<EventNotifier> readEventNotifier() {
+        return services::readEventNotifier(connection_, nodeId_);
+    }
+
     /// @copydoc services::readDataValue
     DataValue readDataValue() {
         return services::readDataValue(connection_, nodeId_);
@@ -435,6 +445,21 @@ public:
     /// @copydoc services::readMinimumSamplingInterval
     double readMinimumSamplingInterval() {
         return services::readMinimumSamplingInterval(connection_, nodeId_);
+    }
+
+    /// @copydoc services::readHistorizing
+    bool readHistorizing() {
+        return services::readHistorizing(connection_, nodeId_);
+    }
+
+    /// @copydoc services::readExecutable
+    bool readExecutable() {
+        return services::readExecutable(connection_, nodeId_);
+    }
+
+    /// @copydoc services::readUserExecutable
+    bool readUserExecutable() {
+        return services::readUserExecutable(connection_, nodeId_);
     }
 
     /// Read the value of an object property.
@@ -489,6 +514,20 @@ public:
     /// @return Current node instance to chain multiple methods (fluent interface)
     Node& writeInverseName(const LocalizedText& name) {
         services::writeInverseName(connection_, nodeId_, name);
+        return *this;
+    }
+
+    /// @copydoc services::writeContainsNoLoops
+    /// @return Current node instance to chain multiple methods (fluent interface)
+    Node& writeContainsNoLoops(bool containsNoLoops) {
+        services::writeContainsNoLoops(connection_, nodeId_, containsNoLoops);
+        return *this;
+    }
+
+    /// @copydoc services::writeEventNotifier
+    /// @return Current node instance to chain multiple methods (fluent interface)
+    Node& writeEventNotifier(Bitmask<EventNotifier> mask) {
+        services::writeEventNotifier(connection_, nodeId_, mask);
         return *this;
     }
 
@@ -585,6 +624,27 @@ public:
     /// @return Current node instance to chain multiple methods (fluent interface)
     Node& writeMinimumSamplingInterval(double milliseconds) {
         services::writeMinimumSamplingInterval(connection_, nodeId_, milliseconds);
+        return *this;
+    }
+
+    /// @copydoc services::writeHistorizing
+    /// @return Current node instance to chain multiple methods (fluent interface)
+    Node& writeHistorizing(bool historizing) {
+        services::writeHistorizing(connection_, nodeId_, historizing);
+        return *this;
+    }
+
+    /// @copydoc services::writeExecutable
+    /// @return Current node instance to chain multiple methods (fluent interface)
+    Node& writeExecutable(bool executable) {
+        services::writeExecutable(connection_, nodeId_, executable);
+        return *this;
+    }
+
+    /// @copydoc services::writeUserExecutable
+    /// @return Current node instance to chain multiple methods (fluent interface)
+    Node& writeUserExecutable(bool userExecutable) {
+        services::writeUserExecutable(connection_, nodeId_, userExecutable);
         return *this;
     }
 

--- a/include/open62541pp/services/Attribute.h
+++ b/include/open62541pp/services/Attribute.h
@@ -198,6 +198,22 @@ inline LocalizedText readInverseName(T& serverOrClient, const NodeId& id) {
 }
 
 /**
+ * Read the `ContainsNoLoops` attribute of a view node.
+ */
+template <typename T>
+inline bool readContainsNoLoops(T& serverOrClient, const NodeId& id) {
+    return readAttributeScalar<bool>(serverOrClient, id, AttributeId::ContainsNoLoops);
+}
+
+/**
+ * Read the `EventNotifier` attribute of an object or view node.
+ */
+template <typename T>
+inline Bitmask<EventNotifier> readEventNotifier(T& serverOrClient, const NodeId& id) {
+    return readAttributeScalar<uint8_t>(serverOrClient, id, AttributeId::EventNotifier);
+}
+
+/**
  * Read the `Value` attribute of a variable node as a DataValue object.
  */
 template <typename T>
@@ -282,6 +298,30 @@ inline double readMinimumSamplingInterval(T& serverOrClient, const NodeId& id) {
     return readAttributeScalar<double>(serverOrClient, id, AttributeId::MinimumSamplingInterval);
 }
 
+/**
+ * Read the `Historizing` attribute of a variable node.
+ */
+template <typename T>
+inline bool readHistorizing(T& serverOrClient, const NodeId& id) {
+    return readAttributeScalar<bool>(serverOrClient, id, AttributeId::Historizing);
+}
+
+/**
+ * Read the `Executable` attribute of a method node.
+ */
+template <typename T>
+inline bool readExecutable(T& serverOrClient, const NodeId& id) {
+    return readAttributeScalar<bool>(serverOrClient, id, AttributeId::Executable);
+}
+
+/**
+ * Read the `UserExecutable` attribute of a method node.
+ */
+template <typename T>
+inline bool readUserExecutable(T& serverOrClient, const NodeId& id) {
+    return readAttributeScalar<bool>(serverOrClient, id, AttributeId::UserExecutable);
+}
+
 /* ---------------------------------------------------------------------------------------------- */
 
 /**
@@ -348,6 +388,28 @@ inline void writeSymmetric(T& serverOrClient, const NodeId& id, bool symmetric) 
 template <typename T>
 inline void writeInverseName(T& serverOrClient, const NodeId& id, const LocalizedText& name) {
     writeAttribute(serverOrClient, id, AttributeId::InverseName, DataValue::fromScalar(name));
+}
+
+/**
+ * Write the `ContainsNoLoops` attribute of a view node.
+ * @copydetails readContainsNoLoops
+ */
+template <typename T>
+inline void writeContainsNoLoops(T& serverOrClient, const NodeId& id, bool containsNoLoops) {
+    writeAttribute(
+        serverOrClient, id, AttributeId::ContainsNoLoops, DataValue::fromScalar(containsNoLoops)
+    );
+}
+
+/**
+ * Write the `EventNotifier` attribute of an object or view node.
+ * @copydetails readEventNotifier
+ */
+template <typename T>
+inline void writeEventNotifier(T& serverOrClient, const NodeId& id, Bitmask<EventNotifier> mask) {
+    writeAttribute(
+        serverOrClient, id, AttributeId::EventNotifier, DataValue::fromScalar(mask.get())
+    );
 }
 
 /**
@@ -439,6 +501,37 @@ inline void writeMinimumSamplingInterval(T& serverOrClient, const NodeId& id, do
         id,
         AttributeId::MinimumSamplingInterval,
         DataValue::fromScalar(milliseconds)
+    );
+}
+
+/**
+ * Write the `Historizing` attribute of a variable node.
+ * @copydetails readHistorizing
+ */
+template <typename T>
+inline void writeHistorizing(T& serverOrClient, const NodeId& id, bool historizing) {
+    writeAttribute(
+        serverOrClient, id, AttributeId::Historizing, DataValue::fromScalar(historizing)
+    );
+}
+
+/**
+ * Write the `Executable` attribute of a method node.
+ * @copydetails readExecutable
+ */
+template <typename T>
+inline void writeExecutable(T& serverOrClient, const NodeId& id, bool executable) {
+    writeAttribute(serverOrClient, id, AttributeId::Executable, DataValue::fromScalar(executable));
+}
+
+/**
+ * Write the `UserExecutable` attribute of a method node.
+ * @copydetails readUserExecutable
+ */
+template <typename T>
+inline void writeUserExecutable(T& serverOrClient, const NodeId& id, bool userExecutable) {
+    writeAttribute(
+        serverOrClient, id, AttributeId::UserExecutable, DataValue::fromScalar(userExecutable)
     );
 }
 

--- a/tests/Node.cpp
+++ b/tests/Node.cpp
@@ -137,7 +137,7 @@ TEST_CASE("Node") {
             CHECK_EQ(objNode.browseParent(), rootNode);
         }
 
-        SUBCASE("Read/write variable attributes") {
+        SUBCASE("Read/write variable node attributes") {
             CHECK_EQ(
                 varNode.writeDisplayName({"en-US", "name"}).readDisplayName(),
                 LocalizedText({"en-US", "name"})
@@ -166,6 +166,7 @@ TEST_CASE("Node") {
             CHECK_EQ(
                 varNode.writeMinimumSamplingInterval(11.11).readMinimumSamplingInterval(), 11.11
             );
+            CHECK_EQ(varNode.writeHistorizing(true).readHistorizing(), true);
         }
 
         SUBCASE("Read/write value") {

--- a/tests/Services.cpp
+++ b/tests/Services.cpp
@@ -144,7 +144,7 @@ TEST_CASE("Attribute service set (server)") {
     Server server;
     const NodeId objectsId{0, UA_NS0ID_OBJECTSFOLDER};
 
-    SUBCASE("Read default attributes") {
+    SUBCASE("Read default variable node attributes") {
         const NodeId id{1, "testAttributes"};
         services::addVariable(server, objectsId, id, "testAttributes");
 
@@ -164,9 +164,10 @@ TEST_CASE("Attribute service set (server)") {
         const uint8_t adminUserAccessLevel = 0xFF;  // all bits set
         CHECK(services::readUserAccessLevel(server, id) == adminUserAccessLevel);
         CHECK(services::readMinimumSamplingInterval(server, id) == 0.0);
+        CHECK(services::readHistorizing(server, id) == false);
     }
 
-    SUBCASE("Read initial attributes") {
+    SUBCASE("Read initial variable node attributes") {
         VariableAttributes attr;
         attr.setDisplayName({"", "testAttributes"});
         attr.setDescription({"", "..."});
@@ -203,7 +204,19 @@ TEST_CASE("Attribute service set (server)") {
         );
     }
 
-    SUBCASE("Read/write node attributes") {
+    SUBCASE("Read/write object node attributes") {
+        const NodeId id{1, "testAttributes"};
+        services::addObject(server, objectsId, id, "testAttributes");
+
+        // write new attributes
+        const auto eventNotifier = EventNotifier::HistoryRead | EventNotifier::HistoryWrite;
+        CHECK_NOTHROW(services::writeEventNotifier(server, id, eventNotifier));
+
+        // read new attributes
+        CHECK(services::readEventNotifier(server, id).allOf(eventNotifier));
+    }
+
+    SUBCASE("Read/write variable node attributes") {
         const NodeId id{1, "testAttributes"};
         services::addVariable(server, objectsId, id, "testAttributes");
 
@@ -217,6 +230,7 @@ TEST_CASE("Attribute service set (server)") {
         const auto newAccessLevel = AccessLevel::CurrentRead | AccessLevel::CurrentWrite;
         CHECK_NOTHROW(services::writeAccessLevel(server, id, newAccessLevel));
         CHECK_NOTHROW(services::writeMinimumSamplingInterval(server, id, 10.0));
+        CHECK_NOTHROW(services::writeHistorizing(server, id, true));
 
         // read new attributes
         CHECK(services::readDisplayName(server, id) == LocalizedText("en-US", "newDisplayName"));
@@ -229,7 +243,22 @@ TEST_CASE("Attribute service set (server)") {
         CHECK(services::readArrayDimensions(server, id).at(1) == 2);
         CHECK(services::readAccessLevel(server, id) == newAccessLevel);
         CHECK(services::readMinimumSamplingInterval(server, id) == 10.0);
+        CHECK(services::readHistorizing(server, id) == true);
     }
+
+#ifdef UA_ENABLE_METHODCALLS
+    SUBCASE("Read/write method node attributes") {
+        const NodeId id{1, "testMethod"};
+        services::addMethod(server, objectsId, id, "testMethod", nullptr, {}, {});
+
+        // write new attributes
+        CHECK_NOTHROW(services::writeExecutable(server, id, true));
+
+        // read new attributes
+        CHECK(services::readExecutable(server, id));
+        CHECK(services::readUserExecutable(server, id));
+    }
+#endif
 
     SUBCASE("Read/write reference node attributes") {
         const NodeId id{0, UA_NS0ID_REFERENCES};


### PR DESCRIPTION
Add missing (specialized inline) functions to read/write following node attributes:

- `ContainsNoLoops`:
  - `services::readContainsNoLoops`
  - `services::writeContainsNoLoops`
  - `Node::readContainsNoLoops`
  - `Node::writeContainsNoLoops`

- `EventNotifier`:
  - `services::readEventNotifier`
  - `services::writeEventNotifier`
  - `Node::readEventNotifier`
  - `Node::writeEventNotifier`

- `Historizing`:
  - `services::readHistorizing`
  - `services::writeHistorizing`
  - `Node::readHistorizing`
  - `Node::writeHistorizing`

- `Executable`:
  - `services::readExecutable`
  - `services::writeExecutable`
  - `Node::readExecutable`
  - `Node::writeExecutable`

- `UserExecutable`:
  - `services::readUserExecutable`
  - `services::writeUserExecutable`
  - `Node::readUserExecutable`
  - `Node::writeUserExecutable`