### PR TITLE
feat!: rename `MonitoringParameters` -> `MonitoringParametersEx`

### DIFF
--- a/examples/client_subscription.cpp
+++ b/examples/client_subscription.cpp
@@ -39,7 +39,7 @@ int main() {
         );
 
         // Modify and delete the monitored item via the returned MonitoredItem<T> object
-        opcua::MonitoringParameters monitoringParameters{};
+        opcua::MonitoringParametersEx monitoringParameters{};
         monitoringParameters.samplingInterval = 100.0;
         mon.setMonitoringParameters(monitoringParameters);
         mon.setMonitoringMode(opcua::MonitoringMode::Reporting);

--- a/include/open62541pp/MonitoredItem.h
+++ b/include/open62541pp/MonitoredItem.h
@@ -17,7 +17,9 @@ class NodeId;
 template <typename ServerOrClient>
 class Subscription;
 
-using MonitoringParameters = services::MonitoringParameters;
+using MonitoringParametersEx = services::MonitoringParametersEx;
+using MonitoringParameters
+    [[deprecated("Use alias MonitoringParametersEx instead")]] = MonitoringParametersEx;
 
 /**
  * High-level monitored item class.
@@ -58,7 +60,7 @@ public:
     /// Modify this monitored item.
     /// @note Not implemented for Server.
     /// @see services::modifyMonitoredItem
-    void setMonitoringParameters(MonitoringParameters& parameters);
+    void setMonitoringParameters(MonitoringParametersEx& parameters);
 
     /// Set the monitoring mode of this monitored item.
     /// @note Not implemented for Server.

--- a/include/open62541pp/Subscription.h
+++ b/include/open62541pp/Subscription.h
@@ -25,7 +25,7 @@ class Span;
 class Variant;
 
 using SubscriptionParameters = services::SubscriptionParameters;
-using MonitoringParameters = services::MonitoringParameters;
+using MonitoringParametersEx = services::MonitoringParametersEx;
 
 /// Data change notification callback.
 /// @tparam T Server or Client
@@ -83,37 +83,37 @@ public:
 
     /// Create a monitored item for data change notifications (default settings).
     /// The monitoring mode is set to MonitoringMode::Reporting and the default open62541
-    /// MonitoringParameters are used.
-    /// @see services::MonitoringParameters
+    /// MonitoringParametersEx are used.
+    /// @see services::MonitoringParametersEx
     MonitoredItem<ServerOrClient> subscribeDataChange(
         const NodeId& id, AttributeId attribute, DataChangeCallback<ServerOrClient> onDataChange
     );
 
     /// Create a monitored item for data change notifications.
-    /// @copydetails services::MonitoringParameters
+    /// @copydetails services::MonitoringParametersEx
     MonitoredItem<ServerOrClient> subscribeDataChange(
         const NodeId& id,
         AttributeId attribute,
         MonitoringMode monitoringMode,
-        MonitoringParameters& parameters,
+        MonitoringParametersEx& parameters,
         DataChangeCallback<ServerOrClient> onDataChange
     );
 
     /// Create a monitored item for event notifications (default settings).
     /// The monitoring mode is set to MonitoringMode::Reporting and the default open62541
-    /// MonitoringParameters are used.
+    /// MonitoringParametersEx are used.
     /// @note Not implemented for Server.
     MonitoredItem<ServerOrClient> subscribeEvent(
         const NodeId& id, const EventFilter& eventFilter, EventCallback<ServerOrClient> onEvent
     );
 
     /// Create a monitored item for event notifications.
-    /// @copydetails services::MonitoringParameters
+    /// @copydetails services::MonitoringParametersEx
     /// @note Not implemented for Server.
     MonitoredItem<ServerOrClient> subscribeEvent(
         const NodeId& id,
         MonitoringMode monitoringMode,
-        MonitoringParameters& parameters,
+        MonitoringParametersEx& parameters,
         EventCallback<ServerOrClient> onEvent
     );
 

--- a/include/open62541pp/services/MonitoredItem.h
+++ b/include/open62541pp/services/MonitoredItem.h
@@ -39,12 +39,13 @@ namespace opcua::services {
  */
 
 /**
- * Monitoring parameters with default values from open62541.
+ * Extended monitoring parameters with default values from open62541.
+ * This is an extended version of `UA_MonitoringParameters` with the `timestamps` parameter.
  * Parameters are passed by reference because illegal parameters can be revised by the server.
  * The updated parameters reflect the actual values that the server will use.
  * @see https://reference.opcfoundation.org/Core/Part4/v105/docs/7.21
  */
