### PR TITLE
fix: compare DataType only by typeId

### DIFF
--- a/include/open62541pp/DataType.h
+++ b/include/open62541pp/DataType.h
@@ -6,11 +6,9 @@
 #include "open62541pp/Span.h"
 #include "open62541pp/Wrapper.h"
 #include "open62541pp/detail/open62541/common.h"
+#include "open62541pp/types/NodeId.h"
 
 namespace opcua {
-
-// forward declare
-class NodeId;
 
 using DataTypeMember = UA_DataTypeMember;
 
@@ -60,16 +58,30 @@ public:
     void setMembers(Span<const DataTypeMember> members);
 };
 
-bool operator==(const UA_DataTypeMember& lhs, const UA_DataTypeMember& rhs) noexcept;
-bool operator!=(const UA_DataTypeMember& lhs, const UA_DataTypeMember& rhs) noexcept;
-bool operator==(const UA_DataType& lhs, const UA_DataType& rhs) noexcept;
-bool operator!=(const UA_DataType& lhs, const UA_DataType& rhs) noexcept;
+inline bool operator==(const UA_DataType& lhs, const UA_DataType& rhs) noexcept {
+    return lhs.typeId == rhs.typeId;
+}
+
+inline bool operator!=(const UA_DataType& lhs, const UA_DataType& rhs) noexcept {
+    return !(lhs == rhs);
+}
+
+inline bool operator==(const UA_DataTypeMember& lhs, const UA_DataTypeMember& rhs) noexcept {
+    if (lhs.memberType == nullptr || rhs.memberType == nullptr) {
+        return false;
+    }
+    return (lhs.memberType == rhs.memberType) || (*lhs.memberType == *rhs.memberType);
+}
+
+inline bool operator!=(const UA_DataTypeMember& lhs, const UA_DataTypeMember& rhs) noexcept {
+    return !(lhs == rhs);
+}
 
 /* ------------------------------------------- Helper ------------------------------------------- */
 
 namespace detail {
 
-[[nodiscard]] DataTypeMember createDataTypeMember(
+[[nodiscard]] UA_DataTypeMember createDataTypeMember(
     const char* memberName,
     const UA_DataType& memberType,
     uint8_t padding,

--- a/include/open62541pp/DataType.h
+++ b/include/open62541pp/DataType.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 
 #include "open62541pp/Common.h"  // TypeIndex
+#include "open62541pp/Config.h"
 #include "open62541pp/Span.h"
 #include "open62541pp/Wrapper.h"
 #include "open62541pp/detail/open62541/common.h"
@@ -67,10 +68,14 @@ inline bool operator!=(const UA_DataType& lhs, const UA_DataType& rhs) noexcept 
 }
 
 inline bool operator==(const UA_DataTypeMember& lhs, const UA_DataTypeMember& rhs) noexcept {
+#if UAPP_OPEN62541_VER_GE(1, 3)
     if (lhs.memberType == nullptr || rhs.memberType == nullptr) {
         return false;
     }
     return (lhs.memberType == rhs.memberType) || (*lhs.memberType == *rhs.memberType);
+#else
+    return lhs.memberTypeIndex == rhs.memberTypeIndex;
+#endif
 }
 
 inline bool operator!=(const UA_DataTypeMember& lhs, const UA_DataTypeMember& rhs) noexcept {

--- a/src/DataType.cpp
+++ b/src/DataType.cpp
@@ -6,7 +6,6 @@
 #include <utility>  // exchange, move, swap
 
 #include "open62541pp/Config.h"
-#include "open62541pp/types/NodeId.h"
 
 namespace opcua {
 
@@ -169,86 +168,6 @@ void DataType::setMembers(Span<const DataTypeMember> members) {
     assert(members.size() < (1U << 8U));
     clearMembers(native());
     copyMembers(members.data(), members.size(), native());
-}
-
-bool operator==(const UA_DataTypeMember& lhs, const UA_DataTypeMember& rhs) noexcept {
-#if UAPP_OPEN62541_VER_GE(1, 3)
-    if (lhs.memberType != rhs.memberType) {
-        return false;
-    }
-#else
-    if ((lhs.memberTypeIndex != rhs.memberTypeIndex) && (lhs.namespaceZero != rhs.namespaceZero)) {
-        return false;
-    }
-#endif
-    if (lhs.padding != rhs.padding) {
-        return false;
-    }
-    if (lhs.isArray != rhs.isArray) {
-        return false;
-    }
-#if UAPP_OPEN62541_VER_GE(1, 1)
-    if (lhs.isOptional != rhs.isOptional) {
-        return false;
-    }
-#endif
-#ifdef UA_ENABLE_TYPEDESCRIPTION
-    if (std::strcmp(emptyIfNullptr(lhs.memberName), emptyIfNullptr(rhs.memberName)) != 0) {
-        return false;
-    }
-#endif
-    return true;
-}
-
-bool operator!=(const UA_DataTypeMember& lhs, const UA_DataTypeMember& rhs) noexcept {
-    return !(lhs == rhs);
-}
-
-bool operator==(const UA_DataType& lhs, const UA_DataType& rhs) noexcept {
-    if (lhs.typeId != rhs.typeId) {
-        return false;
-    }
-    if (lhs.binaryEncodingId != rhs.binaryEncodingId) {
-        return false;
-    }
-    if (lhs.memSize != rhs.memSize) {
-        return false;
-    }
-    if (lhs.typeKind != rhs.typeKind) {
-        return false;
-    }
-    if (lhs.pointerFree != rhs.pointerFree) {
-        return false;
-    }
-    if (lhs.overlayable != rhs.overlayable) {
-        return false;
-    }
-    if (lhs.membersSize != rhs.membersSize) {
-        return false;
-    }
-    for (size_t i = 0; i < lhs.membersSize; ++i) {
-        if (lhs.members[i] != rhs.members[i]) {  // NOLINT
-            return false;
-        }
-    }
-#ifdef UA_ENABLE_TYPEDESCRIPTION
-    if (std::strcmp(emptyIfNullptr(lhs.typeName), emptyIfNullptr(rhs.typeName)) != 0) {
-        return false;  // NOLINT
-    }
-#endif
-    return true;
-}
-
-bool operator!=(const UA_DataType& lhs, const UA_DataType& rhs) noexcept {
-    return !(lhs == rhs);
-}
-
-bool operator==(const DataType& lhs, const DataType& rhs) noexcept {
-    return (*lhs.handle() == *rhs.handle());
-}
-
-bool operator!=(const DataType& lhs, const DataType& rhs) noexcept {
-    return !(lhs == rhs);
 }
 
 namespace detail {

--- a/src/DataType.cpp
+++ b/src/DataType.cpp
@@ -5,8 +5,6 @@
 #include <cstring>
 #include <utility>  // exchange, move, swap
 
-#include "open62541pp/Config.h"
-
 namespace opcua {
 
 static void clearMembers(UA_DataType& native) noexcept {

--- a/src/DataType.cpp
+++ b/src/DataType.cpp
@@ -9,10 +9,6 @@
 
 namespace opcua {
 
-[[maybe_unused]] inline static const char* emptyIfNullptr(const char* name) {
-    return name == nullptr ? "" : name;
-}
-
 static void clearMembers(UA_DataType& native) noexcept {
     delete[] native.members;  // NOLINT
     native.members = nullptr;
@@ -43,7 +39,7 @@ DataType::DataType(const UA_DataType& native)
     : Wrapper(copy(native)) {}
 
 DataType::DataType(UA_DataType&& native)
-    : Wrapper(native) {}
+    : Wrapper(std::move(native)) {}
 
 DataType::DataType(TypeIndex typeIndex)
     : DataType(UA_TYPES[typeIndex]) {  // NOLINT

--- a/src/DataType.cpp
+++ b/src/DataType.cpp
@@ -37,7 +37,7 @@ DataType::DataType(const UA_DataType& native)
     : Wrapper(copy(native)) {}
 
 DataType::DataType(UA_DataType&& native)
-    : Wrapper(std::move(native)) {}
+    : Wrapper(native) {}
 
 DataType::DataType(TypeIndex typeIndex)
     : DataType(UA_TYPES[typeIndex]) {  // NOLINT

--- a/tests/DataType.cpp
+++ b/tests/DataType.cpp
@@ -57,7 +57,6 @@ static const UA_DataType pointType = detail::createDataType(
 
 /* ---------------------------------------------------------------------------------------------- */
 
-
 static void checkDataTypeEqual(const UA_DataType& dt, const UA_DataType& expected) {
 #ifdef UA_ENABLE_TYPEDESCRIPTION
     CHECK(std::string_view(dt.typeName) == std::string_view(expected.typeName));
@@ -69,17 +68,19 @@ static void checkDataTypeEqual(const UA_DataType& dt, const UA_DataType& expecte
     CHECK(dt.pointerFree == expected.pointerFree);
     CHECK(dt.overlayable == expected.overlayable);
     for (uint8_t i = 0; i < dt.membersSize; ++i) {
+        auto& member = dt.members[i];
+        auto& memberExpected = expected.members[i];
         CAPTURE(i);
 #if UAPP_OPEN62541_VER_GE(1, 3)
-        CHECK(dt.members[i].memberType == expected.members[i].memberType);  // NOLINT
+        CHECK(member.memberType == memberExpected.memberType);  // NOLINT
 #else
-        CHECK(dt.members[i].memberTypeIndex == expected.members[i].memberTypeIndex);  // NOLINT
-        CHECK(dt.members[i].namespaceZero == expected.members[i].namespaceZero);  // NOLINT
+        CHECK(member.memberTypeIndex == memberExpected.memberTypeIndex);  // NOLINT
+        CHECK((bool)dt.members[i].namespaceZero == (bool)memberExpected.namespaceZero);  // NOLINT
 #endif
-        CHECK((uint8_t)dt.members[i].padding == (uint8_t)expected.members[i].padding);  // NOLINT
-        CHECK((bool)dt.members[i].isArray == (bool)expected.members[i].isArray);  // NOLINT
+        CHECK((uint8_t)member.padding == (uint8_t)memberExpected.padding);  // NOLINT
+        CHECK((bool)member.isArray == (bool)memberExpected.isArray);  // NOLINT
 #if UAPP_OPEN62541_VER_GE(1, 1)
-        CHECK((bool)dt.members[i].isOptional == (bool)expected.members[i].isOptional);  // NOLINT
+        CHECK((bool)member.isOptional == (bool)memberExpected.isOptional);  // NOLINT
 #endif
     }
 }


### PR DESCRIPTION
Deep comparison of all `UA_DataType` fields should not be required. Just compare the `typeId` instead.