### PR TITLE
perf: ref-qualified Variant::getScalar

### DIFF
--- a/include/open62541pp/types/Variant.h
+++ b/include/open62541pp/types/Variant.h
@@ -33,7 +33,6 @@ private:
     using EnableIfNoSpan = typename std::enable_if_t<!detail::IsSpan<T>::value>;
 
 public:
-    // NOLINTNEXTLINE, false positive?
     using TypeWrapperBase::TypeWrapperBase;  // inherit constructors
 
     /// Create Variant from scalar value (no copy if assignable without conversion).
@@ -185,18 +184,29 @@ public:
     /// Get reference to scalar value with given template type (only native or wrapper types).
     /// @exception BadVariantAccess If the variant is not a scalar or not of type `T`.
     template <typename T>
-    T& getScalar() {
+    T& getScalar() & {
         return const_cast<T&>(std::as_const(*this).getScalar<T>());  // NOLINT
     }
 
-    /// Get const reference to scalar value with given template type (only native or wrapper types).
-    /// @exception BadVariantAccess If the variant is not a scalar or not of type `T`.
+    /// @copydoc getScalar()&
     template <typename T>
-    const T& getScalar() const {
+    const T& getScalar() const& {
         assertIsNative<T>();
         checkIsScalar();
         checkIsDataType<T>();
         return *static_cast<const T*>(handle()->data);
+    }
+
+    /// @copydoc getScalar()&
+    template <typename T>
+    T&& getScalar() && {
+        return std::move(getScalar<T>());
+    }
+
+    /// @copydoc getScalar()&
+    template <typename T>
+    const T&& getScalar() const&& {
+        return std::move(getScalar<T>());
     }
 
     /// Get copy of scalar value with given template type.

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -680,6 +680,29 @@ TEST_CASE("Variant") {
             CHECK(var.getArray<CustomType>().data() != array.data());
         }
     }
+
+    SUBCASE("getScalar (lvalue & rvalue)") {
+        auto var = Variant::fromScalar("test");
+        void* data = var.getScalar<String>()->data;
+
+        String str;
+        SUBCASE("rvalue") {
+            str = var.getScalar<String>();
+            CHECK(str->data != data);  // copy
+        }
+        SUBCASE("const rvalue") {
+            str = std::as_const(var).getScalar<String>();
+            CHECK(str->data != data);  // copy
+        }
+        SUBCASE("lvalue") {
+            str = std::move(var).getScalar<String>();
+            CHECK(str->data == data);  // move
+        }
+        SUBCASE("const lvalue") {
+            str = std::move(std::as_const(var)).getScalar<String>();
+            CHECK(str->data != data);  // can not move const -> copy
+        }
+    }
 }
 
 TEST_CASE("DataValue") {


### PR DESCRIPTION
Ref-qualified scalar getters getScalar allow to move the scalar out of a temporary Variant.

```cpp
String str = Variant::fromScalar("test").getScalar<String>();  // no copy, NEW!
```