-struct MonitoringParameters {
+struct MonitoringParametersEx {
     /// Timestamps to be transmitted. Won't be revised by the server.
     TimestampsToReturn timestamps = TimestampsToReturn::Both;
     /// Interval in milliseconds that defines the fastest rate at which the MonitoredItem should be
@@ -69,6 +70,9 @@ struct MonitoringParameters {
     /// - `false`: the last notification added to the queue gets replaced with the new notification
     bool discardOldest = true;
 };
+
+using MonitoringParameters
+    [[deprecated("Use alias MonitoringParametersEx instead")]] = MonitoringParametersEx;
 
 /**
  * @defgroup CreateMonitoredItems
@@ -106,7 +110,7 @@ using EventNotificationCallback =
  * Create and add a monitored item to a subscription for data change notifications.
  * Don't use this function to monitor the `EventNotifier` attribute.
  * Create a monitored item with @ref createMonitoredItemEvent instead.
- * @copydetails MonitoringParameters
+ * @copydetails MonitoringParametersEx
  *
  * @param client Instance of type Client
  * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
@@ -122,7 +126,7 @@ using EventNotificationCallback =
     uint32_t subscriptionId,
     const ReadValueId& itemToMonitor,
     MonitoringMode monitoringMode,
-    MonitoringParameters& parameters,
+    MonitoringParametersEx& parameters,
     DataChangeNotificationCallback dataChangeCallback,
     DeleteMonitoredItemCallback deleteCallback = {}
 );
@@ -130,7 +134,7 @@ using EventNotificationCallback =
 /**
  * Create a local monitored item for data change notifications.
  * Don't use this function to monitor the `EventNotifier` attribute.
- * @copydetails MonitoringParameters
+ * @copydetails MonitoringParametersEx
  *
  * @param server Instance of type Server
  * @param itemToMonitor Item to monitor
@@ -143,14 +147,14 @@ using EventNotificationCallback =
     Server& server,
     const ReadValueId& itemToMonitor,
     MonitoringMode monitoringMode,
-    MonitoringParameters& parameters,
+    MonitoringParametersEx& parameters,
     DataChangeNotificationCallback dataChangeCallback
 );
 
 /**
  * Create and add a monitored item to a subscription for event notifications.
  * The `attributeId` of ReadValueId must be set to AttributeId::EventNotifier.
- * @copydetails MonitoringParameters
+ * @copydetails MonitoringParametersEx
  *
  * @param client Instance of type Client
  * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
@@ -166,7 +170,7 @@ using EventNotificationCallback =
     uint32_t subscriptionId,
     const ReadValueId& itemToMonitor,
     MonitoringMode monitoringMode,
-    MonitoringParameters& parameters,
+    MonitoringParametersEx& parameters,
     EventNotificationCallback eventCallback,
     DeleteMonitoredItemCallback deleteCallback = {}
 );
@@ -181,7 +185,7 @@ using EventNotificationCallback =
 
 /**
  * Modify a monitored item of a subscription.
- * @copydetails MonitoringParameters
+ * @copydetails MonitoringParametersEx
  *
  * @param client Instance of type Client
  * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
@@ -192,7 +196,7 @@ void modifyMonitoredItem(
     Client& client,
     uint32_t subscriptionId,
     uint32_t monitoredItemId,
-    MonitoringParameters& parameters
+    MonitoringParametersEx& parameters
 );
 
 /**

--- a/src/MonitoredItem.cpp
+++ b/src/MonitoredItem.cpp
@@ -88,7 +88,7 @@ void MonitoredItem<Server>::deleteMonitoredItem() {
 /* ----------------------------------- Client specializations ----------------------------------- */
 
 template <>
-void MonitoredItem<Client>::setMonitoringParameters(MonitoringParameters& parameters) {
+void MonitoredItem<Client>::setMonitoringParameters(MonitoringParametersEx& parameters) {
     services::modifyMonitoredItem(connection_, subscriptionId_, monitoredItemId_, parameters);
 }
 

--- a/src/Subscription.cpp
+++ b/src/Subscription.cpp
@@ -35,7 +35,7 @@ template <typename T>
 MonitoredItem<T> Subscription<T>::subscribeDataChange(
     const NodeId& id, AttributeId attribute, DataChangeCallback<T> onDataChange
 ) {
-    MonitoringParameters parameters;
+    MonitoringParametersEx parameters;
     return subscribeDataChange(
         id, attribute, MonitoringMode::Reporting, parameters, std::move(onDataChange)
     );
@@ -72,7 +72,7 @@ MonitoredItem<Server> Subscription<Server>::subscribeDataChange(
     const NodeId& id,
     AttributeId attribute,
     MonitoringMode monitoringMode,
-    MonitoringParameters& parameters,
+    MonitoringParametersEx& parameters,
     DataChangeCallback<Server> onDataChange
 ) {
     const uint32_t monitoredItemId = services::createMonitoredItemDataChange(
@@ -123,7 +123,7 @@ MonitoredItem<Client> Subscription<Client>::subscribeDataChange(
     const NodeId& id,
     AttributeId attribute,
     MonitoringMode monitoringMode,
-    MonitoringParameters& parameters,
+    MonitoringParametersEx& parameters,
     DataChangeCallback<Client> onDataChange
 ) {
     const uint32_t monitoredItemId = services::createMonitoredItemDataChange(
@@ -146,7 +146,7 @@ template <>
 MonitoredItem<Client> Subscription<Client>::subscribeEvent(
     const NodeId& id,
     MonitoringMode monitoringMode,
-    MonitoringParameters& parameters,
+    MonitoringParametersEx& parameters,
     EventCallback<Client> onEvent
 ) {
     const uint32_t monitoredItemId = services::createMonitoredItemEvent(
@@ -169,7 +169,7 @@ template <>
 MonitoredItem<Client> Subscription<Client>::subscribeEvent(
     const NodeId& id, const EventFilter& eventFilter, EventCallback<Client> onEvent
 ) {
-    MonitoringParameters parameters;
+    MonitoringParametersEx parameters;
     parameters.filter = ExtensionObject::fromDecodedCopy(eventFilter);
     return subscribeEvent(id, MonitoringMode::Reporting, parameters, std::move(onEvent));
 }

--- a/src/services/MonitoredItem.cpp
+++ b/src/services/MonitoredItem.cpp
@@ -30,7 +30,7 @@ uint32_t createMonitoredItemDataChange(
     uint32_t subscriptionId,
     const ReadValueId& itemToMonitor,
     MonitoringMode monitoringMode,
-    MonitoringParameters& parameters,
+    MonitoringParametersEx& parameters,
     DataChangeNotificationCallback dataChangeCallback,
     DeleteMonitoredItemCallback deleteCallback
 ) {
@@ -64,7 +64,7 @@ uint32_t createMonitoredItemDataChange(
     Server& server,
     const ReadValueId& itemToMonitor,
     MonitoringMode monitoringMode,
-    MonitoringParameters& parameters,
+    MonitoringParametersEx& parameters,
     DataChangeNotificationCallback dataChangeCallback
 ) {
     auto context = std::make_unique<detail::MonitoredItemContext>();
@@ -95,7 +95,7 @@ uint32_t createMonitoredItemEvent(
     uint32_t subscriptionId,
     const ReadValueId& itemToMonitor,
     MonitoringMode monitoringMode,
-    MonitoringParameters& parameters,
+    MonitoringParametersEx& parameters,
     EventNotificationCallback eventCallback,
     DeleteMonitoredItemCallback deleteCallback
 ) {
@@ -129,7 +129,7 @@ void modifyMonitoredItem(
     Client& client,
     uint32_t subscriptionId,
     uint32_t monitoredItemId,
-    MonitoringParameters& parameters
+    MonitoringParametersEx& parameters
 ) {
     auto item = detail::createMonitoredItemModifyRequest(monitoredItemId, parameters);
     auto request = detail::createModifyMonitoredItemsRequest(subscriptionId, parameters, item);

--- a/tests/Services.cpp
+++ b/tests/Services.cpp
@@ -824,7 +824,7 @@ TEST_CASE("MonitoredItem service set (client)") {
     services::addVariable(server, {0, UA_NS0ID_OBJECTSFOLDER}, id, "Variable");
 
     services::SubscriptionParameters subscriptionParameters{};
-    services::MonitoringParameters monitoringParameters{};
+    services::MonitoringParametersEx monitoringParameters{};
 
     SUBCASE("createMonitoredItemDataChange without subscription") {
         CHECK_THROWS(discard(services::createMonitoredItemDataChange(
@@ -911,7 +911,7 @@ TEST_CASE("MonitoredItem service set (client)") {
         );
         CAPTURE(monId);
 
-        services::MonitoringParameters modifiedParameters{};
+        services::MonitoringParametersEx modifiedParameters{};
         modifiedParameters.samplingInterval = 1000.0;
         CHECK_NOTHROW(services::modifyMonitoredItem(client, subId, monId, modifiedParameters));
         CHECK(modifiedParameters.samplingInterval == 1000.0);  // should not be revised
@@ -997,7 +997,7 @@ TEST_CASE("MonitoredItem service set (client)") {
 TEST_CASE("MonitoredItem service set (server)") {
     Server server;
 
-    services::MonitoringParameters monitoringParameters{};
+    services::MonitoringParametersEx monitoringParameters{};
 
     SUBCASE("createMonitoredItemDataChange") {
         size_t notificationCount = 0;

--- a/tests/Subscription_MonitoredItem.cpp
+++ b/tests/Subscription_MonitoredItem.cpp
@@ -25,7 +25,7 @@ TEST_CASE("Subscription & MonitoredItem (server)") {
     CHECK(sub.getConnection() == server);
     CHECK(sub.getMonitoredItems().empty());
 
-    MonitoringParameters monitoringParameters{};
+    MonitoringParametersEx monitoringParameters{};
     monitoringParameters.samplingInterval = 0.0;  // = fastest practical
 
     size_t notificationCount = 0;
@@ -87,7 +87,7 @@ TEST_CASE("Subscription & MonitoredItem (client)") {
 
     SUBCASE("Monitor data change") {
         SubscriptionParameters subscriptionParameters{};
-        MonitoringParameters monitoringParameters{};
+        MonitoringParametersEx monitoringParameters{};
 
         auto sub = client.createSubscription(subscriptionParameters);
         sub.setPublishingMode(false);  // enable later
@@ -164,7 +164,7 @@ TEST_CASE("Subscription & MonitoredItem (client)") {
 
         mon.setMonitoringMode(MonitoringMode::Disabled);
 
-        MonitoringParameters monitoringParameters{};
+        MonitoringParametersEx monitoringParameters{};
         monitoringParameters.samplingInterval = 0.0;  // = fastest practical rate
         mon.setMonitoringParameters(monitoringParameters);
         CHECK(monitoringParameters.samplingInterval > 0.0);


### PR DESCRIPTION
The custom struct `MonitoringParameters` shadows the OPC UA type [`MonitoringParameter`](https://reference.opcfoundation.org/Core/Part4/v104/docs/7.16).

Alias for backwards compatibility added but deprecated.
Closes #186 .