### PR TITLE
feat!: return AccessControl user token policies as Span

### DIFF
--- a/include/open62541pp/AccessControl.h
+++ b/include/open62541pp/AccessControl.h
@@ -5,8 +5,9 @@
 #include <vector>
 
 #include "open62541pp/Bitmask.h"
+#include "open62541pp/Span.h"
 #include "open62541pp/types/Builtin.h"
-#include "open62541pp/types/Composed.h"
+#include "open62541pp/types/Composed.h"  // UserTokenPolicy, PerformUpdateType
 #include "open62541pp/types/NodeId.h"
 
 namespace opcua {
@@ -59,8 +60,9 @@ public:
      * Get available user token policies.
      * If the `securityPolicyUri` is empty, the highest available security policy will be used to
      * transfer user tokens.
+     * @note The returned span must be valid throughout the lifetime of the instance.
      */
-    virtual std::vector<UserTokenPolicy> getUserTokenPolicies() = 0;
+    virtual Span<UserTokenPolicy> getUserTokenPolicies() = 0;
 
     /**
      * Authenticate a session.
@@ -140,7 +142,7 @@ class AccessControlDefault : public AccessControlBase {
 public:
     explicit AccessControlDefault(bool allowAnonymous = true, std::vector<Login> logins = {});
 
-    std::vector<UserTokenPolicy> getUserTokenPolicies() override;
+    Span<UserTokenPolicy> getUserTokenPolicies() override;
 
     StatusCode activateSession(
         Session& session,
@@ -190,6 +192,7 @@ public:
 private:
     bool allowAnonymous_;
     std::vector<Login> logins_;
+    std::vector<UserTokenPolicy> userTokenPolicies_;
 };
 
 }  // namespace opcua

--- a/src/AccessControl.cpp
+++ b/src/AccessControl.cpp
@@ -16,15 +16,12 @@ constexpr std::string_view policyIdUsername = "open62541-username-policy";
 
 AccessControlDefault::AccessControlDefault(bool allowAnonymous, std::vector<Login> logins)
     : allowAnonymous_(allowAnonymous),
-      logins_(std::move(logins)) {}
-
-std::vector<UserTokenPolicy> AccessControlDefault::getUserTokenPolicies() {
-    std::vector<UserTokenPolicy> result;
+      logins_(std::move(logins)) {
     std::string_view issuedTokenType{};
     std::string_view issuerEndpointUrl{};
     std::string_view securityPolicyUri{};
     if (allowAnonymous_) {
-        result.emplace_back(
+        userTokenPolicies_.emplace_back(
             policyIdAnonymous,
             UserTokenType::Anonymous,
             issuedTokenType,
@@ -33,7 +30,7 @@ std::vector<UserTokenPolicy> AccessControlDefault::getUserTokenPolicies() {
         );
     }
     if (!logins_.empty()) {
-        result.emplace_back(
+        userTokenPolicies_.emplace_back(
             policyIdUsername,
             UserTokenType::Username,
             issuedTokenType,
@@ -41,7 +38,10 @@ std::vector<UserTokenPolicy> AccessControlDefault::getUserTokenPolicies() {
             securityPolicyUri
         );
     }
-    return result;
+}
+
+Span<UserTokenPolicy> AccessControlDefault::getUserTokenPolicies() {
+    return userTokenPolicies_;
 }
 
 StatusCode AccessControlDefault::activateSession(

--- a/src/CustomAccessControl.cpp
+++ b/src/CustomAccessControl.cpp
@@ -341,8 +341,8 @@ void CustomAccessControl::setAccessControl(UA_AccessControl& ac) {
     detail::clear(ac);
 
     ac.context = this;
-    ac.userTokenPoliciesSize = userTokenPolicies_.size();
-    ac.userTokenPolicies = asNative(userTokenPolicies_.data());
+    ac.userTokenPoliciesSize = getAccessControl()->getUserTokenPolicies().size();
+    ac.userTokenPolicies = asNative(getAccessControl()->getUserTokenPolicies().data());
     ac.activateSession = activateSession;
     ac.closeSession = closeSession;
     ac.getUserRightsMask = getUserRightsMask;
@@ -368,7 +368,6 @@ void CustomAccessControl::setAccessControl(UA_AccessControl& ac) {
 void CustomAccessControl::setAccessControl(
     UA_AccessControl& native, AccessControlBase& accessControl
 ) {
-    userTokenPolicies_ = accessControl.getUserTokenPolicies();
     accessControl_ = &accessControl;
     setAccessControl(native);
 }
@@ -376,7 +375,6 @@ void CustomAccessControl::setAccessControl(
 void CustomAccessControl::setAccessControl(
     UA_AccessControl& native, std::unique_ptr<AccessControlBase> accessControl
 ) {
-    userTokenPolicies_ = accessControl->getUserTokenPolicies();
     accessControl_ = std::move(accessControl);
     setAccessControl(native);
 }

--- a/tests/AccessControl.cpp
+++ b/tests/AccessControl.cpp
@@ -17,13 +17,12 @@ TEST_CASE("AccessControlDefault") {
     SUBCASE("getUserTokenPolicies") {
         AccessControlDefault ac(true, {{"username", "password"}});
 
-        const auto userTokenPolicies = ac.getUserTokenPolicies();
-        CHECK(userTokenPolicies.size() == 2);
-        CHECK(userTokenPolicies.at(0).getPolicyId() == "open62541-anonymous-policy");
-        CHECK(userTokenPolicies.at(0).getTokenType() == UserTokenType::Anonymous);
+        CHECK(ac.getUserTokenPolicies().size() == 2);
+        CHECK(ac.getUserTokenPolicies()[0].getPolicyId() == "open62541-anonymous-policy");
+        CHECK(ac.getUserTokenPolicies()[0].getTokenType() == UserTokenType::Anonymous);
 
-        CHECK(userTokenPolicies.at(1).getPolicyId() == "open62541-username-policy");
-        CHECK(userTokenPolicies.at(1).getTokenType() == UserTokenType::Username);
+        CHECK(ac.getUserTokenPolicies()[1].getPolicyId() == "open62541-username-policy");
+        CHECK(ac.getUserTokenPolicies()[1].getTokenType() == UserTokenType::Username);
     }
 
     SUBCASE("activateSession") {


### PR DESCRIPTION
Following function signature of `AccessControlBase` is changed:

```cpp
// old
virtual std::vector<UserTokenPolicy> getUserTokenPolicies() = 0;
// new
virtual Span<UserTokenPolicy> getUserTokenPolicies() = 0;
```

The user token policies can be stored internally as a `std::vector<UserTokenPolicy>` and returned as a `Span<UserTokenPolicy>`.
Please make sure, that the span must be valid throughout the lifetime of the AccessControl instance. Modifications of the underlying vector may invalidate the span.