### PR TITLE
feat!: remove implicit conversions from `Result<T>` to `T`

### DIFF
--- a/include/open62541pp/Result.h
+++ b/include/open62541pp/Result.h
@@ -89,14 +89,6 @@ public:
         : code_(error.code()),
           maybeValue_(std::nullopt) {}
 
-    operator T&() {
-        return value();
-    }
-
-    operator const T&() const {
-        return value();
-    }
-
     // NOLINTEND(*-explicit-conversions)
 
     /**
@@ -140,6 +132,13 @@ public:
      */
     constexpr StatusCode code() const noexcept {
         return code_;
+    }
+
+    /**
+     * Check if the Result has a value.
+     */
+    constexpr explicit operator bool() const noexcept {
+        return hasValue();
     }
 
     /**
@@ -228,13 +227,6 @@ public:
      */
     constexpr Result(BadResult error) noexcept  // NOLINT, implicit wanted
         : code_(error.code()) {}
-
-    /**
-     * Convert the Result to a StatusCode.
-     */
-    operator StatusCode() const noexcept {  // NOLINT, implicit wanted
-        return code_;
-    }
 
     constexpr void operator*() const noexcept {}
 

--- a/tests/ClientService.cpp
+++ b/tests/ClientService.cpp
@@ -127,7 +127,7 @@ TEST_CASE("sendRequest") {
         SUBCASE("Exception in transform function") {
             sendReadRequest(
                 [](UA_ReadResponse&) { throw std::runtime_error("Error"); },
-                [](StatusCode code) { CHECK(code == UA_STATUSCODE_BADINTERNALERROR); }
+                [](Result<void> result) { CHECK(result.code() == UA_STATUSCODE_BADINTERNALERROR); }
             );
             CHECK_NOTHROW(client.runIterate());
         }

--- a/tests/Result.cpp
+++ b/tests/Result.cpp
@@ -47,12 +47,14 @@ TEST_CASE("Result") {
         CHECK(Result<int>(badResult).code() == badCode);
     }
 
-    SUBCASE("hasValue") {
-        Result<int> result(1);
-        CHECK(result.hasValue());
+    SUBCASE("operator bool") {
+        CHECK(static_cast<bool>(Result<int>(1)));
+        CHECK_FALSE(static_cast<bool>(Result<int>(badResult)));
+    }
 
-        Result<int> resultError(badResult);
-        CHECK_FALSE(resultError.hasValue());
+    SUBCASE("hasValue") {
+        CHECK(Result<int>().hasValue());
+        CHECK_FALSE(Result<int>(badResult).hasValue());
     }
 
     SUBCASE("value") {
@@ -88,11 +90,6 @@ TEST_CASE("Result") {
 }
 
 TEST_CASE("Result (void template specialization)") {
-    SUBCASE("operator StatusCode") {
-        CHECK(static_cast<StatusCode>(Result<void>()) == UA_STATUSCODE_GOOD);
-        CHECK(static_cast<StatusCode>(Result<void>(badResult)) == UA_STATUSCODE_BADUNEXPECTEDERROR);
-    }
-
     SUBCASE("code") {
         CHECK(Result<void>().code() == UA_STATUSCODE_GOOD);
         CHECK(Result<void>(badResult).code() == badCode);


### PR DESCRIPTION
The implicit conversions were a compatibility feature to not break existing code. But they cause more confusion in my opinion, so let's mark this as a breaking change for the next release.

All functions in the `services` namespace will adopt the `Result<T>` type as a return type - both sync and async versions.