### PR TITLE
ci: temporary workaround for sanitizer crashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
       CC: ${{ matrix.config.CC }}
       CXX: ${{ matrix.config.CXX }}
     steps:
+      - name: Temporary workaround for sanitizer crashes
+        # https://github.com/actions/runner-images/issues/9491
+        # the issue should be fixed in the next runner image for Ubuntu 22.04:
+        # https://github.com/actions/runner-images/pull/9513
+        run: sudo sysctl vm.mmap_rnd_bits=28
       - uses: actions/checkout@v4
         with:
           submodules: recursive


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/9491.
The issue should be fixed in the next runner image for Ubuntu 22.04: https://github.com/actions/runner-images/pull/9513