### PR TITLE
refactor: handle immediate data change callbacks

### DIFF
--- a/include/open62541pp/detail/ContextMap.h
+++ b/include/open62541pp/detail/ContextMap.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -72,15 +73,20 @@ public:
 
     /// Acquire the lock/mutex for unique access to the underlying map.
     [[nodiscard]] auto acquireLock() const {
-        return std::lock_guard(mutex_);
+        return std::unique_lock(mutex_);
     }
 
     /// Get access to the underlying map. Use `acquireLock` before any operation.
     const auto& underlying() const noexcept {
+        assertLocked();
         return map_;
     }
 
 private:
+    void assertLocked() const {
+        assert(std::unique_lock(mutex_, std::defer_lock).try_lock() == false);
+    }
+
     std::map<Key, std::unique_ptr<Item>> map_;
     mutable std::mutex mutex_;
 };

--- a/include/open62541pp/services/detail/MonitoredItemContext.h
+++ b/include/open62541pp/services/detail/MonitoredItemContext.h
@@ -18,6 +18,7 @@ struct UA_Server;
 namespace opcua::services::detail {
 
 struct MonitoredItemContext : CallbackAdapter, opcua::detail::Staleable {
+    bool inserted{false};
     ReadValueId itemToMonitor;
     std::function<void(uint32_t subId, uint32_t monId, const DataValue&)> dataChangeCallback;
     std::function<void(uint32_t subId, uint32_t monId, Span<const Variant>)> eventCallback;
@@ -34,6 +35,9 @@ struct MonitoredItemContext : CallbackAdapter, opcua::detail::Staleable {
     ) noexcept {
         if (monContext != nullptr && value != nullptr) {
             auto* self = static_cast<MonitoredItemContext*>(monContext);
+            if (!self->inserted) {
+                return;  // avoid immediate callbacks before insertion
+            }
             self->invoke(self->dataChangeCallback, 0U, monId, asWrapper<DataValue>(*value));
         }
     }
@@ -48,6 +52,9 @@ struct MonitoredItemContext : CallbackAdapter, opcua::detail::Staleable {
     ) noexcept {
         if (monContext != nullptr && value != nullptr) {
             auto* self = static_cast<MonitoredItemContext*>(monContext);
+            if (!self->inserted) {
+                return;  // avoid immediate callbacks before insertion
+            }
             self->invoke(self->dataChangeCallback, subId, monId, asWrapper<DataValue>(*value));
         }
     }
@@ -63,6 +70,9 @@ struct MonitoredItemContext : CallbackAdapter, opcua::detail::Staleable {
     ) noexcept {
         if (monContext != nullptr) {
             auto* self = static_cast<MonitoredItemContext*>(monContext);
+            if (!self->inserted) {
+                return;  // avoid immediate callbacks before insertion
+            }
             self->invoke(
                 self->eventCallback,
                 subId,

--- a/src/Subscription.cpp
+++ b/src/Subscription.cpp
@@ -80,10 +80,10 @@ MonitoredItem<Server> Subscription<Server>::subscribeDataChange(
         {id, attribute},
         monitoringMode,
         parameters,
-        [&, callback = std::move(onDataChange)](
+        [connectionPtr = &connection_, callback = std::move(onDataChange)](
             uint32_t subId, uint32_t monId, const DataValue& value
         ) {
-            const MonitoredItem<Server> monitoredItem(connection_, subId, monId);
+            const MonitoredItem<Server> monitoredItem(*connectionPtr, subId, monId);
             callback(monitoredItem, value);
         }
     );
@@ -121,10 +121,10 @@ MonitoredItem<Client> Subscription<Client>::subscribeDataChange(
         {id, attribute},
         monitoringMode,
         parameters,
-        [&, callback = std::move(onDataChange)](
+        [connectionPtr = &connection_, callback = std::move(onDataChange)](
             uint32_t subId, uint32_t monId, const DataValue& value
         ) {
-            const MonitoredItem<Client> monitoredItem(connection_, subId, monId);
+            const MonitoredItem<Client> monitoredItem(*connectionPtr, subId, monId);
             callback(monitoredItem, value);
         }
     );
@@ -144,10 +144,10 @@ MonitoredItem<Client> Subscription<Client>::subscribeEvent(
         {id, AttributeId::EventNotifier},
         monitoringMode,
         parameters,
-        [&, callback = std::move(onEvent)](
+        [connectionPtr = &connection_, callback = std::move(onEvent)](
             uint32_t subId, uint32_t monId, Span<const Variant> eventFields
         ) {
-            const MonitoredItem<Client> monitoredItem(connection_, subId, monId);
+            const MonitoredItem<Client> monitoredItem(*connectionPtr, subId, monId);
             callback(monitoredItem, eventFields);
         }
     );

--- a/src/services/MonitoredItem.cpp
+++ b/src/services/MonitoredItem.cpp
@@ -53,9 +53,10 @@ uint32_t createMonitoredItemDataChange(
     detail::reviseMonitoringParameters(parameters, asNative(result));
 
     const auto monitoredItemId = result->monitoredItemId;
-    opcua::detail::getContext(client).monitoredItems.insert(
+    auto* contextPtr = opcua::detail::getContext(client).monitoredItems.insert(
         {subscriptionId, monitoredItemId}, std::move(context)
     );
+    contextPtr->inserted = true;
     return monitoredItemId;
 }
 
@@ -83,9 +84,10 @@ uint32_t createMonitoredItemDataChange(
     detail::reviseMonitoringParameters(parameters, asNative(result));
 
     const auto monitoredItemId = result->monitoredItemId;
-    opcua::detail::getContext(server).monitoredItems.insert(
+    auto* contextPtr = opcua::detail::getContext(server).monitoredItems.insert(
         {0U, monitoredItemId}, std::move(context)
     );
+    contextPtr->inserted = true;
     return monitoredItemId;
 }
 
@@ -118,9 +120,10 @@ uint32_t createMonitoredItemEvent(
     detail::reviseMonitoringParameters(parameters, asNative(result));
 
     const auto monitoredItemId = result->monitoredItemId;
-    opcua::detail::getContext(client).monitoredItems.insert(
+    auto* contextPtr = opcua::detail::getContext(client).monitoredItems.insert(
         {subscriptionId, monitoredItemId}, std::move(context)
     );
+    contextPtr->inserted = true;
     return monitoredItemId;
 }
 


### PR DESCRIPTION
Simplify handling of immediate callbacks before context insertion.