### PR TITLE
feat: simplify Variant methods, use VariantPolicy for factory methods

### DIFF
--- a/include/open62541pp/Node.h
+++ b/include/open62541pp/Node.h
@@ -550,23 +550,17 @@ public:
     template <typename T>
     Node& writeValueScalar(const T& value) {
         // NOLINTNEXTLINE, variant isn't modified, try to avoid copy
-        const auto variant = Variant::fromScalar<T>(const_cast<T&>(value));
+        const auto variant = Variant::fromScalar(const_cast<T&>(value));
         writeValue(variant);
         return *this;
     }
 
     /// Write array value to variable node.
     /// @return Current node instance to chain multiple methods (fluent interface)
-    template <typename T>
-    Node& writeValueArray(Span<T> array) {
-        writeValue(Variant::fromArray(array));
-        return *this;
-    }
-
-    /// @overload
     template <typename ArrayLike>
     Node& writeValueArray(ArrayLike&& array) {
-        return writeValueArray(Span{std::forward<ArrayLike>(array)});
+        writeValue(Variant::fromArray(std::forward<ArrayLike>(array)));
+        return *this;
     }
 
     /// Write range of elements as array value to variable node.

--- a/include/open62541pp/Node.h
+++ b/include/open62541pp/Node.h
@@ -550,8 +550,7 @@ public:
     template <typename T>
     Node& writeValueScalar(const T& value) {
         // NOLINTNEXTLINE, variant isn't modified, try to avoid copy
-        const auto variant = Variant::fromScalar(const_cast<T&>(value));
-        writeValue(variant);
+        writeValue(Variant::fromScalar<VariantPolicy::ReferenceIfPossible>(const_cast<T&>(value)));
         return *this;
     }
 
@@ -559,7 +558,9 @@ public:
     /// @return Current node instance to chain multiple methods (fluent interface)
     template <typename ArrayLike>
     Node& writeValueArray(ArrayLike&& array) {
-        writeValue(Variant::fromArray(std::forward<ArrayLike>(array)));
+        writeValue(
+            Variant::fromArray<VariantPolicy::ReferenceIfPossible>(std::forward<ArrayLike>(array))
+        );
         return *this;
     }
 
@@ -567,7 +568,7 @@ public:
     /// @return Current node instance to chain multiple methods (fluent interface)
     template <typename InputIt>
     Node& writeValueArray(InputIt first, InputIt last) {
-        writeValue(Variant::fromArray(first, last));
+        writeValue(Variant::fromArray<VariantPolicy::ReferenceIfPossible>(first, last));
         return *this;
     }
 

--- a/include/open62541pp/detail/traits.h
+++ b/include/open62541pp/detail/traits.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <iterator>
 #include <type_traits>
 
 namespace opcua::detail {
@@ -37,15 +36,17 @@ struct IsContiguousContainer<
     : std::is_pointer<decltype(std::declval<T>().data())>  // detect proxy iterator of vector<bool>
 {};
 
-template <typename Iterator>
-struct IsMutableIterator
-    : std::negation<std::is_const<
-          std::remove_reference_t<typename std::iterator_traits<Iterator>::reference>>> {};
-
 template <typename T>
 struct IsMutableContainer
     : std::conjunction<
-          IsMutableIterator<decltype(std::declval<T>().begin())>,
-          IsMutableIterator<decltype(std::declval<T>().end())>> {};
+          std::is_same<
+              decltype(std::declval<T>().begin()),
+              typename std::remove_reference_t<T>::iterator>,
+          std::is_same<
+              decltype(std::declval<T>().end()),
+              typename std::remove_reference_t<T>::iterator>,
+          std::negation<std::is_same<
+              typename std::remove_reference_t<T>::iterator,
+              typename std::remove_reference_t<T>::const_iterator>>> {};
 
 }  // namespace opcua::detail

--- a/include/open62541pp/types/DataValue.h
+++ b/include/open62541pp/types/DataValue.h
@@ -52,16 +52,16 @@ public:
 
     /// Create DataValue from scalar value.
     /// @see Variant::fromScalar
-    template <typename... Args>
+    template <VariantPolicy Policy = VariantPolicy::ReferenceIfPossible, typename... Args>
     [[nodiscard]] static DataValue fromScalar(Args&&... args) {
-        return DataValue(Variant::fromScalar(std::forward<Args>(args)...));
+        return DataValue(Variant::fromScalar<Policy>(std::forward<Args>(args)...));
     }
 
     /// Create DataValue from array.
     /// @see Variant::fromArray
