### PR TITLE
refactor!: strip get prefix of simple getters

### DIFF
--- a/examples/client_subscription.cpp
+++ b/examples/client_subscription.cpp
@@ -29,8 +29,8 @@ int main() {
                 const opcua::MonitoredItem item(client, subId, monId);
                 std::cout
                     << "Data change notification:\n"
-                    << "- subscription id:   " << item.getSubscriptionId() << "\n"
-                    << "- monitored item id: " << item.getMonitoredItemId() << "\n"
+                    << "- subscription id:   " << item.subscriptionId() << "\n"
+                    << "- monitored item id: " << item.monitoredItemId() << "\n"
                     << "- node id:           " << item.getNodeId().toString() << "\n"
                     << "- attribute id:      " << static_cast<int>(item.getAttributeId()) << "\n";
 

--- a/examples/custom_datatypes/server_custom_datatypes.cpp
+++ b/examples/custom_datatypes/server_custom_datatypes.cpp
@@ -90,7 +90,7 @@ int main() {
             .setDataType(dataTypePoint.getTypeId())
             .setValueRank(opcua::ValueRank::Scalar)
             .setValueScalar(point, dataTypePoint),
-        nodeVariableTypePoint.getNodeId()
+        nodeVariableTypePoint.id()
     );
 
     const std::vector<Point> pointVec{{1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}};
@@ -102,7 +102,7 @@ int main() {
             .setArrayDimensions({0})  // single dimension but unknown in size
             .setValueRank(opcua::ValueRank::OneDimension)
             .setValueArray(pointVec, dataTypePoint),
-        nodeVariableTypePoint.getNodeId()
+        nodeVariableTypePoint.id()
     );
 
     std::vector<float> measurementsValues{19.1F, 20.2F, 19.7F};
@@ -118,7 +118,7 @@ int main() {
             .setDataType(dataTypeMeasurements.getTypeId())
             .setValueRank(opcua::ValueRank::Scalar)
             .setValueScalar(measurements, dataTypeMeasurements),
-        nodeVariableTypeMeasurement.getNodeId()
+        nodeVariableTypeMeasurement.id()
     );
 
     float optC = 10.10F;
@@ -130,7 +130,7 @@ int main() {
             .setDataType(dataTypeOpt.getTypeId())
             .setValueRank(opcua::ValueRank::Scalar)
             .setValueScalar(opt, dataTypeOpt),
-        nodeVariableTypeOpt.getNodeId()
+        nodeVariableTypeOpt.id()
     );
 
     Uni uni{};
@@ -143,7 +143,7 @@ int main() {
             .setDataType(dataTypeUni.getTypeId())
             .setValueRank(opcua::ValueRank::Scalar)
             .setValueScalar(uni, dataTypeUni),
-        nodeVariableTypeUni.getNodeId()
+        nodeVariableTypeUni.id()
     );
 
     nodeObjects.addVariable(

--- a/examples/events/client_eventfilter.cpp
+++ b/examples/events/client_eventfilter.cpp
@@ -49,8 +49,8 @@ int main() {
             const opcua::MonitoredItem item(client, subId, monId);
             std::cout
                 << "Event notification:\n"
-                << "- subscription id:   " << item.getSubscriptionId() << "\n"
-                << "- monitored item id: " << item.getMonitoredItemId() << "\n"
+                << "- subscription id:   " << item.subscriptionId() << "\n"
+                << "- monitored item id: " << item.monitoredItemId() << "\n"
                 << "- node id:           " << item.getNodeId().toString() << "\n"
                 << "- attribute id:      " << static_cast<int>(item.getAttributeId()) << "\n";
 

--- a/examples/method/client_method.cpp
+++ b/examples/method/client_method.cpp
@@ -14,7 +14,7 @@ int main() {
 
     // Call method from parent node (Objects)
     const auto outputs = objNode.callMethod(
-        greetMethodNode.getNodeId(), {opcua::Variant::fromScalar("World")}
+        greetMethodNode.id(), {opcua::Variant::fromScalar("World")}
     );
     std::cout << outputs.at(0).getScalar<opcua::String>() << std::endl;
 }

--- a/examples/method/client_method_async.cpp
+++ b/examples/method/client_method_async.cpp
@@ -20,9 +20,10 @@ int main() {
     {
         auto future = opcua::services::callAsync(
             client,
-            objNode.getNodeId(),
-            greetMethodNode.getNodeId(),
-            {opcua::Variant::fromScalar("Future World")}
+            objNode.id(),
+            greetMethodNode.id(),
+            {opcua::Variant::fromScalar("Future World")},
+            opcua::useFuture  // default, can be omitted
         );
 
         std::cout << "Waiting for asynchronous operation to complete\n";
@@ -37,8 +38,8 @@ int main() {
     {
         opcua::services::callAsync(
             client,
-            objNode.getNodeId(),
-            greetMethodNode.getNodeId(),
+            objNode.id(),
+            greetMethodNode.id(),
             {opcua::Variant::fromScalar("Callback World")},
             [](const opcua::Result<std::vector<opcua::Variant>>& result) {
                 std::cout

--- a/examples/server_datasource.cpp
+++ b/examples/server_datasource.cpp
@@ -37,7 +37,7 @@ int main() {
     };
 
     // Define data source as variable node backend
-    server.setVariableNodeValueBackend(nodeCounter.getNodeId(), dataSource);
+    server.setVariableNodeValueBackend(nodeCounter.id(), dataSource);
 
     server.run();
 }

--- a/examples/server_instantiation.cpp
+++ b/examples/server_instantiation.cpp
@@ -59,7 +59,7 @@ int main() {
         opcua::ObjectAttributes{}
             .setDisplayName({"en-US", "Bello"})
             .setDescription({"en-US", "A dog named Bello"}),
-        nodeDogType.getNodeId()
+        nodeDogType.id()
     );
 
     // Set variables Age and Name

--- a/include/open62541pp/Event.h
+++ b/include/open62541pp/Event.h
@@ -35,12 +35,34 @@ public:
     Event& operator=(Event&&) noexcept = delete;
 
     /// Get the server instance.
-    Server& getConnection() noexcept;
+    Server& connection() noexcept {
+        return connection_;
+    }
+
     /// Get the server instance.
-    const Server& getConnection() const noexcept;
+    const Server& connection() const noexcept {
+        return connection_;
+    }
+
+    [[deprecated("Use connection() instead")]]
+    Server& getConnection() noexcept {
+        return connection_;
+    }
+
+    [[deprecated("Use connection() instead")]]
+    const Server& getConnection() const noexcept {
+        return connection_;
+    }
 
     /// Get the NodeId of the underlying node representation.
-    const NodeId& getNodeId() const noexcept;
+    const NodeId& id() const noexcept {
+        return id_;
+    }
+
+    [[deprecated("Use id() instead")]]
+    const NodeId& getNodeId() const noexcept {
+        return id_;
+    }
 
     /// Set the source name (optional).
     Event& writeSourceName(std::string_view sourceName);

--- a/include/open62541pp/MonitoredItem.h
+++ b/include/open62541pp/MonitoredItem.h
@@ -42,27 +42,47 @@ public:
           monitoredItemId_(monitoredItemId) {}
 
     /// Get the server/client instance.
-    Connection& getConnection() noexcept {
+    Connection& connection() noexcept {
         return connection_;
     }
 
     /// Get the server/client instance.
+    const Connection& connection() const noexcept {
+        return connection_;
+    }
+
+    [[deprecated("Use connection() instead")]]
+    Connection& getConnection() noexcept {
+        return connection_;
+    }
+
+    [[deprecated("Use connection() instead")]]
     const Connection& getConnection() const noexcept {
         return connection_;
     }
 
     /// Get the server-assigned identifier of the underlying subscription.
+    uint32_t subscriptionId() const noexcept {
+        return subscriptionId_;
+    }
+
+    [[deprecated("Use subscriptionId() instead")]]
     uint32_t getSubscriptionId() const noexcept {
         return subscriptionId_;
     }
 
     /// Get the server-assigned identifier of this monitored item.
+    uint32_t monitoredItemId() const noexcept {
+        return monitoredItemId_;
+    }
+
+    [[deprecated("Use monitoredItemId() instead")]]
     uint32_t getMonitoredItemId() const noexcept {
         return monitoredItemId_;
     }
 
     /// Get the underlying subscription.
-    Subscription<Connection> getSubscription() const;
+    Subscription<Connection> subscription() const noexcept;
 
     /// Get the monitored NodeId.
     const NodeId& getNodeId() const;
@@ -100,9 +120,9 @@ private:
 
 template <typename T>
 inline bool operator==(const MonitoredItem<T>& lhs, const MonitoredItem<T>& rhs) noexcept {
-    return (lhs.getConnection() == rhs.getConnection()) &&
-           (lhs.getSubscriptionId() == rhs.getSubscriptionId()) &&
-           (lhs.getMonitoredItemId() == rhs.getMonitoredItemId());
+    return (lhs.connection() == rhs.connection()) &&
+           (lhs.subscriptionId() == rhs.subscriptionId()) &&
+           (lhs.monitoredItemId() == rhs.monitoredItemId());
 }
 
 template <typename T>

--- a/include/open62541pp/MonitoredItem.h
+++ b/include/open62541pp/MonitoredItem.h
@@ -26,7 +26,7 @@ using MonitoringParameters
  *
  * @note Not all methods are available and implemented for servers.
  *
- * Use the free functions in the `services` namespace for more advanced usage:
+ * Use the free functions in the opcua::services namespace for more advanced usage:
  * - @ref MonitoredItem
  */
 template <typename Connection>

--- a/include/open62541pp/MonitoredItem.h
+++ b/include/open62541pp/MonitoredItem.h
@@ -14,8 +14,6 @@ namespace opcua {
 
 // forward declarations
 class Server;
-template <typename Connection>
-class Subscription;
 
 using MonitoringParametersEx = services::MonitoringParametersEx;
 using MonitoringParameters

--- a/include/open62541pp/MonitoredItem.h
+++ b/include/open62541pp/MonitoredItem.h
@@ -81,9 +81,6 @@ public:
         return monitoredItemId_;
     }
 
-    /// Get the underlying subscription.
-    Subscription<Connection> subscription() const noexcept;
-
     /// Get the monitored NodeId.
     const NodeId& getNodeId() const;
 

--- a/include/open62541pp/Node.h
+++ b/include/open62541pp/Node.h
@@ -28,12 +28,12 @@ namespace opcua {
 /**
  * High-level node class to access node attribute, browse and populate address space.
  *
- * The Node API is just a more convenient way of using the free functions in the `services`
+ * The Node API is just a more convenient way of using the free functions in the opcua::services
  * namespace.
  *
  * Node objects are useful as-is but they do not expose the entire OPC UA protocol. You can get
- * access to the associated NodeId instance with the getNodeId() method and apply the native
- * open62541 functions or the free functions in the `services` namespace.
+ * access to the associated NodeId instance with the Node::id() method and apply the native
+ * open62541 functions or the free functions in the opcua::services namespace.
  *
  * @see Services
  */

--- a/include/open62541pp/Session.h
+++ b/include/open62541pp/Session.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>  // move
+
 #include <open62541pp/types/NodeId.h>
 
 namespace opcua {
@@ -12,7 +14,7 @@ class Variant;
 /**
  * High-level session class to manage client sessions.
  *
- * Sessions are identified by a server-assigned `sessionId` (of type NodeId).
+ * Sessions are identified by a server-assigned session id (of type NodeId).
  * A session carries attributes in a key-value list. Custom attributes/meta-data can be attached to
  * a session as key-value pairs of QualifiedName and Variant.
  *
@@ -20,15 +22,39 @@ class Variant;
  */
 class Session {
 public:
-    Session(Server& server, NodeId sessionId) noexcept;
+    Session(Server& server, NodeId sessionId) noexcept
+        : connection_(server),
+          sessionId_(std::move(sessionId)) {}
 
     /// Get the server instance.
-    Server& getConnection() noexcept;
+    Server& connection() noexcept {
+        return connection_;
+    }
+
     /// Get the server instance.
-    const Server& getConnection() const noexcept;
+    const Server& connection() const noexcept {
+        return connection_;
+    }
+
+    [[deprecated("Use connection() instead")]]
+    Server& getConnection() noexcept {
+        return connection_;
+    }
+
+    [[deprecated("Use connection() instead")]]
+    const Server& getConnection() const noexcept {
+        return connection_;
+    }
 
     /// Get the session identifier.
-    const NodeId& getSessionId() const noexcept;
+    const NodeId& id() const noexcept {
+        return sessionId_;
+    }
+
+    [[deprecated("Use id() instead")]]
+    const NodeId& getSessionId() const noexcept {
+        return sessionId_;
+    }
 
     /// Get a session attribute by its key.
     /// @note Supported since open62541 v1.3

--- a/include/open62541pp/Subscription.h
+++ b/include/open62541pp/Subscription.h
@@ -68,16 +68,31 @@ public:
           subscriptionId_(std::is_same_v<Connection, Server> ? 0U : subscriptionId) {}
 
     /// Get the server/client instance.
-    Connection& getConnection() noexcept {
+    Connection& connection() noexcept {
         return connection_;
     }
 
     /// Get the server/client instance.
+    const Connection& connection() const noexcept {
+        return connection_;
+    }
+
+    [[deprecated("Use connection() instead")]]
+    Connection& getConnection() noexcept {
+        return connection_;
+    }
+
+    [[deprecated("Use connection() instead")]]
     const Connection& getConnection() const noexcept {
         return connection_;
     }
 
     /// Get the server-assigned identifier of this subscription.
+    uint32_t subscriptionId() const noexcept {
+        return subscriptionId_;
+    }
+
+    [[deprecated("Use subscriptionId() instead")]]
     uint32_t getSubscriptionId() const noexcept {
         return subscriptionId_;
     }
@@ -238,8 +253,7 @@ private:
 
 template <typename T>
 inline bool operator==(const Subscription<T>& lhs, const Subscription<T>& rhs) noexcept {
-    return (lhs.getConnection() == rhs.getConnection()) &&
-           (lhs.getSubscriptionId() == rhs.getSubscriptionId());
+    return (lhs.connection() == rhs.connection()) && (lhs.subscriptionId() == rhs.subscriptionId());
 }
 
 template <typename T>

--- a/include/open62541pp/Subscription.h
+++ b/include/open62541pp/Subscription.h
@@ -54,7 +54,7 @@ using EventCallback =
  *
  * @note Not all methods are available and implemented for servers.
  *
- * Use the free functions in the `services` namespace for more advanced usage:
+ * Use the free functions in the opcua::services namespace for more advanced usage:
  * - @ref Subscription
  * - @ref MonitoredItem
  */

--- a/src/MonitoredItem.cpp
+++ b/src/MonitoredItem.cpp
@@ -5,11 +5,17 @@
 #include "open62541pp/Client.h"
 #include "open62541pp/ErrorHandling.h"
 #include "open62541pp/Server.h"
+#include "open62541pp/Subscription.h"
 #include "open62541pp/detail/ClientContext.h"
 #include "open62541pp/detail/ServerContext.h"
 #include "open62541pp/detail/open62541/common.h"  // UA_STATUSCODE_BADMONITOREDITEMIDINVALID
 
 namespace opcua {
+
+template <typename T>
+Subscription<T> MonitoredItem<T>::subscription() const noexcept {
+    return Subscription<T>(connection_, subscriptionId_);
+}
 
 template <typename T>
 inline static auto& getMonitoredItemContext(
@@ -36,6 +42,8 @@ AttributeId MonitoredItem<T>::getAttributeId() const {
 }
 
 // explicit template instantiations
+template Subscription<Client> MonitoredItem<Client>::subscription() const noexcept;
+template Subscription<Server> MonitoredItem<Server>::subscription() const noexcept;
 template const NodeId& MonitoredItem<Client>::getNodeId() const;
 template const NodeId& MonitoredItem<Server>::getNodeId() const;
 template AttributeId MonitoredItem<Client>::getAttributeId() const;

--- a/src/MonitoredItem.cpp
+++ b/src/MonitoredItem.cpp
@@ -5,17 +5,11 @@
 #include "open62541pp/Client.h"
 #include "open62541pp/ErrorHandling.h"
 #include "open62541pp/Server.h"
-#include "open62541pp/Subscription.h"
 #include "open62541pp/detail/ClientContext.h"
 #include "open62541pp/detail/ServerContext.h"
 #include "open62541pp/detail/open62541/common.h"  // UA_STATUSCODE_BADMONITOREDITEMIDINVALID
 
 namespace opcua {
-
-template <typename T>
-Subscription<T> MonitoredItem<T>::subscription() const noexcept {
-    return Subscription<T>(connection_, subscriptionId_);
-}
 
 template <typename T>
 inline static auto& getMonitoredItemContext(
@@ -42,8 +36,6 @@ AttributeId MonitoredItem<T>::getAttributeId() const {
 }
 
 // explicit template instantiations
-template Subscription<Client> MonitoredItem<Client>::subscription() const noexcept;
-template Subscription<Server> MonitoredItem<Server>::subscription() const noexcept;
 template const NodeId& MonitoredItem<Client>::getNodeId() const;
 template const NodeId& MonitoredItem<Server>::getNodeId() const;
 template AttributeId MonitoredItem<Client>::getAttributeId() const;

--- a/src/Node.cpp
+++ b/src/Node.cpp
@@ -11,14 +11,14 @@ template <>
 bool Node<Client>::exists() noexcept {
     // create minimal request
     UA_ReadValueId item{};
-    item.nodeId = *getNodeId().handle();
+    item.nodeId = id();
     item.attributeId = UA_ATTRIBUTEID_NODECLASS;
     UA_ReadRequest request{};
     request.timestampsToReturn = UA_TIMESTAMPSTORETURN_NEITHER;
     request.nodesToReadSize = 1;
     request.nodesToRead = &item;
 
-    const ReadResponse response = UA_Client_Service_read(getConnection().handle(), request);
+    const ReadResponse response = UA_Client_Service_read(connection().handle(), request);
     if (response->responseHeader.serviceResult != UA_STATUSCODE_GOOD ||
         response->resultsSize != 1) {
         return false;
@@ -32,7 +32,7 @@ bool Node<Client>::exists() noexcept {
 template <>
 bool Node<Server>::exists() noexcept {
     void* context{};
-    const auto status = UA_Server_getNodeContext(getConnection().handle(), getNodeId(), &context);
+    const auto status = UA_Server_getNodeContext(connection().handle(), id(), &context);
     return (status == UA_STATUSCODE_GOOD);
 }
 

--- a/tests/Event.cpp
+++ b/tests/Event.cpp
@@ -17,7 +17,7 @@ TEST_CASE("Event") {
     SUBCASE("Create and remove node representation") {
         auto event = std::make_unique<Event>(server);
 
-        const auto id = event->getNodeId();
+        const auto id = event->id();
         CHECK_FALSE(id.isNull());
         CHECK_NOTHROW(services::readNodeId(server, id));
 
@@ -29,8 +29,8 @@ TEST_CASE("Event") {
     SUBCASE("Create and trigger event") {
         Event event(server);
 
-        CHECK(&event.getConnection() == &server);
-        CHECK(&std::as_const(event).getConnection() == &server);
+        CHECK(&event.connection() == &server);
+        CHECK(&std::as_const(event).connection() == &server);
 
         CHECK_NOTHROW(event.writeSourceName("SourceName"));
         CHECK_NOTHROW(event.writeTime(DateTime::now()));

--- a/tests/Node.cpp
+++ b/tests/Node.cpp
@@ -25,13 +25,13 @@ TEST_CASE_TEMPLATE("Node", ServerOrClient, Server, Client) {
     auto varNode = serverOrClient.getNode(varId);
     auto refNode = serverOrClient.getNode(ReferenceTypeId::References);
 
-    SUBCASE("getConnection") {
-        CHECK(rootNode.getConnection() == serverOrClient);
+    SUBCASE("connection") {
+        CHECK(rootNode.connection() == serverOrClient);
     }
 
-    SUBCASE("getNodeId") {
+    SUBCASE("id") {
         const NodeId id(0, UA_NS0ID_OBJECTSFOLDER);
-        CHECK(Node(serverOrClient, id).getNodeId() == id);
+        CHECK(Node(serverOrClient, id).id() == id);
     }
 
     SUBCASE("exists") {
@@ -108,12 +108,9 @@ TEST_CASE_TEMPLATE("Node", ServerOrClient, Server, Client) {
 
     SUBCASE("Browse child") {
         CHECK_THROWS_WITH(rootNode.browseChild({{0, "Invalid"}}), "BadNoMatch");
+        CHECK_EQ(rootNode.browseChild({{0, "Objects"}}).id(), NodeId(0, UA_NS0ID_OBJECTSFOLDER));
         CHECK_EQ(
-            rootNode.browseChild({{0, "Objects"}}).getNodeId(), NodeId(0, UA_NS0ID_OBJECTSFOLDER)
-        );
-        CHECK_EQ(
-            rootNode.browseChild({{0, "Objects"}, {0, "Server"}}).getNodeId(),
-            NodeId(0, UA_NS0ID_SERVER)
+            rootNode.browseChild({{0, "Objects"}, {0, "Server"}}).id(), NodeId(0, UA_NS0ID_SERVER)
         );
     }
 

--- a/tests/Server.cpp
+++ b/tests/Server.cpp
@@ -124,10 +124,10 @@ TEST_CASE("Server configuration") {
 
     SUBCASE("Get default nodes") {
         // clang-format off
-            CHECK_EQ(server.getRootNode().getNodeId(),    NodeId{0, UA_NS0ID_ROOTFOLDER});
-            CHECK_EQ(server.getObjectsNode().getNodeId(), NodeId{0, UA_NS0ID_OBJECTSFOLDER});
-            CHECK_EQ(server.getTypesNode().getNodeId(),   NodeId{0, UA_NS0ID_TYPESFOLDER});
-            CHECK_EQ(server.getViewsNode().getNodeId(),   NodeId{0, UA_NS0ID_VIEWSFOLDER});
+        CHECK_EQ(server.getRootNode().id(),    NodeId{0, UA_NS0ID_ROOTFOLDER});
+        CHECK_EQ(server.getObjectsNode().id(), NodeId{0, UA_NS0ID_OBJECTSFOLDER});
+        CHECK_EQ(server.getTypesNode().id(),   NodeId{0, UA_NS0ID_TYPESFOLDER});
+        CHECK_EQ(server.getViewsNode().id(),   NodeId{0, UA_NS0ID_VIEWSFOLDER});
         // clang-format on
     }
 }

--- a/tests/Subscription_MonitoredItem.cpp
+++ b/tests/Subscription_MonitoredItem.cpp
@@ -22,8 +22,8 @@ TEST_CASE("Subscription & MonitoredItem (server)") {
     Server server;
 
     SUBCASE("Create Subscription with arbitrary id") {
-        CHECK(Subscription(server, 11U).getConnection() == server);
-        CHECK(Subscription(server, 11U).getSubscriptionId() == 0U);
+        CHECK(Subscription(server, 11U).connection() == server);
+        CHECK(Subscription(server, 11U).subscriptionId() == 0U);
     }
 
     SUBCASE("Create MonitoredItem with arbitrary ids") {
@@ -34,8 +34,6 @@ TEST_CASE("Subscription & MonitoredItem (server)") {
 
     SUBCASE("Create & delete subscription") {
         auto sub = server.createSubscription();
-
-        CHECK(sub.getConnection() == server);
         CHECK(sub.getMonitoredItems().empty());
 
         MonitoringParametersEx monitoringParameters{};
@@ -66,8 +64,8 @@ TEST_CASE("Subscription & MonitoredItem (client)") {
     auto& client = setup.client;
 
     SUBCASE("Create Subscription with arbitrary id") {
-        CHECK(Subscription(client, 11U).getConnection() == client);
-        CHECK(Subscription(client, 11U).getSubscriptionId() == 11U);
+        CHECK(Subscription(client, 11U).connection() == client);
+        CHECK(Subscription(client, 11U).subscriptionId() == 11U);
     }
 
     SUBCASE("Create MonitoredItem with arbitrary ids") {
@@ -81,12 +79,11 @@ TEST_CASE("Subscription & MonitoredItem (client)") {
 
         SubscriptionParameters parameters{};
         auto sub = client.createSubscription(parameters);
-        CAPTURE(sub.getSubscriptionId());
+        CAPTURE(sub.subscriptionId());
 
         CHECK(client.getSubscriptions().size() == 1);
         CHECK(client.getSubscriptions().at(0) == sub);
 
-        CHECK(sub.getConnection() == client);
         CHECK(sub.getMonitoredItems().empty());
 
         sub.deleteSubscription();


### PR DESCRIPTION
Strip `get` prefix of simple getter member functions:
- `Node::getConnection()` -> `Node::connection()`
- `Node::getNodeId()` -> `Node::id()`
- `Session::getConnection()` -> `Session::connection()`
- `Session::getSessionId()` -> `Session::id()`
- `Subscription::getConnection()` -> `Subscription::connection()`
- `Subscription::getSubscriptionId()` -> `Subscription::subscriptionId()`
- `MonitoredItem::getConnection()` -> `MonitoredItem::connection()`
- `MonitoredItem::getSubscriptionId()` -> `MonitoredItem::getSubscriptionId()`
- `MonitoredItem::getMonitoredItemId()` -> `MonitoredItem::monitoredItemId()`
- `Event::getConnection()` -> `Event::connection()`
- `Event::getNodeId()` -> `Event::id()`

Old member function names are deprecated and will be removed in the future.

As discusses in #197.