### PR TITLE
fix: use UA_Array_delete instead of UA_free

### DIFF
--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -285,7 +285,7 @@ std::vector<ApplicationDescription> Client::findServers(std::string_view serverU
         std::make_move_iterator(array),
         std::make_move_iterator(array + arraySize)  // NOLINT
     );
-    UA_free(array);  // NOLINT
+    UA_Array_delete(array, arraySize, &UA_TYPES[UA_TYPES_APPLICATIONDESCRIPTION]);
     throwIfBad(status);
     return result;
 }
@@ -303,7 +303,7 @@ std::vector<EndpointDescription> Client::getEndpoints(std::string_view serverUrl
         std::make_move_iterator(array),
         std::make_move_iterator(array + arraySize)  // NOLINT
     );
-    UA_free(array);  // NOLINT
+    UA_Array_delete(array, arraySize, &UA_TYPES[UA_TYPES_ENDPOINTDESCRIPTION]);
     throwIfBad(status);
     return result;
 }

--- a/src/services/Method.cpp
+++ b/src/services/Method.cpp
@@ -64,7 +64,7 @@ std::vector<Variant> call(
         std::make_move_iterator(output),
         std::make_move_iterator(output + outputSize)  // NOLINT
     );
-    UA_free(output);  // NOLINT
+    UA_Array_delete(output, outputSize, &UA_TYPES[UA_TYPES_VARIANT]);
     throwIfBad(status);
     return result;
 }


### PR DESCRIPTION
Arrays should be deallocated using UA_Array_delete.
Otherwise non trivial members are not deleted and empty arrays cause problems. 
See #180 