### PR TITLE
feat!: deprecate `Server::setAccessControl` by reference

### DIFF
--- a/examples/server_accesscontrol.cpp
+++ b/examples/server_accesscontrol.cpp
@@ -45,14 +45,14 @@ int main() {
     // We are doing this just for demonstration, don't use it in production!
     Server server;
 
-    AccessControlCustom accessControl(
+    // Create AccessControlCustom instance and transfer ownership to server
+    server.setAccessControl(std::make_unique<AccessControlCustom>(
         true,  // allow anonymous
-        {
+        std::vector<Login>{
             {"admin", "admin"},
             {"user", "user"},
         }
-    );
-    server.setAccessControl(accessControl);
+    ));
 
     // Add variable node. Try to change its value as a client with different logins.
     server.getObjectsNode().addVariable(

--- a/include/open62541pp/Server.h
+++ b/include/open62541pp/Server.h
@@ -110,6 +110,7 @@ public:
 
     /// Set custom access control.
     /// @note Supported since open62541 v1.3
+    [[deprecated("Transfer ownership with std::unique_ptr<AccessControlBase> instead")]]
     void setAccessControl(AccessControlBase& accessControl);
     /// Set custom access control (transfer ownership to Server).
     /// @note Supported since open62541 v1.3

--- a/src/ServerConfig.h
+++ b/src/ServerConfig.h
@@ -36,7 +36,7 @@ public:
         customDataTypes_.assign(std::move(dataTypes));
     }
 
-    [[deprecated]]
+    // deprecated in server interface
     void setAccessControl(AccessControlBase& accessControl) {
         accessControl_.assign(&accessControl);
         setHighestSecurityPolicyForUserTokenTransfer();

--- a/src/ServerConfig.h
+++ b/src/ServerConfig.h
@@ -36,6 +36,7 @@ public:
         customDataTypes_.assign(std::move(dataTypes));
     }
 
+    [[deprecated]]
     void setAccessControl(AccessControlBase& accessControl) {
         accessControl_.assign(&accessControl);
         setHighestSecurityPolicyForUserTokenTransfer();

--- a/src/plugins/PluginManager.h
+++ b/src/plugins/PluginManager.h
@@ -25,7 +25,7 @@ public:
         }
     }
 
-    // TODO: deprecate, pointer might get invalided
+    [[deprecated("Lifetime can not be controlled and pointer might become dangling")]]
     void assign(AdapterType* adapter) {
         if (adapter != nullptr) {
             adapter_ = adapter;

--- a/src/plugins/PluginManager.h
+++ b/src/plugins/PluginManager.h
@@ -25,7 +25,7 @@ public:
         }
     }
 
-    [[deprecated("Lifetime can not be controlled and pointer might become dangling")]]
+    // deprecated: lifetime can not be controlled and pointer might become dangling
     void assign(AdapterType* adapter) {
         if (adapter != nullptr) {
             adapter_ = adapter;

--- a/tests/AccessControl.cpp
+++ b/tests/AccessControl.cpp
@@ -17,7 +17,7 @@ TEST_CASE("AccessControlDefault") {
     Server server;
 
     SUBCASE("getUserTokenPolicies") {
-        AccessControlDefault ac(true, {{"username", "password"}});
+        AccessControlDefault ac(true, std::vector<Login>{{"username", "password"}});
 
         CHECK(ac.getUserTokenPolicies().size() == 2);
         CHECK(ac.getUserTokenPolicies()[0].getPolicyId() == "open62541-anonymous-policy");

--- a/tests/Client.cpp
+++ b/tests/Client.cpp
@@ -78,9 +78,10 @@ TEST_CASE("Client anonymous login") {
 
 #if UAPP_OPEN62541_VER_GE(1, 3)
 TEST_CASE("Client username/password login") {
-    AccessControlDefault accessControl(false, {{"username", "password"}});
     Server server;
-    server.setAccessControl(accessControl);
+    server.setAccessControl(
+        std::make_unique<AccessControlDefault>(false, std::vector<Login>{{"username", "password"}})
+    );
     ServerRunner serverRunner(server);
     Client client;
 

--- a/tests/Config.cpp
+++ b/tests/Config.cpp
@@ -28,8 +28,7 @@ TEST_CASE("ServerConfig") {
                 endpoint.userIdentityTokensSize = 0;
             }
 
-            AccessControlDefault accessControl;
-            config.setAccessControl(accessControl);
+            config.setAccessControl(std::make_unique<AccessControlDefault>());
             auto& ac = config->accessControl;
 
             for (size_t i = 0; i < config->endpointsSize; ++i) {
@@ -39,8 +38,9 @@ TEST_CASE("ServerConfig") {
         }
 
         SUBCASE("Use highest security policy to transfer user tokens") {
-            AccessControlDefault accessControl(true, {{"user", "password"}});
-            config.setAccessControl(accessControl);
+            config.setAccessControl(std::make_unique<AccessControlDefault>(
+                true, std::vector<Login>{{"user", "password"}}
+            ));
             auto& ac = config->accessControl;
 
             CHECK(ac.userTokenPoliciesSize == 2);


### PR DESCRIPTION
The lifetime of the access control instance can not be controlled and the reference might become dangling.
Use following overload instead:
```cpp
void Server::setAccessControl(std::unique_ptr<AccessControlBase> accessControl)  // transfer ownership to server
```