-    template <typename... Args>
+    template <VariantPolicy Policy = VariantPolicy::ReferenceIfPossible, typename... Args>
     [[nodiscard]] static DataValue fromArray(Args&&... args) {
-        return DataValue(Variant::fromArray(std::forward<Args>(args)...));
+        return DataValue(Variant::fromArray<Policy>(std::forward<Args>(args)...));
     }
 
     bool hasValue() const noexcept {

--- a/include/open62541pp/types/DataValue.h
+++ b/include/open62541pp/types/DataValue.h
@@ -52,14 +52,14 @@ public:
 
     /// Create DataValue from scalar value.
     /// @see Variant::fromScalar
-    template <VariantPolicy Policy = VariantPolicy::ReferenceIfPossible, typename... Args>
+    template <VariantPolicy Policy = VariantPolicy::Copy, typename... Args>
     [[nodiscard]] static DataValue fromScalar(Args&&... args) {
         return DataValue(Variant::fromScalar<Policy>(std::forward<Args>(args)...));
     }
 
     /// Create DataValue from array.
     /// @see Variant::fromArray
-    template <VariantPolicy Policy = VariantPolicy::ReferenceIfPossible, typename... Args>
+    template <VariantPolicy Policy = VariantPolicy::Copy, typename... Args>
     [[nodiscard]] static DataValue fromArray(Args&&... args) {
         return DataValue(Variant::fromArray<Policy>(std::forward<Args>(args)...));
     }

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -297,7 +297,7 @@ public:
      *              The container must implement `begin()` and `end()`.
      */
     template <typename ArrayLike>
-    void setArrayCopy(const ArrayLike& array) {
+    void setArrayCopy(ArrayLike&& array) {
         setArrayCopy(array.begin(), array.end());
     }
 
@@ -307,7 +307,7 @@ public:
      * @param dataType Custom data type.
      */
     template <typename ArrayLike>
-    void setArrayCopy(const ArrayLike& array, const UA_DataType& dataType) {
+    void setArrayCopy(ArrayLike&& array, const UA_DataType& dataType) {
         setArrayCopy(array.begin(), array.end(), dataType);
     }
 

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -4,7 +4,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
-#include <iterator>  // distance
+#include <iterator>  // distance, iterator_traits
 #include <optional>
 #include <type_traits>  // enable_if
 #include <utility>  // as_const
@@ -76,7 +76,7 @@ public:
         constexpr bool isMutable = detail::IsMutableContainer<ArrayLike>::value;
         constexpr bool isContiguous = detail::IsContiguousContainer<ArrayLike>::value;
         Variant variant;
-        if constexpr (isMutable && isContiguous && detail::isRegisteredType<ValueType>) {
+        if constexpr (!std::is_rvalue_reference_v<ArrayLike> && isMutable && isContiguous && detail::isRegisteredType<ValueType>) {
             variant.setArray(std::forward<ArrayLike>(array));
         } else {
             variant.setArrayCopy(std::forward<ArrayLike>(array));
@@ -90,7 +90,7 @@ public:
         constexpr bool isMutable = detail::IsMutableContainer<ArrayLike>::value;
         constexpr bool isContiguous = detail::IsContiguousContainer<ArrayLike>::value;
         Variant variant;
-        if constexpr (isMutable && isContiguous) {
+        if constexpr (!std::is_rvalue_reference_v<ArrayLike> && isMutable && isContiguous) {
             variant.setArray(std::forward<ArrayLike>(array), dataType);
         } else {
             variant.setArrayCopy(std::forward<ArrayLike>(array), dataType);
@@ -275,6 +275,7 @@ public:
      */
     template <typename ArrayLike>
     void setArray(ArrayLike&& array, const UA_DataType& dataType) noexcept {
+        static_assert(!std::is_rvalue_reference_v<ArrayLike>);
         setArrayImpl(std::data(array), std::size(array), dataType, UA_VARIANT_DATA_NODELETE);
     }
 

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -4,9 +4,8 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
-#include <iterator>  // distance, iterator_traits
+#include <iterator>  // distance
 #include <optional>
-#include <type_traits>  // enable_if
 #include <utility>  // as_const
 #include <vector>
 
@@ -25,91 +24,97 @@ namespace opcua {
 class NodeId;
 
 /**
+ * Policies for variant factory methods Variant::fromScalar, Variant::fromArray.
+ */
+enum class VariantPolicy {
+    // clang-format off
+    Copy,                 ///< Store copy of scalar/array inside the variant.
+    Reference,            ///< Store reference to scalar/array inside the variant.
+                          ///< Both scalars and arrays must be mutable native/wrapper types.
+                          ///< Arrays must store the elements contiguously in memory.
+    ReferenceIfPossible,  ///< Favor referencing but fall back to copying if necessary.
+    // clang-format on
+};
+
+namespace detail {
+
+template <VariantPolicy>
+struct VariantHandler;
+
+}  // namespace detail
+
+/**
  * UA_Variant wrapper class.
  * @ingroup TypeWrapper
  */
 class Variant : public TypeWrapper<UA_Variant, UA_TYPES_VARIANT> {
 public:
-    // NOLINTNEXTLINE, false positive?
     using TypeWrapperBase::TypeWrapperBase;  // inherit constructors
 
-    /// Create Variant from scalar value (no copy if assignable without conversion).
-    template <typename T>
-    [[nodiscard]] static Variant fromScalar(T& value) {
-        Variant variant;
-        if constexpr (detail::isRegisteredType<T>) {
-            variant.setScalar(value);
-        } else {
-            variant.setScalarCopy(value);
-        }
-        return variant;
+    /// Create Variant from scalar value.
+    /// @tparam Policy Policy (@ref VariantPolicy) how to store the scalar inside the variant
+    template <VariantPolicy Policy = VariantPolicy::ReferenceIfPossible, typename T>
+    [[nodiscard]] static Variant fromScalar(T&& value) {
+        Variant var;
+        detail::VariantHandler<Policy>::setScalar(var, std::forward<T>(value));
+        return var;
     }
 
-    /// Create Variant from scalar value with custom data type (no copy).
-    template <typename T>
-    [[nodiscard]] static Variant fromScalar(T& value, const UA_DataType& dataType) {
-        Variant variant;
-        variant.setScalar(value, dataType);
-        return variant;
+    /// Create Variant from scalar value with custom data type.
+    /// @tparam Policy Policy (@ref VariantPolicy) how to store the scalar inside the variant
+    template <VariantPolicy Policy = VariantPolicy::ReferenceIfPossible, typename T>
+    [[nodiscard]] static Variant fromScalar(T&& value, const UA_DataType& dataType) {
+        Variant var;
+        detail::VariantHandler<Policy>::setScalar(var, std::forward<T>(value), dataType);
+        return var;
     }
 
-    /// Create Variant from scalar value (copy).
-    template <typename T>
-    [[nodiscard]] static Variant fromScalar(const T& value) {
-        Variant variant;
-        variant.setScalarCopy(value);
-        return variant;
-    }
-
-    /// Create Variant from scalar value with custom data type (copy).
-    template <typename T>
-    [[nodiscard]] static Variant fromScalar(const T& value, const UA_DataType& dataType) {
-        Variant variant;
-        variant.setScalarCopy(value, dataType);
-        return variant;
-    }
-
-    /// Create Variant from array (no copy if assignable).
-    template <typename ArrayLike>
+    /// Create Variant from array.
+    /// @tparam Policy Policy (@ref VariantPolicy) how to store the array inside the variant
+    template <VariantPolicy Policy = VariantPolicy::ReferenceIfPossible, typename ArrayLike>
     [[nodiscard]] static Variant fromArray(ArrayLike&& array) {
-        using ValueType = typename std::remove_reference_t<ArrayLike>::value_type;
-        Variant variant;
-        if constexpr (isAssignableArray<decltype(array)>() && detail::isRegisteredType<ValueType>) {
-            variant.setArray(std::forward<ArrayLike>(array));
+        using Handler = detail::VariantHandler<Policy>;
+        Variant var;
+        if constexpr (detail::IsContiguousContainer<ArrayLike>::value) {
+            Handler::setArray(var, Span{std::forward<ArrayLike>(array)});
         } else {
-            variant.setArrayCopy(std::forward<ArrayLike>(array));
+            Handler::setArray(var, array.begin(), array.end());
         }
-        return variant;
+        return var;
     }
 
-    /// Create Variant from array with custom data type (no copy if assignable).
-    template <typename ArrayLike>
+    /// Create Variant from array with custom data type.
+    /// @tparam Policy Policy (@ref VariantPolicy) how to store the array inside the variant
+    template <VariantPolicy Policy = VariantPolicy::ReferenceIfPossible, typename ArrayLike>
     [[nodiscard]] static Variant fromArray(ArrayLike&& array, const UA_DataType& dataType) {
-        Variant variant;
-        if constexpr (isAssignableArray<decltype(array)>()) {
-            variant.setArray(std::forward<ArrayLike>(array), dataType);
+        using Handler = detail::VariantHandler<Policy>;
+        Variant var;
+        if constexpr (detail::IsContiguousContainer<ArrayLike>::value) {
+            Handler::setArray(var, Span{std::forward<ArrayLike>(array)}, dataType);
         } else {
-            variant.setArrayCopy(std::forward<ArrayLike>(array), dataType);
+            Handler::setArray(var, array.begin(), array.end(), dataType);
         }
-        return variant;
+        return var;
     }
 
-    /// Create Variant from range of elements (copy).
-    template <typename InputIt>
+    /// Create Variant from range of elements (copy required).
+    /// @tparam Policy Policy (@ref VariantPolicy) how to store the array inside the variant
+    template <VariantPolicy Policy = VariantPolicy::ReferenceIfPossible, typename InputIt>
     [[nodiscard]] static Variant fromArray(InputIt first, InputIt last) {
-        Variant variant;
-        variant.setArrayCopy(first, last);
-        return variant;
+        Variant var;
+        detail::VariantHandler<Policy>::setArray(var, first, last);
+        return var;
     }
 
-    /// Create Variant from range of elements with custom data type (copy).
-    template <typename InputIt>
+    /// Create Variant from range of elements with custom data type (copy required).
+    /// @tparam Policy Policy (@ref VariantPolicy) how to store the array inside the variant
+    template <VariantPolicy Policy = VariantPolicy::ReferenceIfPossible, typename InputIt>
     [[nodiscard]] static Variant fromArray(
         InputIt first, InputIt last, const UA_DataType& dataType
     ) {
-        Variant variant;
-        variant.setArrayCopy(first, last, dataType);
-        return variant;
+        Variant var;
+        detail::VariantHandler<Policy>::setArray(var, first, last, dataType);
+        return var;
     }
 
     /// Check if the variant is empty.
@@ -325,14 +330,6 @@ private:
         return isTemporary && !isView;
     }
 
-    template <typename ArrayLike>
-    static constexpr bool isAssignableArray() {
-        constexpr bool isTemporary = isTemporaryArray<ArrayLike>();
-        constexpr bool isMutable = detail::IsMutableContainer<ArrayLike>::value;
-        constexpr bool isContiguous = detail::IsContiguousContainer<ArrayLike>::value;
-        return !isTemporary && isMutable && isContiguous;
-    }
-
     template <typename T>
     static constexpr void assertIsNative() {
         static_assert(
@@ -489,5 +486,101 @@ void Variant::setArrayCopyConvertImpl(InputIt first, InputIt last) {
     }
     setArrayImpl(native.release(), size, dataType, UA_VARIANT_DATA);  // move ownership
 }
+
+/* --------------------------------------- Variant handler -------------------------------------- */
+
+namespace detail {
+
+template <>
+struct VariantHandler<VariantPolicy::Copy> {
+    template <typename T>
+    static void setScalar(Variant& var, const T& value) {
+        var.setScalarCopy(value);
+    }
+
+    template <typename T>
+    static void setScalar(Variant& var, const T& value, const UA_DataType& dtype) {
+        var.setScalarCopy(value, dtype);
+    }
+
+    template <typename T>
+    static void setArray(Variant& var, Span<const T> array) {
+        var.setArrayCopy(array.begin(), array.end());
+    }
+
+    template <typename T>
+    static void setArray(Variant& var, Span<const T> array, const UA_DataType& dtype) {
+        var.setArrayCopy(array.begin(), array.end(), dtype);
+    }
+
+    template <typename InputIt>
+    static void setArray(Variant& var, InputIt first, InputIt last) {
+        var.setArrayCopy(first, last);
+    }
+
+    template <typename InputIt>
+    static void setArray(Variant& var, InputIt first, InputIt last, const UA_DataType& dtype) {
+        var.setArrayCopy(first, last, dtype);
+    }
+};
+
+template <>
+struct VariantHandler<VariantPolicy::Reference> {
+    template <typename T>
+    static void setScalar(Variant& var, T& value) {
+        var.setScalar(value);
+    }
+
+    template <typename T>
+    static void setScalar(Variant& var, T& value, const UA_DataType& dtype) {
+        var.setScalar(value, dtype);
+    }
+
+    template <typename T>
+    static void setArray(Variant& var, Span<T> array) {
+        var.setArray(array);
+    }
+
+    template <typename T>
+    static void setArray(Variant& var, Span<T> array, const UA_DataType& dtype) {
+        var.setArray(array, dtype);
+    }
+};
+
+template <>
+struct VariantHandler<VariantPolicy::ReferenceIfPossible> : VariantHandler<VariantPolicy::Copy> {
+    using VariantHandler<VariantPolicy::Copy>::setScalar;
+    using VariantHandler<VariantPolicy::Copy>::setArray;
+
+    template <typename T>
+    static void setScalar(Variant& var, T& value) {
+        if constexpr (detail::isRegisteredType<T>) {
+            var.setScalar(value);
+        } else {
+            var.setScalarCopy(value);
+        }
+    }
+
+    template <typename T>
+    static void setScalar(Variant& var, T& value, const UA_DataType& dtype) {
+        var.setScalar(value, dtype);
+    }
+
+    template <typename T>
+    static void setArray(Variant& var, Span<T> array) {
+        if constexpr (detail::isRegisteredType<T>) {
+            var.setArray(array);
+        } else {
+            var.setArrayCopy(array);
+        }
+    }
+
+    template <typename T>
+    static void setArray(Variant& var, Span<T> array, const UA_DataType& dtype) {
+        var.setArray(array, dtype);
+    }
+};
+
+}  // namespace detail
 
 }  // namespace opcua

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -20,9 +20,6 @@
 
 namespace opcua {
 
-// forward declarations
-class NodeId;
-
 /**
  * Policies for variant factory methods Variant::fromScalar, Variant::fromArray.
  */
@@ -36,11 +33,12 @@ enum class VariantPolicy {
     // clang-format on
 };
 
-namespace detail {
+// forward declarations
+class NodeId;
 
+namespace detail {
 template <VariantPolicy>
 struct VariantHandler;
-
 }  // namespace detail
 
 /**

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -76,7 +76,7 @@ public:
         constexpr bool isMutable = detail::IsMutableContainer<ArrayLike>::value;
         constexpr bool isContiguous = detail::IsContiguousContainer<ArrayLike>::value;
         Variant variant;
-        if constexpr (!std::is_rvalue_reference_v<ArrayLike> && isMutable && isContiguous && detail::isRegisteredType<ValueType>) {
+        if constexpr (!std::is_rvalue_reference_v<decltype(array)> && isMutable && isContiguous && detail::isRegisteredType<ValueType>) {
             variant.setArray(std::forward<ArrayLike>(array));
         } else {
             variant.setArrayCopy(std::forward<ArrayLike>(array));
@@ -90,7 +90,7 @@ public:
         constexpr bool isMutable = detail::IsMutableContainer<ArrayLike>::value;
         constexpr bool isContiguous = detail::IsContiguousContainer<ArrayLike>::value;
         Variant variant;
-        if constexpr (!std::is_rvalue_reference_v<ArrayLike> && isMutable && isContiguous) {
+        if constexpr (!std::is_rvalue_reference_v<decltype(array)> && isMutable && isContiguous) {
             variant.setArray(std::forward<ArrayLike>(array), dataType);
         } else {
             variant.setArrayCopy(std::forward<ArrayLike>(array), dataType);
@@ -262,10 +262,10 @@ public:
      *              The underlying array must be accessible with `std::data` and `std::size`.
      */
     template <typename ArrayLike>
-    void setArray(ArrayLike&& array) noexcept {
+    void setArray(ArrayLike& array) noexcept {
         using ValueType = typename std::remove_reference_t<ArrayLike>::value_type;
         assertIsNative<ValueType>();
-        setArray(std::forward<ArrayLike>(array), opcua::getDataType<ValueType>());
+        setArray(array, opcua::getDataType<ValueType>());
     }
 
     /**
@@ -274,8 +274,7 @@ public:
      * @param dataType Custom data type.
      */
     template <typename ArrayLike>
-    void setArray(ArrayLike&& array, const UA_DataType& dataType) noexcept {
-        static_assert(!std::is_rvalue_reference_v<ArrayLike>);
+    void setArray(ArrayLike& array, const UA_DataType& dataType) noexcept {
         setArrayImpl(std::data(array), std::size(array), dataType, UA_VARIANT_DATA_NODELETE);
     }
 
@@ -285,7 +284,7 @@ public:
      *              The container must implement `begin()` and `end()`.
      */
     template <typename ArrayLike>
-    void setArrayCopy(ArrayLike&& array) {
+    void setArrayCopy(const ArrayLike& array) {
         setArrayCopy(array.begin(), array.end());
     }
 
@@ -295,7 +294,7 @@ public:
      * @param dataType Custom data type.
      */
     template <typename ArrayLike>
-    void setArrayCopy(ArrayLike&& array, const UA_DataType& dataType) {
+    void setArrayCopy(const ArrayLike& array, const UA_DataType& dataType) {
         setArrayCopy(array.begin(), array.end(), dataType);
     }
 

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -235,14 +235,14 @@ public:
         return getArrayCopyImpl<T>();
     }
 
-    /// Assign scalar value to variant.
+    /// Assign scalar value to variant (no copy).
     template <typename T>
     void setScalar(T& value) noexcept {
         assertIsNative<T>();
         setScalar(value, opcua::getDataType<T>());
     }
 
-    /// Assign scalar value to variant with custom data type.
+    /// Assign scalar value to variant with custom data type (no copy).
     template <typename T>
     void setScalar(T& value, const UA_DataType& dataType) noexcept {
         setScalarImpl(&value, dataType, UA_VARIANT_DATA_NODELETE);
@@ -266,7 +266,7 @@ public:
     }
 
     /**
-     * Assign array to variant.
+     * Assign array to variant (no copy).
      * @param array Container with a contiguous sequence of elements.
      *              For example `std::array`, `std::vector` or `Span`.
      *              The underlying array must be accessible with `std::data` and `std::size`.
@@ -279,7 +279,7 @@ public:
     }
 
     /**
-     * Assign array to variant with custom data type.
+     * Assign array to variant with custom data type (no copy).
      * @copydetails setArray
      * @param dataType Custom data type.
      */

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -295,7 +295,7 @@ public:
      *              The container must implement `begin()` and `end()`.
      */
     template <typename ArrayLike>
-    void setArrayCopy(ArrayLike&& array) {
+    void setArrayCopy(const ArrayLike& array) {
         setArrayCopy(array.begin(), array.end());
     }
 
@@ -305,7 +305,7 @@ public:
      * @param dataType Custom data type.
      */
     template <typename ArrayLike>
-    void setArrayCopy(ArrayLike&& array, const UA_DataType& dataType) {
+    void setArrayCopy(const ArrayLike& array, const UA_DataType& dataType) {
         setArrayCopy(array.begin(), array.end(), dataType);
     }
 

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -77,9 +77,9 @@ public:
         constexpr bool isContiguous = detail::IsContiguousContainer<ArrayLike>::value;
         Variant variant;
         if constexpr (isMutable && isContiguous && detail::isRegisteredType<ValueType>) {
-            variant.setArray(array);
+            variant.setArray(std::forward<ArrayLike>(array));
         } else {
-            variant.setArrayCopy(array);
+            variant.setArrayCopy(std::forward<ArrayLike>(array));
         }
         return variant;
     }
@@ -91,9 +91,9 @@ public:
         constexpr bool isContiguous = detail::IsContiguousContainer<ArrayLike>::value;
         Variant variant;
         if constexpr (isMutable && isContiguous) {
-            variant.setArray(array, dataType);
+            variant.setArray(std::forward<ArrayLike>(array), dataType);
         } else {
-            variant.setArrayCopy(array, dataType);
+            variant.setArrayCopy(std::forward<ArrayLike>(array), dataType);
         }
         return variant;
     }

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -51,7 +51,7 @@ public:
 
     /// Create Variant from scalar value.
     /// @tparam Policy Policy (@ref VariantPolicy) how to store the scalar inside the variant
-    template <VariantPolicy Policy = VariantPolicy::ReferenceIfPossible, typename T>
+    template <VariantPolicy Policy = VariantPolicy::Copy, typename T>
     [[nodiscard]] static Variant fromScalar(T&& value) {
         Variant var;
         detail::VariantHandler<Policy>::setScalar(var, std::forward<T>(value));
@@ -60,7 +60,7 @@ public:
 
     /// Create Variant from scalar value with custom data type.
     /// @tparam Policy Policy (@ref VariantPolicy) how to store the scalar inside the variant
-    template <VariantPolicy Policy = VariantPolicy::ReferenceIfPossible, typename T>
+    template <VariantPolicy Policy = VariantPolicy::Copy, typename T>
     [[nodiscard]] static Variant fromScalar(T&& value, const UA_DataType& dataType) {
         Variant var;
         detail::VariantHandler<Policy>::setScalar(var, std::forward<T>(value), dataType);
@@ -69,7 +69,7 @@ public:
 
     /// Create Variant from array.
     /// @tparam Policy Policy (@ref VariantPolicy) how to store the array inside the variant
-    template <VariantPolicy Policy = VariantPolicy::ReferenceIfPossible, typename ArrayLike>
+    template <VariantPolicy Policy = VariantPolicy::Copy, typename ArrayLike>
     [[nodiscard]] static Variant fromArray(ArrayLike&& array) {
         using Handler = detail::VariantHandler<Policy>;
         Variant var;
@@ -83,7 +83,7 @@ public:
 
     /// Create Variant from array with custom data type.
     /// @tparam Policy Policy (@ref VariantPolicy) how to store the array inside the variant
-    template <VariantPolicy Policy = VariantPolicy::ReferenceIfPossible, typename ArrayLike>
+    template <VariantPolicy Policy = VariantPolicy::Copy, typename ArrayLike>
     [[nodiscard]] static Variant fromArray(ArrayLike&& array, const UA_DataType& dataType) {
         using Handler = detail::VariantHandler<Policy>;
         Variant var;
@@ -97,7 +97,7 @@ public:
 
     /// Create Variant from range of elements (copy required).
     /// @tparam Policy Policy (@ref VariantPolicy) how to store the array inside the variant
-    template <VariantPolicy Policy = VariantPolicy::ReferenceIfPossible, typename InputIt>
+    template <VariantPolicy Policy = VariantPolicy::Copy, typename InputIt>
     [[nodiscard]] static Variant fromArray(InputIt first, InputIt last) {
         Variant var;
         detail::VariantHandler<Policy>::setArray(var, first, last);
@@ -106,7 +106,7 @@ public:
 
     /// Create Variant from range of elements with custom data type (copy required).
     /// @tparam Policy Policy (@ref VariantPolicy) how to store the array inside the variant
-    template <VariantPolicy Policy = VariantPolicy::ReferenceIfPossible, typename InputIt>
+    template <VariantPolicy Policy = VariantPolicy::Copy, typename InputIt>
     [[nodiscard]] static Variant fromArray(
         InputIt first, InputIt last, const UA_DataType& dataType
     ) {

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -538,22 +538,22 @@ struct VariantHandler<VariantPolicy::Copy> {
 template <>
 struct VariantHandler<VariantPolicy::Reference> {
     template <typename T>
-    static void setScalar(Variant& var, T& value) {
+    static void setScalar(Variant& var, T& value) noexcept {
         var.setScalar(value);
     }
 
     template <typename T>
-    static void setScalar(Variant& var, T& value, const UA_DataType& dtype) {
+    static void setScalar(Variant& var, T& value, const UA_DataType& dtype) noexcept {
         var.setScalar(value, dtype);
     }
 
     template <typename T>
-    static void setArray(Variant& var, Span<T> array) {
+    static void setArray(Variant& var, Span<T> array) noexcept {
         var.setArray(array);
     }
 
     template <typename T>
-    static void setArray(Variant& var, Span<T> array, const UA_DataType& dtype) {
+    static void setArray(Variant& var, Span<T> array, const UA_DataType& dtype) noexcept {
         var.setArray(array, dtype);
     }
 };
@@ -564,7 +564,7 @@ struct VariantHandler<VariantPolicy::ReferenceIfPossible> : VariantHandler<Varia
     using VariantHandler<VariantPolicy::Copy>::setArray;
 
     template <typename T>
-    static void setScalar(Variant& var, T& value) {
+    static void setScalar(Variant& var, T& value) noexcept(detail::isRegisteredType<T>) {
         if constexpr (detail::isRegisteredType<T>) {
             var.setScalar(value);
         } else {
@@ -573,12 +573,12 @@ struct VariantHandler<VariantPolicy::ReferenceIfPossible> : VariantHandler<Varia
     }
 
     template <typename T>
-    static void setScalar(Variant& var, T& value, const UA_DataType& dtype) {
+    static void setScalar(Variant& var, T& value, const UA_DataType& dtype) noexcept {
         var.setScalar(value, dtype);
     }
 
     template <typename T>
-    static void setArray(Variant& var, Span<T> array) {
+    static void setArray(Variant& var, Span<T> array) noexcept(detail::isRegisteredType<T>) {
         if constexpr (detail::isRegisteredType<T>) {
             var.setArray(array);
         } else {
@@ -587,7 +587,7 @@ struct VariantHandler<VariantPolicy::ReferenceIfPossible> : VariantHandler<Varia
     }
 
     template <typename T>
-    static void setArray(Variant& var, Span<T> array, const UA_DataType& dtype) {
+    static void setArray(Variant& var, Span<T> array, const UA_DataType& dtype) noexcept {
         var.setArray(array, dtype);
     }
 };

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -29,10 +29,6 @@ class NodeId;
  * @ingroup TypeWrapper
  */
 class Variant : public TypeWrapper<UA_Variant, UA_TYPES_VARIANT> {
-private:
-    template <typename T>
-    using EnableIfNoSpan = typename std::enable_if_t<!detail::IsSpan<T>::value>;
-
 public:
     // NOLINTNEXTLINE, false positive?
     using TypeWrapperBase::TypeWrapperBase;  // inherit constructors

--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -513,12 +513,12 @@ struct VariantHandler<VariantPolicy::Copy> {
     }
 
     template <typename T>
-    static void setArray(Variant& var, Span<const T> array) {
+    static void setArray(Variant& var, Span<T> array) {
         var.setArrayCopy(array.begin(), array.end());
     }
 
     template <typename T>
-    static void setArray(Variant& var, Span<const T> array, const UA_DataType& dtype) {
+    static void setArray(Variant& var, Span<T> array, const UA_DataType& dtype) {
         var.setArrayCopy(array.begin(), array.end(), dtype);
     }
 
@@ -587,6 +587,16 @@ struct VariantHandler<VariantPolicy::ReferenceIfPossible> : VariantHandler<Varia
     template <typename T>
     static void setArray(Variant& var, Span<T> array, const UA_DataType& dtype) noexcept {
         var.setArray(array, dtype);
+    }
+
+    template <typename T>
+    static void setArray(Variant& var, Span<const T> array) {
+        var.setArrayCopy(array.begin(), array.end());
+    }
+
+    template <typename T>
+    static void setArray(Variant& var, Span<const T> array, const UA_DataType& dtype) {
+        var.setArrayCopy(array.begin(), array.end(), dtype);
     }
 };
 

--- a/src/Event.cpp
+++ b/src/Event.cpp
@@ -39,7 +39,7 @@ Event& Event::writeSourceName(std::string_view sourceName) {
     return writeProperty({0, "SourceName"}, Variant::fromScalar(String(sourceName)));
 }
 
-Event& Event::writeTime(DateTime time) {
+Event& Event::writeTime(DateTime time) {  // NOLINT
     return writeProperty({0, "Time"}, Variant::fromScalar(time));
 }
 

--- a/src/Event.cpp
+++ b/src/Event.cpp
@@ -36,7 +36,7 @@ const NodeId& Event::getNodeId() const noexcept {
 }
 
 Event& Event::writeSourceName(std::string_view sourceName) {
-    return writeProperty({0, "SourceName"}, Variant::fromScalar(String(sourceName)));
+    return writeProperty({0, "SourceName"}, Variant::fromScalar(sourceName));
 }
 
 Event& Event::writeTime(DateTime time) {  // NOLINT

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(
     Session.cpp
     Span.cpp
     Subscription_MonitoredItem.cpp
+    traits.cpp
     TypeConverter.cpp
     TypeRegistry.cpp
     Types.cpp

--- a/tests/Services.cpp
+++ b/tests/Services.cpp
@@ -582,8 +582,8 @@ TEST_CASE("Method service set (server & client)") {
                 objectsId,
                 methodId,
                 {
-                    Variant::fromScalar<int32_t>(1),
-                    Variant::fromScalar<int32_t>(2),
+                    Variant::fromScalar(int32_t{1}),
+                    Variant::fromScalar(int32_t{2}),
                 }
             );
             CHECK(outputs.size() == 1);
@@ -598,8 +598,8 @@ TEST_CASE("Method service set (server & client)") {
                     objectsId,
                     methodId,
                     {
-                        Variant::fromScalar<int32_t>(1),
-                        Variant::fromScalar<int32_t>(2),
+                        Variant::fromScalar(int32_t{1}),
+                        Variant::fromScalar(int32_t{2}),
                     }
                 ),
                 "BadUnexpectedError"
@@ -613,8 +613,8 @@ TEST_CASE("Method service set (server & client)") {
                     objectsId,
                     methodId,
                     {
-                        Variant::fromScalar<bool>(true),
-                        Variant::fromScalar<float>(11.11f),
+                        Variant::fromScalar(true),
+                        Variant::fromScalar(11.11f),
                     }
                 ),
                 "BadInvalidArgument"
@@ -628,9 +628,9 @@ TEST_CASE("Method service set (server & client)") {
                     objectsId,
                     methodId,
                     {
-                        Variant::fromScalar<int32_t>(1),
-                        Variant::fromScalar<int32_t>(2),
-                        Variant::fromScalar<int32_t>(3),
+                        Variant::fromScalar(int32_t{1}),
+                        Variant::fromScalar(int32_t{2}),
+                        Variant::fromScalar(int32_t{3}),
                     }
                 ),
                 "BadTooManyArguments"

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -405,6 +405,95 @@ TEST_CASE("ExpandedNodeId") {
 }
 
 TEST_CASE("Variant") {
+    SUBCASE("fromScalar (ReferenceIfPossible)") {
+        constexpr auto policy = VariantPolicy::ReferenceIfPossible;
+        String value("test");
+        Variant var;
+        SUBCASE("Reference if mutable") {
+            SUBCASE("Deduce data type") {
+                var = Variant::fromScalar<policy>(value);
+            }
+            SUBCASE("Custom data type") {
+                var = Variant::fromScalar<policy>(value, UA_TYPES[UA_TYPES_STRING]);
+            }
+            CHECK(var->data == value.handle());
+        }
+        SUBCASE("Copy if rvalue") {
+            SUBCASE("Deduce data type") {
+                var = Variant::fromScalar<policy>(std::move(value));
+            }
+            SUBCASE("Custom data type") {
+                var = Variant::fromScalar<policy>(std::move(value), UA_TYPES[UA_TYPES_STRING]);
+            }
+            CHECK(var->data != value.handle());
+        }
+        SUBCASE("Copy if const") {
+            SUBCASE("Deduce data type") {
+                var = Variant::fromScalar<policy>(std::as_const(value));
+            }
+            SUBCASE("Custom data type") {
+                var = Variant::fromScalar<policy>(std::as_const(value), UA_TYPES[UA_TYPES_STRING]);
+            }
+            CHECK(var->data != value.handle());
+        }
+        SUBCASE("Copy if conversion needed") {
+            std::string str{"test"};
+            var = Variant::fromScalar<policy>(str);
+            CHECK(var->data != &str);
+        }
+        CHECK(var.isScalar());
+        CHECK(var->type == &UA_TYPES[UA_TYPES_STRING]);
+    }
+
+    SUBCASE("fromArray (ReferenceIfPossible)") {
+        constexpr auto policy = VariantPolicy::ReferenceIfPossible;
+        Variant var;
+        std::vector<String> vec{String("1"), String("2"), String("3")};
+        SUBCASE("Reference if mutable") {
+            SUBCASE("Deduce data type") {
+                var = Variant::fromArray<policy>(vec);
+            }
+            SUBCASE("Custom data type") {
+                var = Variant::fromArray<policy>(vec, UA_TYPES[UA_TYPES_STRING]);
+            }
+            CHECK(var->data == vec.data());
+        }
+        SUBCASE("Copy if rvalue") {
+            SUBCASE("Deduce data type") {
+                var = Variant::fromArray<policy>(std::move(vec));
+            }
+            SUBCASE("Custom data type") {
+                var = Variant::fromArray<policy>(std::move(vec), UA_TYPES[UA_TYPES_STRING]);
+            }
+            CHECK(var->data != vec.data());
+        }
+        SUBCASE("Copy if const") {
+            SUBCASE("Deduce data type") {
+                var = Variant::fromArray<policy>(std::as_const(vec));
+            }
+            SUBCASE("Custom data type") {
+                var = Variant::fromArray<policy>(std::as_const(vec), UA_TYPES[UA_TYPES_STRING]);
+            }
+            CHECK(var->data != vec.data());
+        }
+        SUBCASE("Copy if conversion needed") {
+            std::vector<std::string> vecStr{"1", "2", "3"};
+            var = Variant::fromArray<policy>(vecStr);
+            CHECK(var->data != vec.data());
+        }
+        SUBCASE("Copy iterator pair") {
+            SUBCASE("Deduce data type") {
+                var = Variant::fromArray<policy>(vec.begin(), vec.end());
+            }
+            SUBCASE("Custom data type") {
+                var = Variant::fromArray<policy>(vec.begin(), vec.end());
+            }
+            CHECK(var->data != vec.data());
+        }
+        CHECK(var.isArray());
+        CHECK(var->type == &UA_TYPES[UA_TYPES_STRING]);
+    }
+
     SUBCASE("Empty variant") {
         Variant var;
         CHECK(var.isEmpty());
@@ -433,95 +522,6 @@ TEST_CASE("Variant") {
         CHECK(var.isType(DataTypeId::String));
         CHECK(var.isType<String>());
         CHECK(var.getDataType() == &UA_TYPES[UA_TYPES_STRING]);
-    }
-
-    SUBCASE("Create from scalar") {
-        SUBCASE("Assign if possible") {
-            double value = 11.11;
-            const auto var = Variant::fromScalar(value);
-            CHECK(var.isScalar());
-            CHECK(var->type == &UA_TYPES[UA_TYPES_DOUBLE]);
-            CHECK(var->data == &value);
-        }
-        SUBCASE("Assign with custom datatype") {
-            double value = 11.11;
-            const auto var = Variant::fromScalar(value, UA_TYPES[UA_TYPES_DOUBLE]);
-            CHECK(var.isScalar());
-            CHECK(var->type == &UA_TYPES[UA_TYPES_DOUBLE]);
-            CHECK(var->data == &value);
-        }
-        SUBCASE("Copy if const") {
-            const double value = 11.11;
-            const auto var = Variant::fromScalar(value);
-            CHECK(var.isScalar());
-            CHECK(var->type == &UA_TYPES[UA_TYPES_DOUBLE]);
-            CHECK(var->data != &value);
-        }
-        SUBCASE("Copy rvalue") {
-            auto var = Variant::fromScalar(11.11);
-            CHECK(var.isScalar());
-            CHECK(var->type == &UA_TYPES[UA_TYPES_DOUBLE]);
-            CHECK(var.getScalar<double>() == 11.11);
-        }
-        SUBCASE("Copy if not assignable (const or conversion check failed)") {
-            std::string value{"test"};
-            const auto var = Variant::fromScalar(value);
-            CHECK(var.isScalar());
-            CHECK(var->type == &UA_TYPES[UA_TYPES_STRING]);
-            CHECK(var->data != &value);
-        }
-        SUBCASE("Copy with custom data type") {
-            const double value = 11.11;
-            const auto var = Variant::fromScalar(value, UA_TYPES[UA_TYPES_DOUBLE]);
-            CHECK(var.isScalar());
-            CHECK(var->type == &UA_TYPES[UA_TYPES_DOUBLE]);
-            CHECK(var->data != &value);
-        }
-    }
-
-    SUBCASE("Create from array") {
-        SUBCASE("Assign if possible") {
-            std::vector<double> vec{1.1, 2.2, 3.3};
-            const auto var = Variant::fromArray(vec);
-            CHECK(var.isArray());
-            CHECK(var->type == &UA_TYPES[UA_TYPES_DOUBLE]);
-            CHECK(var->data == vec.data());
-        }
-        SUBCASE("Assign with custom data type") {
-            std::vector<UA_WriteValue> vec{{}, {}};
-            const auto var = Variant::fromArray(vec, UA_TYPES[UA_TYPES_WRITEVALUE]);
-            CHECK(var.isArray());
-            CHECK(var->type == &UA_TYPES[UA_TYPES_WRITEVALUE]);
-            CHECK(var->data == vec.data());
-        }
-        SUBCASE("Copy if const") {
-            const std::vector<double> vec{1.1, 2.2, 3.3};
-            const auto var = Variant::fromArray(vec);
-            CHECK(var.isArray());
-            CHECK(var->type == &UA_TYPES[UA_TYPES_DOUBLE]);
-            CHECK(var->data != vec.data());
-        }
-        SUBCASE("Copy with custom data type") {
-            const std::vector<UA_WriteValue> vec{{}, {}};
-            const auto var = Variant::fromArray(vec, UA_TYPES[UA_TYPES_WRITEVALUE]);
-            CHECK(var.isArray());
-            CHECK(var->type == &UA_TYPES[UA_TYPES_WRITEVALUE]);
-            CHECK(var->data != vec.data());
-        }
-        SUBCASE("Copy from iterator") {
-            const std::vector<double> vec{1.1, 2.2, 3.3};
-            const auto var = Variant::fromArray(vec.begin(), vec.end());
-            CHECK(var.isArray());
-            CHECK(var->type == &UA_TYPES[UA_TYPES_DOUBLE]);
-            CHECK(var->data != vec.data());
-        }
-        SUBCASE("Copy from iterator with custom data type") {
-            const std::vector<double> vec{1.1, 2.2, 3.3};
-            const auto var = Variant::fromArray(vec.begin(), vec.end(), UA_TYPES[UA_TYPES_DOUBLE]);
-            CHECK(var.isArray());
-            CHECK(var->type == &UA_TYPES[UA_TYPES_DOUBLE]);
-            CHECK(var->data != vec.data());
-        }
     }
 
     SUBCASE("Set/get scalar") {

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -567,7 +567,7 @@ TEST_CASE("Variant") {
             detail::toNativeString("item2"),
             detail::toNativeString("item3"),
         };
-        var.setArray(array, UA_TYPES[UA_TYPES_STRING]);
+        var.setArray(Span{array.data(), array.size()}, UA_TYPES[UA_TYPES_STRING]);
         CHECK(var.data() == array.data());
         CHECK(var.getArrayLength() == array.size());
     }

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -465,7 +465,7 @@ TEST_CASE("Variant") {
         }
         SUBCASE("Copy if not assignable (const or conversion check failed)") {
             std::string value{"test"};
-            const auto var = Variant::fromScalar<std::string>(value);
+            const auto var = Variant::fromScalar(value);
             CHECK(var.isScalar());
             CHECK(var->type == &UA_TYPES[UA_TYPES_STRING]);
             CHECK(var->data != &value);
@@ -614,7 +614,7 @@ TEST_CASE("Variant") {
 
     SUBCASE("Set array from initializer list (copy)") {
         Variant var;
-        var.setArrayCopy<const int>({1, 2, 3});  // TODO: avoid manual template types
+        var.setArrayCopy(Span<const int>{1, 2, 3});  // TODO: avoid manual template types
     }
 
     SUBCASE("Set/get array with std::vector<bool> (copy)") {
@@ -622,6 +622,10 @@ TEST_CASE("Variant") {
         // several problems: https://github.com/open62541pp/open62541pp/issues/164
         Variant var;
         std::vector<bool> array{true, false, true};
+
+        SUBCASE("From vector") {
+            var = Variant::fromArray(array);
+        }
 
         SUBCASE("Copy from iterator") {
             var.setArrayCopy(array.begin(), array.end());

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -567,7 +567,7 @@ TEST_CASE("Variant") {
             detail::toNativeString("item2"),
             detail::toNativeString("item3"),
         };
-        var.setArray(Span{array.data(), array.size()}, UA_TYPES[UA_TYPES_STRING]);
+        var.setArray(array, UA_TYPES[UA_TYPES_STRING]);
         CHECK(var.data() == array.data());
         CHECK(var.getArrayLength() == array.size());
     }

--- a/tests/traits.cpp
+++ b/tests/traits.cpp
@@ -27,7 +27,7 @@ TEST_CASE_TEMPLATE("IsContiguousContainer false", T, std::list<int>, std::vector
     CHECK_FALSE(detail::IsContiguousContainer<const T&&>::value);
 }
 
-TEST_CASE_TEMPLATE("IsMutableContainer true", T, std::vector<int>, std::array<int, 3>, Span<int>) {
+TEST_CASE_TEMPLATE("IsMutableContainer true", T, std::vector<int>, std::array<int, 3>, Span<int>, std::vector<bool>) {
     CHECK(detail::IsMutableContainer<T>::value);
     CHECK(detail::IsMutableContainer<T&>::value);
     CHECK(detail::IsMutableContainer<T&&>::value);

--- a/tests/traits.cpp
+++ b/tests/traits.cpp
@@ -33,7 +33,7 @@ TEST_CASE_TEMPLATE("IsMutableContainer true", T, std::vector<int>, std::array<in
     CHECK(detail::IsMutableContainer<T&&>::value);
 }
 
-TEST_CASE_TEMPLATE("IsMutableContainer false", T, const std::vector<int>, const std::array<int, 3>, const Span<const int>) {
+TEST_CASE_TEMPLATE("IsMutableContainer false", T, const std::vector<int>, const std::array<int, 3>, const Span<const int>, const std::vector<bool>) {
     CHECK_FALSE(detail::IsMutableContainer<T>::value);
     CHECK_FALSE(detail::IsMutableContainer<T&>::value);
     CHECK_FALSE(detail::IsMutableContainer<T&&>::value);

--- a/tests/traits.cpp
+++ b/tests/traits.cpp
@@ -1,0 +1,40 @@
+#include <array>
+#include <list>
+#include <vector>
+
+#include "doctest/doctest.h"
+
+#include "open62541pp/Span.h"
+#include "open62541pp/detail/traits.h"
+
+using namespace opcua;
+
+TEST_CASE_TEMPLATE("IsContiguousContainer true", T, std::vector<int>, std::array<int, 3>, Span<int>, Span<const int>) {
+    CHECK(detail::IsContiguousContainer<T>::value);
+    CHECK(detail::IsContiguousContainer<T&>::value);
+    CHECK(detail::IsContiguousContainer<T&&>::value);
+    CHECK(detail::IsContiguousContainer<const T>::value);
+    CHECK(detail::IsContiguousContainer<const T&>::value);
+    CHECK(detail::IsContiguousContainer<const T&&>::value);
+}
+
+TEST_CASE_TEMPLATE("IsContiguousContainer false", T, std::list<int>, std::vector<bool>) {
+    CHECK_FALSE(detail::IsContiguousContainer<T>::value);
+    CHECK_FALSE(detail::IsContiguousContainer<T&>::value);
+    CHECK_FALSE(detail::IsContiguousContainer<T&&>::value);
+    CHECK_FALSE(detail::IsContiguousContainer<const T>::value);
+    CHECK_FALSE(detail::IsContiguousContainer<const T&>::value);
+    CHECK_FALSE(detail::IsContiguousContainer<const T&&>::value);
+}
+
+TEST_CASE_TEMPLATE("IsMutableContainer true", T, std::vector<int>, std::array<int, 3>, Span<int>) {
+    CHECK(detail::IsMutableContainer<T>::value);
+    CHECK(detail::IsMutableContainer<T&>::value);
+    CHECK(detail::IsMutableContainer<T&&>::value);
+}
+
+TEST_CASE_TEMPLATE("IsMutableContainer false", T, const std::vector<int>, const std::array<int, 3>, const Span<const int>) {
+    CHECK_FALSE(detail::IsMutableContainer<T>::value);
+    CHECK_FALSE(detail::IsMutableContainer<T&>::value);
+    CHECK_FALSE(detail::IsMutableContainer<T&&>::value);
+}


### PR DESCRIPTION
### Remove redundant `Variant` method overloads

| Removed overload                            | Replacement                                     |
|---------------------------------------------|-------------------------------------------------|
| `setArray(Span<T>)`                         | `setArray(ArrayLike&&)`                         |
| `setArray(Span<T>, const UA_DataType&)`     | `setArray(ArrayLike&&, const UA_DataType&)`     |
| `setArrayCopy(Span<T>)`                     | `setArrayCopy(ArrayLike&&)`                     |
| `setArrayCopy(Span<T>, const UA_DataType&)` | `setArrayCopy(ArrayLike&&, const UA_DataType&)` |
| `fromScalar(T&)`                            | `fromScalar(T&&)`                               |
| `fromScalar(T&, const UA_DataType&)`        | `fromScalar(T&&, const UA_DataType&)`           |
| `fromScalar(const T&)`                      | `fromScalar(T&&)`                               |
| `fromScalar(const T&, const UA_DataType&)`  | `fromScalar(T&&, const UA_DataType&)`           |
| `fromArray(Span<T>)`                        | `fromArray(ArrayLike&&)`                        |
| `fromArray(Span<T>, const UA_DataType&)`    | `fromArray(ArrayLike&&, const UA_DataType&)`    |
| `fromArray(Span<T>)`                        | `fromArray(ArrayLike&&)`                        |
| `fromArray(Span<T>, const UA_DataType&)`    | `fromArray(ArrayLike&&, const UA_DataType&)`    |

### Add `VariantPolicy` to define behaviour in factory methods

The factory methods `Variant::fromScalar` and `Variant::fromArray` now accept a `VariantPolicy` enum value as the first template parameter.

- `VariantPolicy::Copy`: Store copy of scalar/array inside the variant
- `VariantPolicy::Reference`: Store reference to scalar/array inside the variant
- `VariantPolicy::ReferenceIfPossible`: Favor referencing but fall back to copying if necessary (**default**)

Closes #164 (as a side-effect).