### PR TITLE
feat!: deprecate high-level `DataChangeCallback` and `EventCallback`

### DIFF
--- a/examples/client_subscription.cpp
+++ b/examples/client_subscription.cpp
@@ -25,7 +25,8 @@ int main() {
         auto mon = sub.subscribeDataChange(
             opcua::VariableId::Server_ServerStatus_CurrentTime,  // monitored node id
             opcua::AttributeId::Value,  // monitored attribute
-            [&](const auto& item, const opcua::DataValue& value) {
+            [&](uint32_t subId, uint32_t monId, const opcua::DataValue& value) {
+                const opcua::MonitoredItem item(client, subId, monId);
                 std::cout
                     << "Data change notification:\n"
                     << "- subscription id:   " << item.getSubscriptionId() << "\n"

--- a/examples/events/client_eventfilter.cpp
+++ b/examples/events/client_eventfilter.cpp
@@ -45,7 +45,8 @@ int main() {
     sub.subscribeEvent(
         opcua::ObjectId::Server,
         eventFilter,
-        [&](const auto& item, opcua::Span<const opcua::Variant> eventFields) {
+        [&](uint32_t subId, uint32_t monId, opcua::Span<const opcua::Variant> eventFields) {
+            const opcua::MonitoredItem item(client, subId, monId);
             std::cout
                 << "Event notification:\n"
                 << "- subscription id:   " << item.getSubscriptionId() << "\n"

--- a/include/open62541pp/Subscription.h
+++ b/include/open62541pp/Subscription.h
@@ -161,7 +161,7 @@ public:
         const NodeId& id,
         MonitoringMode monitoringMode,
         MonitoringParametersEx& parameters,
-        EventNotificationCallback onEvent
+        EventNotificationCallback onEvent  // NOLINT(*-unnecessary-value-param), false positive?
     ) {
         const uint32_t monitoredItemId = services::createMonitoredItemEvent(
             connection_,

--- a/include/open62541pp/Subscription.h
+++ b/include/open62541pp/Subscription.h
@@ -3,12 +3,15 @@
 #include <cstdint>
 #include <functional>
 #include <type_traits>
+#include <utility>  // move
 #include <vector>
 
 #include "open62541pp/Config.h"
 #include "open62541pp/MonitoredItem.h"
+#include "open62541pp/Span.h"
 #include "open62541pp/services/MonitoredItem.h"
 #include "open62541pp/services/Subscription.h"
+#include "open62541pp/types/ExtensionObject.h"
 #include "open62541pp/types/NodeId.h"
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
@@ -20,20 +23,22 @@ class Client;
 class DataValue;
 class EventFilter;
 class Server;
-template <typename T>
-class Span;
 class Variant;
 
 using SubscriptionParameters = services::SubscriptionParameters;
 using MonitoringParametersEx = services::MonitoringParametersEx;
+using DataChangeNotificationCallback = services::DataChangeNotificationCallback;
+using EventNotificationCallback = services::EventNotificationCallback;
 
 /// Data change notification callback.
+/// @deprecated Use DataChangeNotificationCallback instead
 /// @tparam T Server or Client
 template <typename T>
 using DataChangeCallback =
     std::function<void(const MonitoredItem<T>& item, const DataValue& value)>;
 
 /// Event notification callback.
+/// @deprecated Use EventNotificationCallback instead
 /// @tparam T Server or Client
 template <typename T>
 using EventCallback =
@@ -83,20 +88,16 @@ public:
     /// Modify this subscription.
     /// @note Not implemented for Server.
     /// @see services::modifySubscription
-    void setSubscriptionParameters(SubscriptionParameters& parameters);
+    void setSubscriptionParameters(SubscriptionParameters& parameters) {
+        services::modifySubscription(connection_, subscriptionId_, parameters);
+    }
 
     /// Enable/disable publishing of notification messages.
     /// @note Not implemented for Server.
     /// @see services::setPublishingMode
-    void setPublishingMode(bool publishing);
-
-    /// Create a monitored item for data change notifications (default settings).
-    /// The monitoring mode is set to MonitoringMode::Reporting and the default open62541
-    /// MonitoringParametersEx are used.
-    /// @see services::MonitoringParametersEx
-    MonitoredItem<Connection> subscribeDataChange(
-        const NodeId& id, AttributeId attribute, DataChangeCallback<Connection> onDataChange
-    );
+    void setPublishingMode(bool publishing) {
+        services::setPublishingMode(connection_, subscriptionId_, publishing);
+    }
 
     /// Create a monitored item for data change notifications.
     /// @copydetails services::MonitoringParametersEx
@@ -105,16 +106,53 @@ public:
         AttributeId attribute,
         MonitoringMode monitoringMode,
         MonitoringParametersEx& parameters,
-        DataChangeCallback<Connection> onDataChange
-    );
+        DataChangeNotificationCallback onDataChange
+    ) {
+        const uint32_t monitoredItemId = services::createMonitoredItemDataChange(
+            connection_,
+            subscriptionId_,
+            {id, attribute},
+            monitoringMode,
+            parameters,
+            std::move(onDataChange)
+        );
+        return {connection_, subscriptionId_, monitoredItemId};
+    }
 
-    /// Create a monitored item for event notifications (default settings).
+    /// @deprecated Use overload with DataChangeNotificationCallback instead
+    [[deprecated("Use overload with DataChangeNotificationCallback instead")]]
+    MonitoredItem<Connection> subscribeDataChange(
+        const NodeId& id,
+        AttributeId attribute,
+        MonitoringMode monitoringMode,
+        MonitoringParametersEx& parameters,
+        DataChangeCallback<Connection> onDataChange
+    ) {
+        return subscribeDataChange(
+            id, attribute, monitoringMode, parameters, createCallback(std::move(onDataChange))
+        );
+    }
+
+    /// Create a monitored item for data change notifications (default settings).
     /// The monitoring mode is set to MonitoringMode::Reporting and the default open62541
     /// MonitoringParametersEx are used.
-    /// @note Not implemented for Server.
-    MonitoredItem<Connection> subscribeEvent(
-        const NodeId& id, const EventFilter& eventFilter, EventCallback<Connection> onEvent
-    );
+    /// @see services::MonitoringParametersEx
+    MonitoredItem<Connection> subscribeDataChange(
+        const NodeId& id, AttributeId attribute, DataChangeNotificationCallback onDataChange
+    ) {
+        MonitoringParametersEx parameters;
+        return subscribeDataChange(
+            id, attribute, MonitoringMode::Reporting, parameters, std::move(onDataChange)
+        );
+    }
+
+    /// @deprecated Use overload with DataChangeNotificationCallback instead
+    [[deprecated("Use overload with DataChangeNotificationCallback instead")]]
+    MonitoredItem<Connection> subscribeDataChange(
+        const NodeId& id, AttributeId attribute, DataChangeCallback<Connection> onDataChange
+    ) {
+        return subscribeDataChange(id, attribute, createCallback(std::move(onDataChange)));
+    }
 
     /// Create a monitored item for event notifications.
     /// @copydetails services::MonitoringParametersEx
@@ -123,15 +161,75 @@ public:
         const NodeId& id,
         MonitoringMode monitoringMode,
         MonitoringParametersEx& parameters,
+        EventNotificationCallback onEvent
+    ) {
+        const uint32_t monitoredItemId = services::createMonitoredItemEvent(
+            connection_,
+            subscriptionId_,
+            {id, AttributeId::EventNotifier},
+            monitoringMode,
+            parameters,
+            std::move(onEvent)
+        );
+        return {connection_, subscriptionId_, monitoredItemId};
+    }
+
+    /// @deprecated Use overload with EventNotificationCallback instead
+    [[deprecated("Use overload with EventNotificationCallback instead")]]
+    MonitoredItem<Connection> subscribeEvent(
+        const NodeId& id,
+        MonitoringMode monitoringMode,
+        MonitoringParametersEx& parameters,
         EventCallback<Connection> onEvent
-    );
+    ) {
+        return subscribeEvent(id, monitoringMode, parameters, createCallback(std::move(onEvent)));
+    }
+
+    /// Create a monitored item for event notifications (default settings).
+    /// The monitoring mode is set to MonitoringMode::Reporting and the default open62541
+    /// MonitoringParametersEx are used.
+    /// @note Not implemented for Server.
+    MonitoredItem<Connection> subscribeEvent(
+        const NodeId& id, const EventFilter& eventFilter, EventNotificationCallback onEvent
+    ) {
+        MonitoringParametersEx parameters;
+        parameters.filter = ExtensionObject::fromDecodedCopy(eventFilter);
+        return subscribeEvent(id, MonitoringMode::Reporting, parameters, std::move(onEvent));
+    }
+
+    /// @deprecated Use overload with EventNotificationCallback instead
+    [[deprecated("Use overload with EventNotificationCallback instead")]]
+    MonitoredItem<Connection> subscribeEvent(
+        const NodeId& id, const EventFilter& eventFilter, EventCallback<Connection> onEvent
+    ) {
+        return subscribeEvent(id, eventFilter, createCallback(std::move(onEvent)));
+    }
 
     /// Delete this subscription.
     /// @note Not implemented for Server.
-    /// @see services::deleteSubscription
-    void deleteSubscription();
+    void deleteSubscription() {
+        services::deleteSubscription(connection_, subscriptionId_);
+    }
 
 private:
+    DataChangeNotificationCallback createCallback(DataChangeCallback<Connection> onDataChange) {
+        return [connectionPtr = &connection_, callback = std::move(onDataChange)](
+                   uint32_t subId, uint32_t monId, const DataValue& value
+               ) {
+            const MonitoredItem<Connection> monitoredItem(*connectionPtr, subId, monId);
+            callback(monitoredItem, value);
+        };
+    }
+
+    EventNotificationCallback createCallback(EventCallback<Connection> onEvent) {
+        return [connectionPtr = &connection_, callback = std::move(onEvent)](
+                   uint32_t subId, uint32_t monId, Span<const Variant> eventFields
+               ) {
+            const MonitoredItem<Connection> monitoredItem(*connectionPtr, subId, monId);
+            callback(monitoredItem, eventFields);
+        };
+    }
+
     Connection& connection_;
     uint32_t subscriptionId_{0U};
 };

--- a/src/Subscription.cpp
+++ b/src/Subscription.cpp
@@ -2,29 +2,12 @@
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
 
-#include <atomic>
-#include <utility>  // move
-
 #include "open62541pp/Client.h"
 #include "open62541pp/Server.h"
-#include "open62541pp/Span.h"
 #include "open62541pp/detail/ClientContext.h"
 #include "open62541pp/detail/ServerContext.h"
-#include "open62541pp/services/MonitoredItem.h"
-#include "open62541pp/types/Composed.h"
-#include "open62541pp/types/ExtensionObject.h"
 
 namespace opcua {
-
-template <typename T>
-MonitoredItem<T> Subscription<T>::subscribeDataChange(
-    const NodeId& id, AttributeId attribute, DataChangeCallback<T> onDataChange
-) {
-    MonitoringParametersEx parameters;
-    return subscribeDataChange(
-        id, attribute, MonitoringMode::Reporting, parameters, std::move(onDataChange)
-    );
-}
 
 template <typename T>
 std::vector<MonitoredItem<T>> Subscription<T>::getMonitoredItems() {
@@ -43,109 +26,9 @@ std::vector<MonitoredItem<T>> Subscription<T>::getMonitoredItems() {
     return result;
 }
 
-/* ----------------------------------- Server specializations ----------------------------------- */
-
-template <>
-MonitoredItem<Server> Subscription<Server>::subscribeDataChange(
-    const NodeId& id,
-    AttributeId attribute,
-    MonitoringMode monitoringMode,
-    MonitoringParametersEx& parameters,
-    DataChangeCallback<Server> onDataChange
-) {
-    const uint32_t monitoredItemId = services::createMonitoredItemDataChange(
-        connection_,
-        {id, attribute},
-        monitoringMode,
-        parameters,
-        [connectionPtr = &connection_, callback = std::move(onDataChange)](
-            uint32_t subId, uint32_t monId, const DataValue& value
-        ) {
-            const MonitoredItem<Server> monitoredItem(*connectionPtr, subId, monId);
-            callback(monitoredItem, value);
-        }
-    );
-    return {connection_, 0U, monitoredItemId};
-}
-
-/* ----------------------------------- Client specializations ----------------------------------- */
-
-template <>
-void Subscription<Client>::setSubscriptionParameters(SubscriptionParameters& parameters) {
-    services::modifySubscription(connection_, subscriptionId_, parameters);
-}
-
-template <>
-void Subscription<Client>::setPublishingMode(bool publishing) {
-    services::setPublishingMode(connection_, subscriptionId_, publishing);
-}
-
-template <>
-MonitoredItem<Client> Subscription<Client>::subscribeDataChange(
-    const NodeId& id,
-    AttributeId attribute,
-    MonitoringMode monitoringMode,
-    MonitoringParametersEx& parameters,
-    DataChangeCallback<Client> onDataChange
-) {
-    const uint32_t monitoredItemId = services::createMonitoredItemDataChange(
-        connection_,
-        subscriptionId_,
-        {id, attribute},
-        monitoringMode,
-        parameters,
-        [connectionPtr = &connection_, callback = std::move(onDataChange)](
-            uint32_t subId, uint32_t monId, const DataValue& value
-        ) {
-            const MonitoredItem<Client> monitoredItem(*connectionPtr, subId, monId);
-            callback(monitoredItem, value);
-        }
-    );
-    return {connection_, subscriptionId_, monitoredItemId};
-}
-
-template <>
-MonitoredItem<Client> Subscription<Client>::subscribeEvent(
-    const NodeId& id,
-    MonitoringMode monitoringMode,
-    MonitoringParametersEx& parameters,
-    EventCallback<Client> onEvent
-) {
-    const uint32_t monitoredItemId = services::createMonitoredItemEvent(
-        connection_,
-        subscriptionId_,
-        {id, AttributeId::EventNotifier},
-        monitoringMode,
-        parameters,
-        [connectionPtr = &connection_, callback = std::move(onEvent)](
-            uint32_t subId, uint32_t monId, Span<const Variant> eventFields
-        ) {
-            const MonitoredItem<Client> monitoredItem(*connectionPtr, subId, monId);
-            callback(monitoredItem, eventFields);
-        }
-    );
-    return {connection_, subscriptionId_, monitoredItemId};
-}
-
-template <>
-MonitoredItem<Client> Subscription<Client>::subscribeEvent(
-    const NodeId& id, const EventFilter& eventFilter, EventCallback<Client> onEvent
-) {
-    MonitoringParametersEx parameters;
-    parameters.filter = ExtensionObject::fromDecodedCopy(eventFilter);
-    return subscribeEvent(id, MonitoringMode::Reporting, parameters, std::move(onEvent));
-}
-
-template <>
-void Subscription<Client>::deleteSubscription() {
-    services::deleteSubscription(connection_, subscriptionId_);
-}
-
-/* ---------------------------------------------------------------------------------------------- */
-
 // explicit template instantiation
-template class Subscription<Server>;
-template class Subscription<Client>;
+template std::vector<MonitoredItem<Client>> Subscription<Client>::getMonitoredItems();
+template std::vector<MonitoredItem<Server>> Subscription<Server>::getMonitoredItems();
 
 }  // namespace opcua
 


### PR DESCRIPTION
Solves lifetime issues as discussed in #187.

Use the same callback signature as in the `services` namespace. If the user wants to access the `MonitoredItem` object, it can be easily created by capturing the server/client instance (the user has to decide about the lifetime!).

### Old

```cpp
auto sub = client.createSubscription();
auto mon = sub.subscribeDataChange(
    opcua::VariableId::Server_ServerStatus_CurrentTime,  // monitored node id
    opcua::AttributeId::Value,  // monitored attribute
    [&](const opcua::MonitoredItem<Client>& item, const opcua::DataValue& value) {
        // ...
    }
);
```

### New

```cpp
auto sub = client.createSubscription();
auto mon = sub.subscribeDataChange(
    opcua::VariableId::Server_ServerStatus_CurrentTime,  // monitored node id
    opcua::AttributeId::Value,  // monitored attribute
    [&](uint32_t subId, uint32_t monId, const DataValue& value) {
        const opcua::MonitoredItem item(client, subId, monId);
        // ...
    }
);
```