### PR TITLE
feat: rename DataValue methods from has/get/setStatusCode to has/get/setStatus

### DIFF
--- a/include/open62541pp/types/DataValue.h
+++ b/include/open62541pp/types/DataValue.h
@@ -31,7 +31,7 @@ public:
         std::optional<DateTime> serverTimestamp,  // NOLINT
         std::optional<uint16_t> sourcePicoseconds,
         std::optional<uint16_t> serverPicoseconds,
-        std::optional<StatusCode> statusCode
+        std::optional<StatusCode> status
     ) noexcept
         : DataValue(UA_DataValue{
               UA_Variant{},
@@ -39,13 +39,13 @@ public:
               serverTimestamp.value_or(UA_DateTime{}),
               sourcePicoseconds.value_or(uint16_t{}),
               serverPicoseconds.value_or(uint16_t{}),
-              statusCode.value_or(UA_StatusCode{}),
+              status.value_or(UA_StatusCode{}),
               false,
               sourceTimestamp.has_value(),
               serverTimestamp.has_value(),
               sourcePicoseconds.has_value(),
               serverPicoseconds.has_value(),
-              statusCode.has_value(),
+              status.has_value(),
           }) {
         setValue(std::move(value));
     }
@@ -84,8 +84,13 @@ public:
         return handle()->hasServerPicoseconds;
     }
 
-    bool hasStatusCode() const noexcept {
+    bool hasStatus() const noexcept {
         return handle()->hasStatus;
+    }
+
+    [[deprecated("Use hasStatus() instead")]]
+    bool hasStatusCode() const noexcept {
+        return hasStatus();
     }
 
     /// Get value.
@@ -128,9 +133,14 @@ public:
         return handle()->serverPicoseconds;
     }
 
-    /// Get status code.
-    StatusCode getStatusCode() const noexcept {
+    /// Get status.
+    StatusCode getStatus() const noexcept {
         return handle()->status;
+    }
+
+    [[deprecated("Use getStatus() instead")]]
+    StatusCode getStatusCode() const noexcept {
+        return getStatus();
     }
 
     /// Set value (copy).
@@ -169,10 +179,15 @@ public:
         handle()->hasServerPicoseconds = true;
     }
 
-    /// Set status code.
-    void setStatusCode(StatusCode statusCode) noexcept {
-        handle()->status = statusCode;
+    /// Set status.
+    void setStatus(StatusCode status) noexcept {
+        handle()->status = status;
         handle()->hasStatus = true;
+    }
+
+    [[deprecated("Use setStatus(StatusCode) instead.")]]
+    void setStatusCode(StatusCode statusCode) noexcept {
+        setStatus(statusCode);
     }
 };
 

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -732,7 +732,7 @@ TEST_CASE("DataValue") {
         CHECK_FALSE(dv.hasServerTimestamp());
         CHECK_FALSE(dv.hasSourcePicoseconds());
         CHECK_FALSE(dv.hasServerPicoseconds());
-        CHECK_FALSE(dv.hasStatusCode());
+        CHECK_FALSE(dv.hasStatus());
     }
 
     SUBCASE("Constructor with all optional parameter specified") {
@@ -749,7 +749,7 @@ TEST_CASE("DataValue") {
         CHECK(dv.getServerTimestamp() == DateTime{2});
         CHECK(dv.getSourcePicoseconds() == 3);
         CHECK(dv.getServerPicoseconds() == 4);
-        CHECK(dv.getStatusCode() == UA_STATUSCODE_BADINTERNALERROR);
+        CHECK(dv.getStatus() == UA_STATUSCODE_BADINTERNALERROR);
     }
 
     SUBCASE("Setter methods") {
@@ -760,6 +760,7 @@ TEST_CASE("DataValue") {
             var.setScalar(value);
             CHECK(var->data == &value);
             dv.setValue(std::move(var));
+            CHECK(dv.hasValue());
             CHECK(dv.getValue().getScalar<float>() == value);
             CHECK(dv->value.data == &value);
         }
@@ -768,32 +769,38 @@ TEST_CASE("DataValue") {
             Variant var;
             var.setScalar(value);
             dv.setValue(var);
+            CHECK(dv.hasValue());
             CHECK(dv.getValue().getScalar<float>() == value);
         }
         SUBCASE("Source timestamp") {
             DateTime dt{123};
             dv.setSourceTimestamp(dt);
+            CHECK(dv.hasSourceTimestamp());
             CHECK(dv.getSourceTimestamp() == dt);
         }
         SUBCASE("Server timestamp") {
             DateTime dt{456};
             dv.setServerTimestamp(dt);
+            CHECK(dv.hasServerTimestamp());
             CHECK(dv.getServerTimestamp() == dt);
         }
         SUBCASE("Source picoseconds") {
             const uint16_t ps = 123;
             dv.setSourcePicoseconds(ps);
+            CHECK(dv.hasSourcePicoseconds());
             CHECK(dv.getSourcePicoseconds() == ps);
         }
         SUBCASE("Server picoseconds") {
             const uint16_t ps = 456;
             dv.setServerPicoseconds(ps);
+            CHECK(dv.hasServerPicoseconds());
             CHECK(dv.getServerPicoseconds() == ps);
         }
-        SUBCASE("Status code") {
+        SUBCASE("Status") {
             const UA_StatusCode statusCode = UA_STATUSCODE_BADALREADYEXISTS;
-            dv.setStatusCode(statusCode);
-            CHECK(dv.getStatusCode() == statusCode);
+            dv.setStatus(statusCode);
+            CHECK(dv.hasStatus());
+            CHECK(dv.getStatus() == statusCode);
         }
     }
 


### PR DESCRIPTION
Use same naming as in OPC UA standard.

- `DataValue::hasStatusCode` -> `DataValue::hasStatus`
- `DataValue::getStatusCode` -> `DataValue::getStatus`
- `DataValue::setStatusCode` -> `DataValue::setStatus`

The old methods are deprecated and will be removed in the future.