### PR TITLE
feat: symmetric createMonitoredItemDataChange, deleteMonitoredItem

### DIFF
--- a/include/open62541pp/services/MonitoredItem.h
+++ b/include/open62541pp/services/MonitoredItem.h
@@ -112,8 +112,9 @@ using EventNotificationCallback =
  * Create a monitored item with @ref createMonitoredItemEvent instead.
  * @copydetails MonitoringParametersEx
  *
- * @param client Instance of type Client
- * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
+ * @param connection Instance of type Server or Client
+ * @param subscriptionId Identifier of the subscription returned by @ref createSubscription.
+ *                       Use `0U` for a local server-side monitored item.
  * @param itemToMonitor Item to monitor
  * @param monitoringMode Monitoring mode
  * @param parameters Monitoring parameters, may be revised by server
@@ -121,8 +122,9 @@ using EventNotificationCallback =
  * @param deleteCallback Invoked when the monitored item is deleted
  * @returns Server-assigned identifier of the monitored item
  */
+template <typename T>
 [[nodiscard]] uint32_t createMonitoredItemDataChange(
-    Client& client,
+    T& connection,
     uint32_t subscriptionId,
     const ReadValueId& itemToMonitor,
     MonitoringMode monitoringMode,
@@ -136,7 +138,7 @@ using EventNotificationCallback =
  * Don't use this function to monitor the `EventNotifier` attribute.
  * @copydetails MonitoringParametersEx
  *
- * @param server Instance of type Server
+ * @param connection Instance of type Server
  * @param itemToMonitor Item to monitor
  * @param monitoringMode Monitoring mode
  * @param parameters Monitoring parameters, may be revised by server
@@ -144,7 +146,7 @@ using EventNotificationCallback =
  * @returns Server-assigned identifier of the monitored item
  */
 [[nodiscard]] uint32_t createMonitoredItemDataChange(
-    Server& server,
+    Server& connection,
     const ReadValueId& itemToMonitor,
     MonitoringMode monitoringMode,
     MonitoringParametersEx& parameters,
@@ -156,7 +158,7 @@ using EventNotificationCallback =
  * The `attributeId` of ReadValueId must be set to AttributeId::EventNotifier.
  * @copydetails MonitoringParametersEx
  *
- * @param client Instance of type Client
+ * @param connection Instance of type Client
  * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
  * @param itemToMonitor Item to monitor
  * @param monitoringMode Monitoring mode
@@ -166,7 +168,7 @@ using EventNotificationCallback =
  * @returns Server-assigned identifier of the monitored item
  */
 [[nodiscard]] uint32_t createMonitoredItemEvent(
-    Client& client,
+    Client& connection,
     uint32_t subscriptionId,
     const ReadValueId& itemToMonitor,
     MonitoringMode monitoringMode,
@@ -187,13 +189,13 @@ using EventNotificationCallback =
  * Modify a monitored item of a subscription.
  * @copydetails MonitoringParametersEx
  *
- * @param client Instance of type Client
+ * @param connection Instance of type Client
  * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
  * @param monitoredItemId Identifier of the monitored item
  * @param parameters Monitoring parameters, may be revised by server
  */
 void modifyMonitoredItem(
-    Client& client,
+    Client& connection,
     uint32_t subscriptionId,
     uint32_t monitoredItemId,
     MonitoringParametersEx& parameters
@@ -210,13 +212,13 @@ void modifyMonitoredItem(
 /**
  * Set the monitoring mode of a monitored item.
  *
- * @param client Instance of type Client
+ * @param connection Instance of type Client
  * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
  * @param monitoredItemId Identifier of the monitored item
  * @param monitoringMode Monitoring mode
  */
 void setMonitoringMode(
-    Client& client, uint32_t subscriptionId, uint32_t monitoredItemId, MonitoringMode monitoringMode
+    Client& connection, uint32_t subscriptionId, uint32_t monitoredItemId, MonitoringMode monitoringMode
 );
 
 /**
@@ -233,14 +235,14 @@ void setMonitoringMode(
  * The triggering item and the items to report shall belong to the same subscription.
  * @note Supported since open62541 v1.2
  *
- * @param client Instance of type Client
+ * @param connection Instance of type Client
  * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
  * @param triggeringItemId Identifier of the triggering monitored item
  * @param linksToAdd List of monitoring item identifiers to be added as triggering links
  * @param linksToRemove List of monitoring item identifiers to be removed as triggering links
  */
 void setTriggering(
-    Client& client,
+    Client& connection,
     uint32_t subscriptionId,
     uint32_t triggeringItemId,
     Span<const uint32_t> linksToAdd,
@@ -258,11 +260,13 @@ void setTriggering(
 /**
  * Delete a monitored item from a subscription.
  *
- * @param client Instance of type Client
- * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
+ * @param connection Instance of type Server or Client
+ * @param subscriptionId Identifier of the subscription returned by @ref createSubscription.
+ *                       Use `0U` for a local server-side monitored item.
  * @param monitoredItemId Identifier of the monitored item
  */
-void deleteMonitoredItem(Client& client, uint32_t subscriptionId, uint32_t monitoredItemId);
+template <typename T>
+void deleteMonitoredItem(T& connection, uint32_t subscriptionId, uint32_t monitoredItemId);
 
 /**
  * Delete a local monitored item.
@@ -270,7 +274,7 @@ void deleteMonitoredItem(Client& client, uint32_t subscriptionId, uint32_t monit
  * @param server Instance of type Server
  * @param monitoredItemId Identifier of the monitored item
  */
-void deleteMonitoredItem(Server& server, uint32_t monitoredItemId);
+void deleteMonitoredItem(Server& connection, uint32_t monitoredItemId);
 
 /**
  * @}

--- a/src/MonitoredItem.cpp
+++ b/src/MonitoredItem.cpp
@@ -15,39 +15,6 @@
 namespace opcua {
 
 template <typename T>
-MonitoredItem<T>::MonitoredItem(
-    T& connection, uint32_t subscriptionId, uint32_t monitoredItemId
-) noexcept
-    : connection_(connection),
-      subscriptionId_(subscriptionId),
-      monitoredItemId_(monitoredItemId) {}
-
-template <typename T>
-T& MonitoredItem<T>::getConnection() noexcept {
-    return connection_;
-}
-
-template <typename T>
-const T& MonitoredItem<T>::getConnection() const noexcept {
-    return connection_;
-}
-
-template <typename T>
-uint32_t MonitoredItem<T>::getSubscriptionId() const noexcept {
-    return subscriptionId_;
-}
-
-template <typename T>
-uint32_t MonitoredItem<T>::getMonitoredItemId() const noexcept {
-    return monitoredItemId_;
-}
-
-template <typename T>
-Subscription<T> MonitoredItem<T>::getSubscription() const {
-    return {connection_, subscriptionId_};
-}
-
-template <typename T>
 inline static auto& getMonitoredItemContext(
     T& connection, uint32_t subscriptionId, uint32_t monitoredItemId
 ) {
@@ -71,20 +38,6 @@ AttributeId MonitoredItem<T>::getAttributeId() const {
         .itemToMonitor.getAttributeId();
 }
 
-/* ----------------------------------- Server specializations ----------------------------------- */
-
-template <>
-MonitoredItem<Server>::MonitoredItem(
-    Server& connection, [[maybe_unused]] uint32_t subscriptionId, uint32_t monitoredItemId
-) noexcept
-    : connection_(connection),
-      monitoredItemId_(monitoredItemId) {}
-
-template <>
-void MonitoredItem<Server>::deleteMonitoredItem() {
-    services::deleteMonitoredItem(connection_, monitoredItemId_);
-}
-
 /* ----------------------------------- Client specializations ----------------------------------- */
 
 template <>
@@ -95,11 +48,6 @@ void MonitoredItem<Client>::setMonitoringParameters(MonitoringParametersEx& para
 template <>
 void MonitoredItem<Client>::setMonitoringMode(MonitoringMode monitoringMode) {
     services::setMonitoringMode(connection_, subscriptionId_, monitoredItemId_, monitoringMode);
-}
-
-template <>
-void MonitoredItem<Client>::deleteMonitoredItem() {
-    services::deleteMonitoredItem(connection_, subscriptionId_, monitoredItemId_);
 }
 
 /* ---------------------------------------------------------------------------------------------- */

--- a/src/Subscription.cpp
+++ b/src/Subscription.cpp
@@ -17,21 +17,6 @@
 namespace opcua {
 
 template <typename T>
-T& Subscription<T>::getConnection() noexcept {
-    return connection_;
-}
-
-template <typename T>
-const T& Subscription<T>::getConnection() const noexcept {
-    return connection_;
-}
-
-template <typename T>
-uint32_t Subscription<T>::getSubscriptionId() const noexcept {
-    return subscriptionId_;
-}
-
-template <typename T>
 MonitoredItem<T> Subscription<T>::subscribeDataChange(
     const NodeId& id, AttributeId attribute, DataChangeCallback<T> onDataChange
 ) {
@@ -61,13 +46,6 @@ std::vector<MonitoredItem<T>> Subscription<T>::getMonitoredItems() {
 /* ----------------------------------- Server specializations ----------------------------------- */
 
 template <>
-Subscription<Server>::Subscription(
-    Server& connection,
-    [[maybe_unused]] uint32_t subscriptionId  // ignore specified id and use default 0U
-) noexcept
-    : connection_(connection) {}
-
-template <>
 MonitoredItem<Server> Subscription<Server>::subscribeDataChange(
     const NodeId& id,
     AttributeId attribute,
@@ -91,11 +69,6 @@ MonitoredItem<Server> Subscription<Server>::subscribeDataChange(
 }
 
 /* ----------------------------------- Client specializations ----------------------------------- */
-
-template <>
-Subscription<Client>::Subscription(Client& connection, uint32_t subscriptionId) noexcept
-    : connection_(connection),
-      subscriptionId_(subscriptionId) {}
 
 template <>
 void Subscription<Client>::setSubscriptionParameters(SubscriptionParameters& parameters) {

--- a/src/services/MonitoredItem.cpp
+++ b/src/services/MonitoredItem.cpp
@@ -26,7 +26,7 @@ namespace opcua::services {
 
 template <>
 uint32_t createMonitoredItemDataChange<Client>(
-    Client& client,
+    Client& connection,
     uint32_t subscriptionId,
     const ReadValueId& itemToMonitor,
     MonitoringMode monitoringMode,
@@ -35,14 +35,15 @@ uint32_t createMonitoredItemDataChange<Client>(
     DeleteMonitoredItemCallback deleteCallback
 ) {
     auto context = std::make_unique<detail::MonitoredItemContext>();
-    context->catcher = &opcua::detail::getContext(client).exceptionCatcher;
+    context->catcher = &opcua::detail::getContext(connection).exceptionCatcher;
     context->itemToMonitor = itemToMonitor;
     context->dataChangeCallback = std::move(dataChangeCallback);
     context->deleteCallback = std::move(deleteCallback);
+    auto* contextPtr = context.get();
 
     using Result = TypeWrapper<UA_MonitoredItemCreateResult, UA_TYPES_MONITOREDITEMCREATERESULT>;
     const Result result = UA_Client_MonitoredItems_createDataChange(
-        client.handle(),
+        connection.handle(),
         subscriptionId,
         static_cast<UA_TimestampsToReturn>(parameters.timestamps),
         detail::createMonitoredItemCreateRequest(itemToMonitor, monitoringMode, parameters),
@@ -54,16 +55,15 @@ uint32_t createMonitoredItemDataChange<Client>(
     detail::reviseMonitoringParameters(parameters, asNative(result));
 
     const auto monitoredItemId = result->monitoredItemId;
-    auto* contextPtr = opcua::detail::getContext(client).monitoredItems.insert(
-        {subscriptionId, monitoredItemId}, std::move(context)
-    );
+    opcua::detail::getContext(connection)
+        .monitoredItems.insert({subscriptionId, monitoredItemId}, std::move(context));
     contextPtr->inserted = true;
     return monitoredItemId;
 }
 
 template <>
 uint32_t createMonitoredItemDataChange<Server>(
-    Server& server,
+    Server& connection,
     [[maybe_unused]] uint32_t subscriptionId,
     const ReadValueId& itemToMonitor,
     MonitoringMode monitoringMode,
@@ -72,14 +72,15 @@ uint32_t createMonitoredItemDataChange<Server>(
     DeleteMonitoredItemCallback deleteCallback
 ) {
     auto context = std::make_unique<detail::MonitoredItemContext>();
-    context->catcher = &opcua::detail::getContext(server).exceptionCatcher;
+    context->catcher = &opcua::detail::getContext(connection).exceptionCatcher;
     context->itemToMonitor = itemToMonitor;
     context->dataChangeCallback = std::move(dataChangeCallback);
     context->deleteCallback = std::move(deleteCallback);
+    auto* contextPtr = context.get();
 
     using Result = TypeWrapper<UA_MonitoredItemCreateResult, UA_TYPES_MONITOREDITEMCREATERESULT>;
     const Result result = UA_Server_createDataChangeMonitoredItem(
-        server.handle(),
+        connection.handle(),
         static_cast<UA_TimestampsToReturn>(parameters.timestamps),
         detail::createMonitoredItemCreateRequest(itemToMonitor, monitoringMode, parameters),
         context.get(),
@@ -89,9 +90,8 @@ uint32_t createMonitoredItemDataChange<Server>(
     detail::reviseMonitoringParameters(parameters, asNative(result));
 
     const auto monitoredItemId = result->monitoredItemId;
-    auto* contextPtr = opcua::detail::getContext(server).monitoredItems.insert(
-        {0U, monitoredItemId}, std::move(context)
-    );
+    opcua::detail::getContext(connection)
+        .monitoredItems.insert({0U, monitoredItemId}, std::move(context));
     contextPtr->inserted = true;
     return monitoredItemId;
 }
@@ -109,7 +109,7 @@ uint32_t createMonitoredItemDataChange<Server>(
 }
 
 uint32_t createMonitoredItemEvent(
-    Client& client,
+    Client& connection,
     uint32_t subscriptionId,
     const ReadValueId& itemToMonitor,
     MonitoringMode monitoringMode,
@@ -118,14 +118,15 @@ uint32_t createMonitoredItemEvent(
     DeleteMonitoredItemCallback deleteCallback
 ) {
     auto context = std::make_unique<detail::MonitoredItemContext>();
-    context->catcher = &opcua::detail::getContext(client).exceptionCatcher;
+    context->catcher = &opcua::detail::getContext(connection).exceptionCatcher;
     context->itemToMonitor = itemToMonitor;
     context->eventCallback = std::move(eventCallback);
     context->deleteCallback = std::move(deleteCallback);
+    auto* contextPtr = context.get();
 
     using Result = TypeWrapper<UA_MonitoredItemCreateResult, UA_TYPES_MONITOREDITEMCREATERESULT>;
     const Result result = UA_Client_MonitoredItems_createEvent(
-        client.handle(),
+        connection.handle(),
         subscriptionId,
         static_cast<UA_TimestampsToReturn>(parameters.timestamps),
         detail::createMonitoredItemCreateRequest(itemToMonitor, monitoringMode, parameters),
@@ -137,15 +138,14 @@ uint32_t createMonitoredItemEvent(
     detail::reviseMonitoringParameters(parameters, asNative(result));
 
     const auto monitoredItemId = result->monitoredItemId;
-    auto* contextPtr = opcua::detail::getContext(client).monitoredItems.insert(
-        {subscriptionId, monitoredItemId}, std::move(context)
-    );
+    opcua::detail::getContext(connection)
+        .monitoredItems.insert({subscriptionId, monitoredItemId}, std::move(context));
     contextPtr->inserted = true;
     return monitoredItemId;
 }
 
 void modifyMonitoredItem(
-    Client& client,
+    Client& connection,
     uint32_t subscriptionId,
     uint32_t monitoredItemId,
     MonitoringParametersEx& parameters
@@ -154,17 +154,20 @@ void modifyMonitoredItem(
     auto request = detail::createModifyMonitoredItemsRequest(subscriptionId, parameters, item);
     using Response =
         TypeWrapper<UA_ModifyMonitoredItemsResponse, UA_TYPES_MODIFYMONITOREDITEMSRESPONSE>;
-    const Response response = UA_Client_MonitoredItems_modify(client.handle(), request);
+    const Response response = UA_Client_MonitoredItems_modify(connection.handle(), request);
     auto& result = detail::getSingleResult(asNative(response));
     throwIfBad(result.statusCode);
     detail::reviseMonitoringParameters(parameters, result);
 }
 
 void setMonitoringMode(
-    Client& client, uint32_t subscriptionId, uint32_t monitoredItemId, MonitoringMode monitoringMode
+    Client& connection,
+    uint32_t subscriptionId,
+    uint32_t monitoredItemId,
+    MonitoringMode monitoringMode
 ) {
     detail::sendRequest<UA_SetMonitoringModeRequest, UA_SetMonitoringModeResponse>(
-        client,
+        connection,
         detail::createSetMonitoringModeRequest(
             subscriptionId, {&monitoredItemId, 1}, monitoringMode
         ),
@@ -176,14 +179,14 @@ void setMonitoringMode(
 }
 
 void setTriggering(
-    Client& client,
+    Client& connection,
     uint32_t subscriptionId,
     uint32_t triggeringItemId,
     Span<const uint32_t> linksToAdd,
     Span<const uint32_t> linksToRemove
 ) {
     detail::sendRequest<UA_SetTriggeringRequest, UA_SetTriggeringResponse>(
-        client,
+        connection,
         detail::createSetTriggeringRequest(
             subscriptionId, triggeringItemId, linksToAdd, linksToRemove
         ),
@@ -198,21 +201,21 @@ void setTriggering(
 
 template <>
 void deleteMonitoredItem<Client>(
-    Client& client, uint32_t subscriptionId, uint32_t monitoredItemId
+    Client& connection, uint32_t subscriptionId, uint32_t monitoredItemId
 ) {
     const auto status = UA_Client_MonitoredItems_deleteSingle(
-        client.handle(), subscriptionId, monitoredItemId
+        connection.handle(), subscriptionId, monitoredItemId
     );
     throwIfBad(status);
 }
 
 template <>
 void deleteMonitoredItem<Server>(
-    Server& server, [[maybe_unused]] uint32_t subscriptionId, uint32_t monitoredItemId
+    Server& connection, [[maybe_unused]] uint32_t subscriptionId, uint32_t monitoredItemId
 ) {
-    const auto status = UA_Server_deleteMonitoredItem(server.handle(), monitoredItemId);
+    const auto status = UA_Server_deleteMonitoredItem(connection.handle(), monitoredItemId);
     throwIfBad(status);
-    opcua::detail::getContext(server).monitoredItems.erase({0U, monitoredItemId});
+    opcua::detail::getContext(connection).monitoredItems.erase({0U, monitoredItemId});
 }
 
 void deleteMonitoredItem(Server& connection, uint32_t monitoredItemId) {


### PR DESCRIPTION
Symmetric implementation (same definition for `Server` and `Client`) for:
- `services::createMonitoredItemDataChange`
- `services::deleteMonitoredItem`
