### PR TITLE
feat: `Result` monadic operations transform, andThen, orElse

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,8 +7,9 @@ AccessModifierOffset: -4
 AlignAfterOpenBracket: BlockIndent # version >= 14 required
 # AlignConsecutiveAssignments: true
 # AlignConsecutiveDeclarations: true
-AlignTrailingComments: false
+AlignOperands: DontAlign
 AllowShortFunctionsOnASingleLine: Empty
+AlignTrailingComments: false
 AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: false
 BinPackParameters: false


### PR DESCRIPTION
Add monadic operations to `Result<T>` class:
- `Result<T>::transform`
- `Result<T>::andThen`
- `Result<T>::orElse`