### PR TITLE
feat!: remove logger utility functions, add server_logger example

### DIFF
--- a/doc/examples.dox
+++ b/doc/examples.dox
@@ -2,6 +2,7 @@
 @example server_minimal.cpp
 @example server.cpp
 @example server_instantiation.cpp
+@example server_logger.cpp
 @example server_valuecallback.cpp
 @example server_datasource.cpp
 @example server_accesscontrol.cpp

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -62,6 +62,7 @@ add_example(server.cpp)
 add_example(server_accesscontrol.cpp)
 add_example(server_datasource.cpp)
 add_example(server_instantiation.cpp)
+add_example(server_logger.cpp)
 add_example(server_minimal.cpp)
 add_example(server_valuecallback.cpp)
 

--- a/examples/server.cpp
+++ b/examples/server.cpp
@@ -6,10 +6,8 @@ int main() {
     opcua::Server server(4840 /* port */);
 
     server.setApplicationName("open62541pp server example");
-    server.setLogger([](auto level, auto category, auto msg) {
-        std::cout << "[" << opcua::getLogLevelName(level) << "] "
-                  << "[" << opcua::getLogCategoryName(category) << "] " << msg << std::endl;
-    });
+    server.setApplicationUri("urn:open62541pp.server.application");
+    server.setProductUri("https://open62541pp.github.io");
 
     // Add a variable node to the Objects node
     auto parentNode = server.getObjectsNode();

--- a/examples/server_logger.cpp
+++ b/examples/server_logger.cpp
@@ -1,0 +1,59 @@
+#include <iostream>
+#include <string_view>
+
+#include "open62541pp/open62541pp.h"
+
+constexpr std::string_view getLogLevelName(opcua::LogLevel level) {
+    switch (level) {
+    case opcua::LogLevel::Trace:
+        return "trace";
+    case opcua::LogLevel::Debug:
+        return "debug";
+    case opcua::LogLevel::Info:
+        return "info";
+    case opcua::LogLevel::Warning:
+        return "warning";
+    case opcua::LogLevel::Error:
+        return "error";
+    case opcua::LogLevel::Fatal:
+        return "fatal";
+    default:
+        return "unknown";
+    }
+}
+
+constexpr std::string_view getLogCategoryName(opcua::LogCategory category) {
+    switch (category) {
+    case opcua::LogCategory::Network:
+        return "network";
+    case opcua::LogCategory::SecureChannel:
+        return "channel";
+    case opcua::LogCategory::Session:
+        return "session";
+    case opcua::LogCategory::Server:
+        return "server";
+    case opcua::LogCategory::Client:
+        return "client";
+    case opcua::LogCategory::Userland:
+        return "userland";
+    case opcua::LogCategory::SecurityPolicy:
+        return "securitypolicy";
+    default:
+        return "unknown";
+    }
+}
+
+int main() {
+    auto logger = [](auto level, auto category, auto msg) {
+        std::cout << "[" << getLogLevelName(level) << "] "
+                  << "[" << getLogCategoryName(category) << "] " << msg << std::endl;
+    };
+
+    // Set logger in constructor
+    opcua::Server server(4840, {}, logger);
+
+    // Set logger after construction
+    server.setLogger(logger);
+
+    server.run();
+}

--- a/include/open62541pp/Logger.h
+++ b/include/open62541pp/Logger.h
@@ -55,48 +55,4 @@ void log(UA_Server* server, LogLevel level, LogCategory category, std::string_vi
 /// Generate log message with servers's logger.
 void log(Server& server, LogLevel level, LogCategory category, std::string_view msg);
 
-/* -------------------------------------- Utility functions ------------------------------------- */
-
-/// Get name of log level.
-constexpr std::string_view getLogLevelName(LogLevel level) {
-    switch (level) {
-    case LogLevel::Trace:
-        return "trace";
-    case LogLevel::Debug:
-        return "debug";
-    case LogLevel::Info:
-        return "info";
-    case LogLevel::Warning:
-        return "warning";
-    case LogLevel::Error:
-        return "error";
-    case LogLevel::Fatal:
-        return "fatal";
-    default:
-        return "unknown";
-    }
-}
-
-/// Get name of log category.
-constexpr std::string_view getLogCategoryName(LogCategory category) {
-    switch (category) {
-    case LogCategory::Network:
-        return "network";
-    case LogCategory::SecureChannel:
-        return "channel";
-    case LogCategory::Session:
-        return "session";
-    case LogCategory::Server:
-        return "server";
-    case LogCategory::Client:
-        return "client";
-    case LogCategory::Userland:
-        return "userland";
-    case LogCategory::SecurityPolicy:
-        return "securitypolicy";
-    default:
-        return "unknown";
-    }
-}
-
 }  // namespace opcua

--- a/tools/run_examples.py
+++ b/tools/run_examples.py
@@ -101,6 +101,7 @@ def main():
     run(path / exe("typeconversion"))
 
     run(path / exe("server"))
+    run(path / exe("server_logger"))
     run(path / exe("server_instantiation"))
     run(path / exe("server_valuecallback"))
     run(path / exe("server_datasource"))


### PR DESCRIPTION
Remove following logger utility functions:
```cpp
constexpr std::string_view getLogLevelName(opcua::LogLevel level);
constexpr std::string_view getLogCategoryName(opcua::LogCategory category);
```

Add `server_logger` example with previous utility functions.