### PR TITLE
refactor: rename ServerOrClient -> Connection

### DIFF
--- a/include/open62541pp/Client.h
+++ b/include/open62541pp/Client.h
@@ -21,7 +21,7 @@ class Client;
 class DataType;
 class EndpointDescription;
 struct Login;
-template <typename ServerOrClient>
+template <typename Connection>
 class Node;
 class NodeId;
 

--- a/include/open62541pp/Event.h
+++ b/include/open62541pp/Event.h
@@ -23,7 +23,7 @@ class Variant;
 class Event {
 public:
     /// Create an event with the underlying (abstract) node representation.
-    explicit Event(Server& server, const NodeId& eventType = ObjectTypeId::BaseEventType);
+    explicit Event(Server& connection, const NodeId& eventType = ObjectTypeId::BaseEventType);
 
     /// Delete the node representation of the event.
     ~Event();

--- a/include/open62541pp/MonitoredItem.h
+++ b/include/open62541pp/MonitoredItem.h
@@ -22,6 +22,7 @@ using MonitoringParameters
 /**
  * High-level monitored item class.
  *
+ * @tparam Connection Server or Client
  * @note Not all methods are available and implemented for servers.
  *
  * Use the free functions in the opcua::services namespace for more advanced usage:

--- a/include/open62541pp/Node.h
+++ b/include/open62541pp/Node.h
@@ -35,38 +35,39 @@ namespace opcua {
  * access to the associated NodeId instance with the Node::id() method and apply the native
  * open62541 functions or the free functions in the opcua::services namespace.
  *
+ * @tparam Connection Server or Client
  * @see Services
  */
-template <typename ServerOrClient>
+template <typename Connection>
 class Node {
 public:
     /// Create a Node object.
-    Node(ServerOrClient& connection, const NodeId& id)
+    Node(Connection& connection, const NodeId& id)
         : connection_(connection),
           id_(id) {}
 
     /// Create a Node object.
-    Node(ServerOrClient& connection, NodeId&& id)
+    Node(Connection& connection, NodeId&& id)
         : connection_(connection),
           id_(std::move(id)) {}
 
     /// Get the server/client instance.
-    ServerOrClient& connection() noexcept {
+    Connection& connection() noexcept {
         return connection_;
     }
 
     /// Get the server/client instance.
-    const ServerOrClient& connection() const noexcept {
+    const Connection& connection() const noexcept {
         return connection_;
     }
 
     [[deprecated("Use connection() instead")]]
-    ServerOrClient& getConnection() noexcept {
+    Connection& getConnection() noexcept {
         return connection_;
     }
 
     [[deprecated("Use connection() instead")]]
-    const ServerOrClient& getConnection() const noexcept {
+    const Connection& getConnection() const noexcept {
         return connection_;
     }
 
@@ -680,19 +681,19 @@ private:
         throw BadStatus(UA_STATUSCODE_BADNOTFOUND);
     }
 
-    ServerOrClient& connection_;
+    Connection& connection_;
     NodeId id_;
 };
 
 /* ---------------------------------------------------------------------------------------------- */
 
-template <typename ServerOrClient>
-bool operator==(const Node<ServerOrClient>& lhs, const Node<ServerOrClient>& rhs) noexcept {
+template <typename Connection>
+bool operator==(const Node<Connection>& lhs, const Node<Connection>& rhs) noexcept {
     return (lhs.connection() == rhs.connection()) && (lhs.id() == rhs.id());
 }
 
-template <typename ServerOrClient>
-bool operator!=(const Node<ServerOrClient>& lhs, const Node<ServerOrClient>& rhs) noexcept {
+template <typename Connection>
+bool operator!=(const Node<Connection>& lhs, const Node<Connection>& rhs) noexcept {
     return !(lhs == rhs);
 }
 

--- a/include/open62541pp/Server.h
+++ b/include/open62541pp/Server.h
@@ -20,7 +20,7 @@ class AccessControlBase;
 class ByteString;
 class DataType;
 class Event;
-template <typename ServerOrClient>
+template <typename Connection>
 class Node;
 class NodeId;
 class Server;
@@ -32,7 +32,6 @@ namespace detail {
 struct ServerConnection;
 struct ServerContext;
 }  // namespace detail
-
 
 /* -------------------------------------- Helper functions -------------------------------------- */
 

--- a/include/open62541pp/Session.h
+++ b/include/open62541pp/Session.h
@@ -22,8 +22,8 @@ class Variant;
  */
 class Session {
 public:
-    Session(Server& server, NodeId sessionId) noexcept
-        : connection_(server),
+    Session(Server& connection, NodeId sessionId) noexcept
+        : connection_(connection),
           sessionId_(std::move(sessionId)) {}
 
     /// Get the server instance.

--- a/include/open62541pp/Subscription.h
+++ b/include/open62541pp/Subscription.h
@@ -52,6 +52,7 @@ using EventCallback =
  * are registered locally. Notifications are then forwarded to user-defined callbacks instead of a
  * remote client. The `subscriptionId` for servers is always `0U`.
  *
+ * @tparam Connection Server or Client
  * @note Not all methods are available and implemented for servers.
  *
  * Use the free functions in the opcua::services namespace for more advanced usage:

--- a/include/open62541pp/services/Attribute.h
+++ b/include/open62541pp/services/Attribute.h
@@ -94,7 +94,7 @@ inline auto readAsync(
  */
 template <typename T>
 DataValue readAttribute(
-    T& serverOrClient,
+    T& connection,
     const NodeId& id,
     AttributeId attributeId,
     TimestampsToReturn timestamps = TimestampsToReturn::Neither
@@ -189,7 +189,7 @@ inline auto writeAsync(
  */
 template <typename T>
 void writeAttribute(
-    T& serverOrClient, const NodeId& id, AttributeId attributeId, const DataValue& value
+    T& connection, const NodeId& id, AttributeId attributeId, const DataValue& value
 );
 
 /**
@@ -224,9 +224,9 @@ auto writeAttributeAsync(
 namespace detail {
 
 template <AttributeId Attribute, typename T>
-inline auto readAttributeImpl(T& serverOrClient, const NodeId& id) {
+inline auto readAttributeImpl(T& connection, const NodeId& id) {
     using Handler = typename detail::AttributeHandler<Attribute>;
-    return Handler::fromDataValue(readAttribute(serverOrClient, id, Attribute));
+    return Handler::fromDataValue(readAttribute(connection, id, Attribute));
 }
 
 template <AttributeId Attribute, typename CompletionToken>
@@ -245,18 +245,18 @@ inline auto readAttributeAsyncImpl(Client& client, const NodeId& id, CompletionT
 }
 
 template <AttributeId Attribute, typename T, typename U>
-inline void writeAttributeImpl(T& serverOrClient, const NodeId& id, U&& value) {
+inline void writeAttributeImpl(T& connection, const NodeId& id, U&& value) {
     using Handler = detail::AttributeHandler<Attribute>;
-    writeAttribute(serverOrClient, id, Attribute, Handler::toDataValue(std::forward<U>(value)));
+    writeAttribute(connection, id, Attribute, Handler::toDataValue(std::forward<U>(value)));
 }
 
 template <AttributeId Attribute, typename T, typename U, typename CompletionToken>
 inline auto writeAttributeAsyncImpl(
-    T& serverOrClient, const NodeId& id, U&& value, CompletionToken&& token
+    T& connection, const NodeId& id, U&& value, CompletionToken&& token
 ) {
     using Handler = detail::AttributeHandler<Attribute>;
     return writeAttributeAsync(
-        serverOrClient,
+        connection,
         id,
         Attribute,
         Handler::toDataValue(std::forward<U>(value)),
@@ -271,8 +271,8 @@ inline auto writeAttributeAsyncImpl(
  * @ingroup Read
  */
 template <typename T>
-inline DataValue readDataValue(T& serverOrClient, const NodeId& id) {
-    return readAttribute(serverOrClient, id, AttributeId::Value, TimestampsToReturn::Both);
+inline DataValue readDataValue(T& connection, const NodeId& id) {
+    return readAttribute(connection, id, AttributeId::Value, TimestampsToReturn::Both);
 }
 
 /**
@@ -281,9 +281,9 @@ inline DataValue readDataValue(T& serverOrClient, const NodeId& id) {
  * @ingroup Read
  */
 template <typename T, typename CompletionToken = DefaultCompletionToken>
-inline auto readDataValueAsync(T& serverOrClient, const NodeId& id, CompletionToken&& token) {
+inline auto readDataValueAsync(T& connection, const NodeId& id, CompletionToken&& token) {
     return readAttributeAsync(
-        serverOrClient,
+        connection,
         id,
         AttributeId::Value,
         TimestampsToReturn::Both,
@@ -296,8 +296,8 @@ inline auto readDataValueAsync(T& serverOrClient, const NodeId& id, CompletionTo
  * @ingroup Write
  */
 template <typename T>
-inline void writeDataValue(T& serverOrClient, const NodeId& id, const DataValue& value) {
-    writeAttribute(serverOrClient, id, AttributeId::Value, value);
+inline void writeDataValue(T& connection, const NodeId& id, const DataValue& value) {
+    writeAttribute(connection, id, AttributeId::Value, value);
 }
 
 /**

--- a/include/open62541pp/services/Attribute_highlevel.h
+++ b/include/open62541pp/services/Attribute_highlevel.h
@@ -13,8 +13,8 @@ namespace opcua::services {
  * @ingroup Read
  */
 template <typename T>
-inline NodeId readNodeId(T& serverOrClient, const NodeId& id) {
-    return detail::readAttributeImpl<AttributeId::NodeId>(serverOrClient, id);
+inline NodeId readNodeId(T& connection, const NodeId& id) {
+    return detail::readAttributeImpl<AttributeId::NodeId>(connection, id);
 }
 
 /**
@@ -24,10 +24,10 @@ inline NodeId readNodeId(T& serverOrClient, const NodeId& id) {
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto readNodeIdAsync(
-    Client& client, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::readAttributeAsyncImpl<AttributeId::NodeId>(
-        client, id, std::forward<CompletionToken>(token)
+        connection, id, std::forward<CompletionToken>(token)
     );
 }
 
@@ -36,8 +36,8 @@ inline auto readNodeIdAsync(
  * @ingroup Read
  */
 template <typename T>
-inline NodeClass readNodeClass(T& serverOrClient, const NodeId& id) {
-    return detail::readAttributeImpl<AttributeId::NodeClass>(serverOrClient, id);
+inline NodeClass readNodeClass(T& connection, const NodeId& id) {
+    return detail::readAttributeImpl<AttributeId::NodeClass>(connection, id);
 }
 
 /**
@@ -47,10 +47,10 @@ inline NodeClass readNodeClass(T& serverOrClient, const NodeId& id) {
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto readNodeClassAsync(
-    Client& client, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::readAttributeAsyncImpl<AttributeId::NodeClass>(
-        client, id, std::forward<CompletionToken>(token)
+        connection, id, std::forward<CompletionToken>(token)
     );
 }
 
@@ -59,8 +59,8 @@ inline auto readNodeClassAsync(
  * @ingroup Read
  */
 template <typename T>
-inline QualifiedName readBrowseName(T& serverOrClient, const NodeId& id) {
-    return detail::readAttributeImpl<AttributeId::BrowseName>(serverOrClient, id);
+inline QualifiedName readBrowseName(T& connection, const NodeId& id) {
+    return detail::readAttributeImpl<AttributeId::BrowseName>(connection, id);
 }
 
 /**
@@ -70,10 +70,10 @@ inline QualifiedName readBrowseName(T& serverOrClient, const NodeId& id) {
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto readBrowseNameAsync(
-    Client& client, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::readAttributeAsyncImpl<AttributeId::BrowseName>(
-        client, id, std::forward<CompletionToken>(token)
+        connection, id, std::forward<CompletionToken>(token)
     );
 }
 
@@ -82,8 +82,8 @@ inline auto readBrowseNameAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeBrowseName(T& serverOrClient, const NodeId& id, const QualifiedName& browseName) {
-    detail::writeAttributeImpl<AttributeId::BrowseName>(serverOrClient, id, browseName);
+inline void writeBrowseName(T& connection, const NodeId& id, const QualifiedName& browseName) {
+    detail::writeAttributeImpl<AttributeId::BrowseName>(connection, id, browseName);
 }
 
 /**
@@ -93,13 +93,13 @@ inline void writeBrowseName(T& serverOrClient, const NodeId& id, const Qualified
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto writeBrowseNameAsync(
-    Client& client,
+    Client& connection,
     const NodeId& id,
     const QualifiedName& browseName,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     detail::writeAttributeAsyncImpl<AttributeId::BrowseName>(
-        client, id, browseName, std::forward<CompletionToken>(token)
+        connection, id, browseName, std::forward<CompletionToken>(token)
     );
 }
 
@@ -108,8 +108,8 @@ inline auto writeBrowseNameAsync(
  * @ingroup Read
  */
 template <typename T>
-inline LocalizedText readDisplayName(T& serverOrClient, const NodeId& id) {
-    return detail::readAttributeImpl<AttributeId::DisplayName>(serverOrClient, id);
+inline LocalizedText readDisplayName(T& connection, const NodeId& id) {
+    return detail::readAttributeImpl<AttributeId::DisplayName>(connection, id);
 }
 
 /**
@@ -119,10 +119,10 @@ inline LocalizedText readDisplayName(T& serverOrClient, const NodeId& id) {
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto readDisplayNameAsync(
-    Client& client, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::readAttributeAsyncImpl<AttributeId::DisplayName>(
-        client, id, std::forward<CompletionToken>(token)
+        connection, id, std::forward<CompletionToken>(token)
     );
 }
 
@@ -131,10 +131,8 @@ inline auto readDisplayNameAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeDisplayName(
-    T& serverOrClient, const NodeId& id, const LocalizedText& displayName
-) {
-    detail::writeAttributeImpl<AttributeId::DisplayName>(serverOrClient, id, displayName);
+inline void writeDisplayName(T& connection, const NodeId& id, const LocalizedText& displayName) {
+    detail::writeAttributeImpl<AttributeId::DisplayName>(connection, id, displayName);
 }
 
 /**
@@ -144,13 +142,13 @@ inline void writeDisplayName(
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto writeDisplayNameAsync(
-    Client& client,
+    Client& connection,
     const NodeId& id,
     const LocalizedText& displayName,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     detail::writeAttributeAsyncImpl<AttributeId::DisplayName>(
-        client, id, displayName, std::forward<CompletionToken>(token)
+        connection, id, displayName, std::forward<CompletionToken>(token)
     );
 }
 
@@ -159,8 +157,8 @@ inline auto writeDisplayNameAsync(
  * @ingroup Read
  */
 template <typename T>
-inline LocalizedText readDescription(T& serverOrClient, const NodeId& id) {
-    return detail::readAttributeImpl<AttributeId::Description>(serverOrClient, id);
+inline LocalizedText readDescription(T& connection, const NodeId& id) {
+    return detail::readAttributeImpl<AttributeId::Description>(connection, id);
 }
 
 /**
@@ -170,10 +168,10 @@ inline LocalizedText readDescription(T& serverOrClient, const NodeId& id) {
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto readDescriptionAsync(
-    Client& client, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::readAttributeAsyncImpl<AttributeId::Description>(
-        client, id, std::forward<CompletionToken>(token)
+        connection, id, std::forward<CompletionToken>(token)
     );
 }
 
@@ -182,10 +180,8 @@ inline auto readDescriptionAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeDescription(
-    T& serverOrClient, const NodeId& id, const LocalizedText& description
-) {
-    detail::writeAttributeImpl<AttributeId::Description>(serverOrClient, id, description);
+inline void writeDescription(T& connection, const NodeId& id, const LocalizedText& description) {
+    detail::writeAttributeImpl<AttributeId::Description>(connection, id, description);
 }
 
 /**
@@ -195,13 +191,13 @@ inline void writeDescription(
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto writeDescriptionAsync(
-    Client& client,
+    Client& connection,
     const NodeId& id,
     const LocalizedText& description,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     detail::writeAttributeAsyncImpl<AttributeId::Description>(
-        client, id, description, std::forward<CompletionToken>(token)
+        connection, id, description, std::forward<CompletionToken>(token)
     );
 }
 
@@ -210,8 +206,8 @@ inline auto writeDescriptionAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Bitmask<WriteMask> readWriteMask(T& serverOrClient, const NodeId& id) {
-    return detail::readAttributeImpl<AttributeId::WriteMask>(serverOrClient, id);
+inline Bitmask<WriteMask> readWriteMask(T& connection, const NodeId& id) {
+    return detail::readAttributeImpl<AttributeId::WriteMask>(connection, id);
 }
 
 /**
@@ -221,10 +217,10 @@ inline Bitmask<WriteMask> readWriteMask(T& serverOrClient, const NodeId& id) {
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto readWriteMaskAsync(
-    Client& client, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::readAttributeAsyncImpl<AttributeId::WriteMask>(
-        client, id, std::forward<CompletionToken>(token)
+        connection, id, std::forward<CompletionToken>(token)
     );
 }
 
@@ -233,8 +229,8 @@ inline auto readWriteMaskAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeWriteMask(T& serverOrClient, const NodeId& id, Bitmask<WriteMask> writeMask) {
-    detail::writeAttributeImpl<AttributeId::WriteMask>(serverOrClient, id, writeMask);
+inline void writeWriteMask(T& connection, const NodeId& id, Bitmask<WriteMask> writeMask) {
+    detail::writeAttributeImpl<AttributeId::WriteMask>(connection, id, writeMask);
 }
 
 /**
@@ -244,13 +240,13 @@ inline void writeWriteMask(T& serverOrClient, const NodeId& id, Bitmask<WriteMas
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto writeWriteMaskAsync(
-    Client& client,
+    Client& connection,
     const NodeId& id,
     Bitmask<WriteMask> writeMask,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     detail::writeAttributeAsyncImpl<AttributeId::WriteMask>(
-        client, id, writeMask, std::forward<CompletionToken>(token)
+        connection, id, writeMask, std::forward<CompletionToken>(token)
     );
 }
 
@@ -259,8 +255,8 @@ inline auto writeWriteMaskAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Bitmask<WriteMask> readUserWriteMask(T& serverOrClient, const NodeId& id) {
-    return detail::readAttributeImpl<AttributeId::UserWriteMask>(serverOrClient, id);
+inline Bitmask<WriteMask> readUserWriteMask(T& connection, const NodeId& id) {
+    return detail::readAttributeImpl<AttributeId::UserWriteMask>(connection, id);
 }
 
 /**
@@ -270,10 +266,10 @@ inline Bitmask<WriteMask> readUserWriteMask(T& serverOrClient, const NodeId& id)
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto readUserWriteMaskAsync(
-    Client& client, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::readAttributeAsyncImpl<AttributeId::UserWriteMask>(
-        client, id, std::forward<CompletionToken>(token)
+        connection, id, std::forward<CompletionToken>(token)
     );
 }
 
@@ -282,10 +278,8 @@ inline auto readUserWriteMaskAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeUserWriteMask(
-    T& serverOrClient, const NodeId& id, Bitmask<WriteMask> userWriteMask
-) {
-    detail::writeAttributeImpl<AttributeId::UserWriteMask>(serverOrClient, id, userWriteMask);
+inline void writeUserWriteMask(T& connection, const NodeId& id, Bitmask<WriteMask> userWriteMask) {
+    detail::writeAttributeImpl<AttributeId::UserWriteMask>(connection, id, userWriteMask);
 }
 
 /**
@@ -295,13 +289,13 @@ inline void writeUserWriteMask(
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto writeUserWriteMaskAsync(
-    Client& client,
+    Client& connection,
     const NodeId& id,
     Bitmask<WriteMask> userWriteMask,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     detail::writeAttributeAsyncImpl<AttributeId::UserWriteMask>(
-        client, id, userWriteMask, std::forward<CompletionToken>(token)
+        connection, id, userWriteMask, std::forward<CompletionToken>(token)
     );
 }
 
@@ -310,8 +304,8 @@ inline auto writeUserWriteMaskAsync(
  * @ingroup Read
  */
 template <typename T>
-inline bool readIsAbstract(T& serverOrClient, const NodeId& id) {
-    return detail::readAttributeImpl<AttributeId::IsAbstract>(serverOrClient, id);
+inline bool readIsAbstract(T& connection, const NodeId& id) {
+    return detail::readAttributeImpl<AttributeId::IsAbstract>(connection, id);
 }
 
 /**
@@ -321,10 +315,10 @@ inline bool readIsAbstract(T& serverOrClient, const NodeId& id) {
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto readIsAbstractAsync(
-    Client& client, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::readAttributeAsyncImpl<AttributeId::IsAbstract>(
-        client, id, std::forward<CompletionToken>(token)
+        connection, id, std::forward<CompletionToken>(token)
     );
 }
 
@@ -333,8 +327,8 @@ inline auto readIsAbstractAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeIsAbstract(T& serverOrClient, const NodeId& id, bool isAbstract) {
-    detail::writeAttributeImpl<AttributeId::IsAbstract>(serverOrClient, id, isAbstract);
+inline void writeIsAbstract(T& connection, const NodeId& id, bool isAbstract) {
+    detail::writeAttributeImpl<AttributeId::IsAbstract>(connection, id, isAbstract);
 }
 
 /**
@@ -344,13 +338,13 @@ inline void writeIsAbstract(T& serverOrClient, const NodeId& id, bool isAbstract
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto writeIsAbstractAsync(
-    Client& client,
+    Client& connection,
     const NodeId& id,
     bool isAbstract,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     detail::writeAttributeAsyncImpl<AttributeId::IsAbstract>(
-        client, id, isAbstract, std::forward<CompletionToken>(token)
+        connection, id, isAbstract, std::forward<CompletionToken>(token)
     );
 }
 
@@ -359,8 +353,8 @@ inline auto writeIsAbstractAsync(
  * @ingroup Read
  */
 template <typename T>
-inline bool readSymmetric(T& serverOrClient, const NodeId& id) {
-    return detail::readAttributeImpl<AttributeId::Symmetric>(serverOrClient, id);
+inline bool readSymmetric(T& connection, const NodeId& id) {
+    return detail::readAttributeImpl<AttributeId::Symmetric>(connection, id);
 }
 
 /**
@@ -370,10 +364,10 @@ inline bool readSymmetric(T& serverOrClient, const NodeId& id) {
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto readSymmetricAsync(
-    Client& client, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::readAttributeAsyncImpl<AttributeId::Symmetric>(
-        client, id, std::forward<CompletionToken>(token)
+        connection, id, std::forward<CompletionToken>(token)
     );
 }
 
@@ -382,8 +376,8 @@ inline auto readSymmetricAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeSymmetric(T& serverOrClient, const NodeId& id, bool symmetric) {
-    detail::writeAttributeImpl<AttributeId::Symmetric>(serverOrClient, id, symmetric);
+inline void writeSymmetric(T& connection, const NodeId& id, bool symmetric) {
+    detail::writeAttributeImpl<AttributeId::Symmetric>(connection, id, symmetric);
 }
 
 /**
@@ -393,13 +387,13 @@ inline void writeSymmetric(T& serverOrClient, const NodeId& id, bool symmetric) 
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto writeSymmetricAsync(
-    Client& client,
+    Client& connection,
     const NodeId& id,
     bool symmetric,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     detail::writeAttributeAsyncImpl<AttributeId::Symmetric>(
-        client, id, symmetric, std::forward<CompletionToken>(token)
+        connection, id, symmetric, std::forward<CompletionToken>(token)
     );
 }
 
@@ -408,8 +402,8 @@ inline auto writeSymmetricAsync(
  * @ingroup Read
  */
 template <typename T>
-inline LocalizedText readInverseName(T& serverOrClient, const NodeId& id) {
-    return detail::readAttributeImpl<AttributeId::InverseName>(serverOrClient, id);
+inline LocalizedText readInverseName(T& connection, const NodeId& id) {
+    return detail::readAttributeImpl<AttributeId::InverseName>(connection, id);
 }
 
 /**
@@ -419,10 +413,10 @@ inline LocalizedText readInverseName(T& serverOrClient, const NodeId& id) {
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto readInverseNameAsync(
-    Client& client, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::readAttributeAsyncImpl<AttributeId::InverseName>(
-        client, id, std::forward<CompletionToken>(token)
+        connection, id, std::forward<CompletionToken>(token)
     );
 }
 
@@ -431,10 +425,8 @@ inline auto readInverseNameAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeInverseName(
-    T& serverOrClient, const NodeId& id, const LocalizedText& inverseName
-) {
-    detail::writeAttributeImpl<AttributeId::InverseName>(serverOrClient, id, inverseName);
+inline void writeInverseName(T& connection, const NodeId& id, const LocalizedText& inverseName) {
+    detail::writeAttributeImpl<AttributeId::InverseName>(connection, id, inverseName);
 }
 
 /**
@@ -444,13 +436,13 @@ inline void writeInverseName(
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto writeInverseNameAsync(
-    Client& client,
+    Client& connection,
     const NodeId& id,
     const LocalizedText& inverseName,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     detail::writeAttributeAsyncImpl<AttributeId::InverseName>(
-        client, id, inverseName, std::forward<CompletionToken>(token)
+        connection, id, inverseName, std::forward<CompletionToken>(token)
     );
 }
 
@@ -459,8 +451,8 @@ inline auto writeInverseNameAsync(
  * @ingroup Read
  */
 template <typename T>
-inline bool readContainsNoLoops(T& serverOrClient, const NodeId& id) {
-    return detail::readAttributeImpl<AttributeId::ContainsNoLoops>(serverOrClient, id);
+inline bool readContainsNoLoops(T& connection, const NodeId& id) {
+    return detail::readAttributeImpl<AttributeId::ContainsNoLoops>(connection, id);
 }
 
 /**
@@ -470,10 +462,10 @@ inline bool readContainsNoLoops(T& serverOrClient, const NodeId& id) {
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto readContainsNoLoopsAsync(
-    Client& client, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::readAttributeAsyncImpl<AttributeId::ContainsNoLoops>(
-        client, id, std::forward<CompletionToken>(token)
+        connection, id, std::forward<CompletionToken>(token)
     );
 }
 
@@ -482,8 +474,8 @@ inline auto readContainsNoLoopsAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeContainsNoLoops(T& serverOrClient, const NodeId& id, const bool& containsNoLoops) {
-    detail::writeAttributeImpl<AttributeId::ContainsNoLoops>(serverOrClient, id, containsNoLoops);
+inline void writeContainsNoLoops(T& connection, const NodeId& id, const bool& containsNoLoops) {
+    detail::writeAttributeImpl<AttributeId::ContainsNoLoops>(connection, id, containsNoLoops);
 }
 
 /**
@@ -493,13 +485,13 @@ inline void writeContainsNoLoops(T& serverOrClient, const NodeId& id, const bool
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto writeContainsNoLoopsAsync(
-    Client& client,
+    Client& connection,
     const NodeId& id,
     const bool& containsNoLoops,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     detail::writeAttributeAsyncImpl<AttributeId::ContainsNoLoops>(
-        client, id, containsNoLoops, std::forward<CompletionToken>(token)
+        connection, id, containsNoLoops, std::forward<CompletionToken>(token)
     );
 }
 
@@ -508,8 +500,8 @@ inline auto writeContainsNoLoopsAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Bitmask<EventNotifier> readEventNotifier(T& serverOrClient, const NodeId& id) {
-    return detail::readAttributeImpl<AttributeId::EventNotifier>(serverOrClient, id);
+inline Bitmask<EventNotifier> readEventNotifier(T& connection, const NodeId& id) {
+    return detail::readAttributeImpl<AttributeId::EventNotifier>(connection, id);
 }
 
 /**
@@ -519,10 +511,10 @@ inline Bitmask<EventNotifier> readEventNotifier(T& serverOrClient, const NodeId&
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto readEventNotifierAsync(
-    Client& client, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::readAttributeAsyncImpl<AttributeId::EventNotifier>(
-        client, id, std::forward<CompletionToken>(token)
+        connection, id, std::forward<CompletionToken>(token)
     );
 }
 
@@ -532,9 +524,9 @@ inline auto readEventNotifierAsync(
  */
 template <typename T>
 inline void writeEventNotifier(
-    T& serverOrClient, const NodeId& id, Bitmask<EventNotifier> eventNotifier
+    T& connection, const NodeId& id, Bitmask<EventNotifier> eventNotifier
 ) {
-    detail::writeAttributeImpl<AttributeId::EventNotifier>(serverOrClient, id, eventNotifier);
+    detail::writeAttributeImpl<AttributeId::EventNotifier>(connection, id, eventNotifier);
 }
 
 /**
@@ -544,13 +536,13 @@ inline void writeEventNotifier(
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto writeEventNotifierAsync(
-    Client& client,
+    Client& connection,
     const NodeId& id,
     Bitmask<EventNotifier> eventNotifier,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     detail::writeAttributeAsyncImpl<AttributeId::EventNotifier>(
-        client, id, eventNotifier, std::forward<CompletionToken>(token)
+        connection, id, eventNotifier, std::forward<CompletionToken>(token)
     );
 }
 
@@ -559,8 +551,8 @@ inline auto writeEventNotifierAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Variant readValue(T& serverOrClient, const NodeId& id) {
-    return detail::readAttributeImpl<AttributeId::Value>(serverOrClient, id);
+inline Variant readValue(T& connection, const NodeId& id) {
+    return detail::readAttributeImpl<AttributeId::Value>(connection, id);
 }
 
 /**
@@ -570,10 +562,10 @@ inline Variant readValue(T& serverOrClient, const NodeId& id) {
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto readValueAsync(
-    Client& client, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::readAttributeAsyncImpl<AttributeId::Value>(
-        client, id, std::forward<CompletionToken>(token)
+        connection, id, std::forward<CompletionToken>(token)
     );
 }
 
@@ -582,8 +574,8 @@ inline auto readValueAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeValue(T& serverOrClient, const NodeId& id, const Variant& value) {
-    detail::writeAttributeImpl<AttributeId::Value>(serverOrClient, id, value);
+inline void writeValue(T& connection, const NodeId& id, const Variant& value) {
+    detail::writeAttributeImpl<AttributeId::Value>(connection, id, value);
 }
 
 /**
@@ -593,13 +585,13 @@ inline void writeValue(T& serverOrClient, const NodeId& id, const Variant& value
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto writeValueAsync(
-    Client& client,
+    Client& connection,
     const NodeId& id,
     const Variant& value,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     detail::writeAttributeAsyncImpl<AttributeId::Value>(
-        client, id, value, std::forward<CompletionToken>(token)
+        connection, id, value, std::forward<CompletionToken>(token)
     );
 }
 
@@ -608,8 +600,8 @@ inline auto writeValueAsync(
  * @ingroup Read
  */
 template <typename T>
-inline NodeId readDataType(T& serverOrClient, const NodeId& id) {
-    return detail::readAttributeImpl<AttributeId::DataType>(serverOrClient, id);
+inline NodeId readDataType(T& connection, const NodeId& id) {
+    return detail::readAttributeImpl<AttributeId::DataType>(connection, id);
 }
 
 /**
@@ -619,10 +611,10 @@ inline NodeId readDataType(T& serverOrClient, const NodeId& id) {
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto readDataTypeAsync(
-    Client& client, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::readAttributeAsyncImpl<AttributeId::DataType>(
-        client, id, std::forward<CompletionToken>(token)
+        connection, id, std::forward<CompletionToken>(token)
     );
 }
 
@@ -631,8 +623,8 @@ inline auto readDataTypeAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeDataType(T& serverOrClient, const NodeId& id, const NodeId& dataType) {
-    detail::writeAttributeImpl<AttributeId::DataType>(serverOrClient, id, dataType);
+inline void writeDataType(T& connection, const NodeId& id, const NodeId& dataType) {
+    detail::writeAttributeImpl<AttributeId::DataType>(connection, id, dataType);
 }
 
 /**
@@ -642,13 +634,13 @@ inline void writeDataType(T& serverOrClient, const NodeId& id, const NodeId& dat
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto writeDataTypeAsync(
-    Client& client,
+    Client& connection,
     const NodeId& id,
     const NodeId& dataType,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     detail::writeAttributeAsyncImpl<AttributeId::DataType>(
-        client, id, dataType, std::forward<CompletionToken>(token)
+        connection, id, dataType, std::forward<CompletionToken>(token)
     );
 }
 
@@ -657,8 +649,8 @@ inline auto writeDataTypeAsync(
  * @ingroup Read
  */
 template <typename T>
-inline ValueRank readValueRank(T& serverOrClient, const NodeId& id) {
-    return detail::readAttributeImpl<AttributeId::ValueRank>(serverOrClient, id);
+inline ValueRank readValueRank(T& connection, const NodeId& id) {
+    return detail::readAttributeImpl<AttributeId::ValueRank>(connection, id);
 }
 
 /**
@@ -668,10 +660,10 @@ inline ValueRank readValueRank(T& serverOrClient, const NodeId& id) {
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto readValueRankAsync(
-    Client& client, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::readAttributeAsyncImpl<AttributeId::ValueRank>(
-        client, id, std::forward<CompletionToken>(token)
+        connection, id, std::forward<CompletionToken>(token)
     );
 }
 
@@ -680,8 +672,8 @@ inline auto readValueRankAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeValueRank(T& serverOrClient, const NodeId& id, ValueRank valueRank) {
-    detail::writeAttributeImpl<AttributeId::ValueRank>(serverOrClient, id, valueRank);
+inline void writeValueRank(T& connection, const NodeId& id, ValueRank valueRank) {
+    detail::writeAttributeImpl<AttributeId::ValueRank>(connection, id, valueRank);
 }
 
 /**
@@ -691,13 +683,13 @@ inline void writeValueRank(T& serverOrClient, const NodeId& id, ValueRank valueR
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto writeValueRankAsync(
-    Client& client,
+    Client& connection,
     const NodeId& id,
     ValueRank valueRank,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     detail::writeAttributeAsyncImpl<AttributeId::ValueRank>(
-        client, id, valueRank, std::forward<CompletionToken>(token)
+        connection, id, valueRank, std::forward<CompletionToken>(token)
     );
 }
 
@@ -706,8 +698,8 @@ inline auto writeValueRankAsync(
  * @ingroup Read
  */
 template <typename T>
-inline std::vector<uint32_t> readArrayDimensions(T& serverOrClient, const NodeId& id) {
-    return detail::readAttributeImpl<AttributeId::ArrayDimensions>(serverOrClient, id);
+inline std::vector<uint32_t> readArrayDimensions(T& connection, const NodeId& id) {
+    return detail::readAttributeImpl<AttributeId::ArrayDimensions>(connection, id);
 }
 
 /**
@@ -717,10 +709,10 @@ inline std::vector<uint32_t> readArrayDimensions(T& serverOrClient, const NodeId
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto readArrayDimensionsAsync(
-    Client& client, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::readAttributeAsyncImpl<AttributeId::ArrayDimensions>(
-        client, id, std::forward<CompletionToken>(token)
+        connection, id, std::forward<CompletionToken>(token)
     );
 }
 
@@ -730,9 +722,9 @@ inline auto readArrayDimensionsAsync(
  */
 template <typename T>
 inline void writeArrayDimensions(
-    T& serverOrClient, const NodeId& id, Span<const uint32_t> arrayDimensions
+    T& connection, const NodeId& id, Span<const uint32_t> arrayDimensions
 ) {
-    detail::writeAttributeImpl<AttributeId::ArrayDimensions>(serverOrClient, id, arrayDimensions);
+    detail::writeAttributeImpl<AttributeId::ArrayDimensions>(connection, id, arrayDimensions);
 }
 
 /**
@@ -742,13 +734,13 @@ inline void writeArrayDimensions(
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto writeArrayDimensionsAsync(
-    Client& client,
+    Client& connection,
     const NodeId& id,
     Span<const uint32_t> arrayDimensions,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     detail::writeAttributeAsyncImpl<AttributeId::ArrayDimensions>(
-        client, id, arrayDimensions, std::forward<CompletionToken>(token)
+        connection, id, arrayDimensions, std::forward<CompletionToken>(token)
     );
 }
 
@@ -757,8 +749,8 @@ inline auto writeArrayDimensionsAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Bitmask<AccessLevel> readAccessLevel(T& serverOrClient, const NodeId& id) {
-    return detail::readAttributeImpl<AttributeId::AccessLevel>(serverOrClient, id);
+inline Bitmask<AccessLevel> readAccessLevel(T& connection, const NodeId& id) {
+    return detail::readAttributeImpl<AttributeId::AccessLevel>(connection, id);
 }
 
 /**
@@ -768,10 +760,10 @@ inline Bitmask<AccessLevel> readAccessLevel(T& serverOrClient, const NodeId& id)
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto readAccessLevelAsync(
-    Client& client, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::readAttributeAsyncImpl<AttributeId::AccessLevel>(
-        client, id, std::forward<CompletionToken>(token)
+        connection, id, std::forward<CompletionToken>(token)
     );
 }
 
@@ -780,10 +772,8 @@ inline auto readAccessLevelAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeAccessLevel(
-    T& serverOrClient, const NodeId& id, Bitmask<AccessLevel> accessLevel
-) {
-    detail::writeAttributeImpl<AttributeId::AccessLevel>(serverOrClient, id, accessLevel);
+inline void writeAccessLevel(T& connection, const NodeId& id, Bitmask<AccessLevel> accessLevel) {
+    detail::writeAttributeImpl<AttributeId::AccessLevel>(connection, id, accessLevel);
 }
 
 /**
@@ -793,13 +783,13 @@ inline void writeAccessLevel(
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto writeAccessLevelAsync(
-    Client& client,
+    Client& connection,
     const NodeId& id,
     Bitmask<AccessLevel> accessLevel,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     detail::writeAttributeAsyncImpl<AttributeId::AccessLevel>(
-        client, id, accessLevel, std::forward<CompletionToken>(token)
+        connection, id, accessLevel, std::forward<CompletionToken>(token)
     );
 }
 
@@ -808,8 +798,8 @@ inline auto writeAccessLevelAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Bitmask<AccessLevel> readUserAccessLevel(T& serverOrClient, const NodeId& id) {
-    return detail::readAttributeImpl<AttributeId::UserAccessLevel>(serverOrClient, id);
+inline Bitmask<AccessLevel> readUserAccessLevel(T& connection, const NodeId& id) {
+    return detail::readAttributeImpl<AttributeId::UserAccessLevel>(connection, id);
 }
 
 /**
@@ -819,10 +809,10 @@ inline Bitmask<AccessLevel> readUserAccessLevel(T& serverOrClient, const NodeId&
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto readUserAccessLevelAsync(
-    Client& client, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::readAttributeAsyncImpl<AttributeId::UserAccessLevel>(
-        client, id, std::forward<CompletionToken>(token)
+        connection, id, std::forward<CompletionToken>(token)
     );
 }
 
@@ -832,9 +822,9 @@ inline auto readUserAccessLevelAsync(
  */
 template <typename T>
 inline void writeUserAccessLevel(
-    T& serverOrClient, const NodeId& id, Bitmask<AccessLevel> userAccessLevel
+    T& connection, const NodeId& id, Bitmask<AccessLevel> userAccessLevel
 ) {
-    detail::writeAttributeImpl<AttributeId::UserAccessLevel>(serverOrClient, id, userAccessLevel);
+    detail::writeAttributeImpl<AttributeId::UserAccessLevel>(connection, id, userAccessLevel);
 }
 
 /**
@@ -844,13 +834,13 @@ inline void writeUserAccessLevel(
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto writeUserAccessLevelAsync(
-    Client& client,
+    Client& connection,
     const NodeId& id,
     Bitmask<AccessLevel> userAccessLevel,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     detail::writeAttributeAsyncImpl<AttributeId::UserAccessLevel>(
-        client, id, userAccessLevel, std::forward<CompletionToken>(token)
+        connection, id, userAccessLevel, std::forward<CompletionToken>(token)
     );
 }
 
@@ -859,8 +849,8 @@ inline auto writeUserAccessLevelAsync(
  * @ingroup Read
  */
 template <typename T>
-inline double readMinimumSamplingInterval(T& serverOrClient, const NodeId& id) {
-    return detail::readAttributeImpl<AttributeId::MinimumSamplingInterval>(serverOrClient, id);
+inline double readMinimumSamplingInterval(T& connection, const NodeId& id) {
+    return detail::readAttributeImpl<AttributeId::MinimumSamplingInterval>(connection, id);
 }
 
 /**
@@ -870,10 +860,10 @@ inline double readMinimumSamplingInterval(T& serverOrClient, const NodeId& id) {
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto readMinimumSamplingIntervalAsync(
-    Client& client, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::readAttributeAsyncImpl<AttributeId::MinimumSamplingInterval>(
-        client, id, std::forward<CompletionToken>(token)
+        connection, id, std::forward<CompletionToken>(token)
     );
 }
 
@@ -883,10 +873,10 @@ inline auto readMinimumSamplingIntervalAsync(
  */
 template <typename T>
 inline void writeMinimumSamplingInterval(
-    T& serverOrClient, const NodeId& id, double minimumSamplingInterval
+    T& connection, const NodeId& id, double minimumSamplingInterval
 ) {
     detail::writeAttributeImpl<AttributeId::MinimumSamplingInterval>(
-        serverOrClient, id, minimumSamplingInterval
+        connection, id, minimumSamplingInterval
     );
 }
 
@@ -897,13 +887,13 @@ inline void writeMinimumSamplingInterval(
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto writeMinimumSamplingIntervalAsync(
-    Client& client,
+    Client& connection,
     const NodeId& id,
     double minimumSamplingInterval,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     detail::writeAttributeAsyncImpl<AttributeId::MinimumSamplingInterval>(
-        client, id, minimumSamplingInterval, std::forward<CompletionToken>(token)
+        connection, id, minimumSamplingInterval, std::forward<CompletionToken>(token)
     );
 }
 
@@ -912,8 +902,8 @@ inline auto writeMinimumSamplingIntervalAsync(
  * @ingroup Read
  */
 template <typename T>
-inline bool readHistorizing(T& serverOrClient, const NodeId& id) {
-    return detail::readAttributeImpl<AttributeId::Historizing>(serverOrClient, id);
+inline bool readHistorizing(T& connection, const NodeId& id) {
+    return detail::readAttributeImpl<AttributeId::Historizing>(connection, id);
 }
 
 /**
@@ -923,10 +913,10 @@ inline bool readHistorizing(T& serverOrClient, const NodeId& id) {
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto readHistorizingAsync(
-    Client& client, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::readAttributeAsyncImpl<AttributeId::Historizing>(
-        client, id, std::forward<CompletionToken>(token)
+        connection, id, std::forward<CompletionToken>(token)
     );
 }
 
@@ -935,8 +925,8 @@ inline auto readHistorizingAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeHistorizing(T& serverOrClient, const NodeId& id, bool historizing) {
-    detail::writeAttributeImpl<AttributeId::Historizing>(serverOrClient, id, historizing);
+inline void writeHistorizing(T& connection, const NodeId& id, bool historizing) {
+    detail::writeAttributeImpl<AttributeId::Historizing>(connection, id, historizing);
 }
 
 /**
@@ -946,13 +936,13 @@ inline void writeHistorizing(T& serverOrClient, const NodeId& id, bool historizi
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto writeHistorizingAsync(
-    Client& client,
+    Client& connection,
     const NodeId& id,
     bool historizing,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     detail::writeAttributeAsyncImpl<AttributeId::Historizing>(
-        client, id, historizing, std::forward<CompletionToken>(token)
+        connection, id, historizing, std::forward<CompletionToken>(token)
     );
 }
 
@@ -961,8 +951,8 @@ inline auto writeHistorizingAsync(
  * @ingroup Read
  */
 template <typename T>
-inline bool readExecutable(T& serverOrClient, const NodeId& id) {
-    return detail::readAttributeImpl<AttributeId::Executable>(serverOrClient, id);
+inline bool readExecutable(T& connection, const NodeId& id) {
+    return detail::readAttributeImpl<AttributeId::Executable>(connection, id);
 }
 
 /**
@@ -972,10 +962,10 @@ inline bool readExecutable(T& serverOrClient, const NodeId& id) {
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto readExecutableAsync(
-    Client& client, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::readAttributeAsyncImpl<AttributeId::Executable>(
-        client, id, std::forward<CompletionToken>(token)
+        connection, id, std::forward<CompletionToken>(token)
     );
 }
 
@@ -984,8 +974,8 @@ inline auto readExecutableAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeExecutable(T& serverOrClient, const NodeId& id, bool executable) {
-    detail::writeAttributeImpl<AttributeId::Executable>(serverOrClient, id, executable);
+inline void writeExecutable(T& connection, const NodeId& id, bool executable) {
+    detail::writeAttributeImpl<AttributeId::Executable>(connection, id, executable);
 }
 
 /**
@@ -995,13 +985,13 @@ inline void writeExecutable(T& serverOrClient, const NodeId& id, bool executable
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto writeExecutableAsync(
-    Client& client,
+    Client& connection,
     const NodeId& id,
     bool executable,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     detail::writeAttributeAsyncImpl<AttributeId::Executable>(
-        client, id, executable, std::forward<CompletionToken>(token)
+        connection, id, executable, std::forward<CompletionToken>(token)
     );
 }
 
@@ -1010,8 +1000,8 @@ inline auto writeExecutableAsync(
  * @ingroup Read
  */
 template <typename T>
-inline bool readUserExecutable(T& serverOrClient, const NodeId& id) {
-    return detail::readAttributeImpl<AttributeId::UserExecutable>(serverOrClient, id);
+inline bool readUserExecutable(T& connection, const NodeId& id) {
+    return detail::readAttributeImpl<AttributeId::UserExecutable>(connection, id);
 }
 
 /**
@@ -1021,10 +1011,10 @@ inline bool readUserExecutable(T& serverOrClient, const NodeId& id) {
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto readUserExecutableAsync(
-    Client& client, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::readAttributeAsyncImpl<AttributeId::UserExecutable>(
-        client, id, std::forward<CompletionToken>(token)
+        connection, id, std::forward<CompletionToken>(token)
     );
 }
 
@@ -1033,8 +1023,8 @@ inline auto readUserExecutableAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeUserExecutable(T& serverOrClient, const NodeId& id, bool userExecutable) {
-    detail::writeAttributeImpl<AttributeId::UserExecutable>(serverOrClient, id, userExecutable);
+inline void writeUserExecutable(T& connection, const NodeId& id, bool userExecutable) {
+    detail::writeAttributeImpl<AttributeId::UserExecutable>(connection, id, userExecutable);
 }
 
 /**
@@ -1044,13 +1034,13 @@ inline void writeUserExecutable(T& serverOrClient, const NodeId& id, bool userEx
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto writeUserExecutableAsync(
-    Client& client,
+    Client& connection,
     const NodeId& id,
     bool userExecutable,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     detail::writeAttributeAsyncImpl<AttributeId::UserExecutable>(
-        client, id, userExecutable, std::forward<CompletionToken>(token)
+        connection, id, userExecutable, std::forward<CompletionToken>(token)
     );
 }
 

--- a/include/open62541pp/services/Method.h
+++ b/include/open62541pp/services/Method.h
@@ -56,7 +56,7 @@ auto callAsync(
  * Call a server method and return outputs.
  * The `objectId` must have a `HasComponent` reference to the method specified in `methodId`.
  *
- * @param serverOrClient Instance of type Server or Client
+ * @param connection Instance of type Server or Client
  * @param objectId NodeId of the object on which the method is invoked
  * @param methodId NodeId of the method to invoke
  * @param inputArguments Input argument values
@@ -67,7 +67,7 @@ auto callAsync(
  */
 template <typename T>
 std::vector<Variant> call(
-    T& serverOrClient,
+    T& connection,
     const NodeId& objectId,
     const NodeId& methodId,
     Span<const Variant> inputArguments

--- a/include/open62541pp/services/Method.h
+++ b/include/open62541pp/services/Method.h
@@ -33,10 +33,10 @@ namespace opcua::services {
 
 /**
  * Call server methods.
- * @param client Instance of type Client
+ * @param connection Instance of type Client
  * @param request Call request
  */
-CallResponse call(Client& client, const CallRequest& request);
+CallResponse call(Client& connection, const CallRequest& request);
 
 /**
  * Asynchronously call server methods.
@@ -45,10 +45,15 @@ CallResponse call(Client& client, const CallRequest& request);
  */
 template <typename CompletionToken = DefaultCompletionToken>
 auto callAsync(
-    Client& client, const CallRequest& request, CompletionToken&& token = DefaultCompletionToken()
+    Client& connection,
+    const CallRequest& request,
+    CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::sendRequest<UA_CallRequest, UA_CallResponse>(
-        client, request, detail::WrapResponse<CallResponse>{}, std::forward<CompletionToken>(token)
+        connection,
+        request,
+        detail::WrapResponse<CallResponse>{},
+        std::forward<CompletionToken>(token)
     );
 }
 
@@ -76,7 +81,7 @@ std::vector<Variant> call(
 /**
  * Asynchronously call a server method and return outputs.
  *
- * @param client Instance of type Client
+ * @param connection Instance of type Client
  * @param objectId NodeId of the object on which the method is invoked
  * @param methodId NodeId of the method to invoke
  * @param inputArguments Input argument values
@@ -85,7 +90,7 @@ std::vector<Variant> call(
  */
 template <typename CompletionToken = DefaultCompletionToken>
 auto callAsync(
-    Client& client,
+    Client& connection,
     const NodeId& objectId,
     const NodeId& methodId,
     Span<const Variant> inputArguments,
@@ -96,7 +101,7 @@ auto callAsync(
     request.methodsToCall = &item;
     request.methodsToCallSize = 1;
     return detail::sendRequest<UA_CallRequest, UA_CallResponse>(
-        client,
+        connection,
         request,
         [](UA_CallResponse& response) {
             return detail::getOutputArguments(detail::getSingleResult(response));

--- a/include/open62541pp/services/MonitoredItem.h
+++ b/include/open62541pp/services/MonitoredItem.h
@@ -218,7 +218,10 @@ void modifyMonitoredItem(
  * @param monitoringMode Monitoring mode
  */
 void setMonitoringMode(
-    Client& connection, uint32_t subscriptionId, uint32_t monitoredItemId, MonitoringMode monitoringMode
+    Client& connection,
+    uint32_t subscriptionId,
+    uint32_t monitoredItemId,
+    MonitoringMode monitoringMode
 );
 
 /**
@@ -271,7 +274,7 @@ void deleteMonitoredItem(T& connection, uint32_t subscriptionId, uint32_t monito
 /**
  * Delete a local monitored item.
  *
- * @param server Instance of type Server
+ * @param connection Instance of type Server
  * @param monitoredItemId Identifier of the monitored item
  */
 void deleteMonitoredItem(Server& connection, uint32_t monitoredItemId);

--- a/include/open62541pp/services/NodeManagement.h
+++ b/include/open62541pp/services/NodeManagement.h
@@ -67,7 +67,7 @@ auto addNodesAsync(
  */
 template <typename T>
 NodeId addNode(
-    T& serverOrClient,
+    T& connection,
     NodeClass nodeClass,
     const NodeId& parentId,
     const NodeId& id,
@@ -157,7 +157,7 @@ auto addReferencesAsync(
  */
 template <typename T>
 void addReference(
-    T& serverOrClient,
+    T& connection,
     const NodeId& sourceId,
     const NodeId& targetId,
     const NodeId& referenceType,
@@ -233,7 +233,7 @@ auto deleteNodesAsync(
  * Delete node.
  */
 template <typename T>
-void deleteNode(T& serverOrClient, const NodeId& id, bool deleteReferences = true);
+void deleteNode(T& connection, const NodeId& id, bool deleteReferences = true);
 
 /**
  * Asynchronously delete node.
@@ -300,7 +300,7 @@ auto deleteReferencesAsync(
  */
 template <typename T>
 void deleteReference(
-    T& serverOrClient,
+    T& connection,
     const NodeId& sourceId,
     const NodeId& targetId,
     const NodeId& referenceType,
@@ -358,7 +358,7 @@ auto deleteReferenceAsync(
  */
 template <typename T>
 inline NodeId addObject(
-    T& serverOrClient,
+    T& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
@@ -367,7 +367,7 @@ inline NodeId addObject(
     const NodeId& referenceType = ReferenceTypeId::HasComponent
 ) {
     return addNode(
-        serverOrClient,
+        connection,
         NodeClass::Object,
         parentId,
         id,
@@ -412,7 +412,7 @@ inline auto addObjectAsync(
  */
 template <typename T>
 inline NodeId addFolder(
-    T& serverOrClient,
+    T& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
@@ -420,13 +420,7 @@ inline NodeId addFolder(
     const NodeId& referenceType = ReferenceTypeId::HasComponent
 ) {
     return addObject(
-        serverOrClient,
-        parentId,
-        id,
-        browseName,
-        attributes,
-        ObjectTypeId::FolderType,
-        referenceType
+        connection, parentId, id, browseName, attributes, ObjectTypeId::FolderType, referenceType
     );
 }
 
@@ -462,7 +456,7 @@ inline auto addFolderAsync(
  */
 template <typename T>
 inline NodeId addVariable(
-    T& serverOrClient,
+    T& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
@@ -471,7 +465,7 @@ inline NodeId addVariable(
     const NodeId& referenceType = ReferenceTypeId::HasComponent
 ) {
     return addNode(
-        serverOrClient,
+        connection,
         NodeClass::Variable,
         parentId,
         id,
@@ -516,14 +510,14 @@ inline auto addVariableAsync(
  */
 template <typename T>
 inline NodeId addProperty(
-    T& serverOrClient,
+    T& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
     const VariableAttributes& attributes = {}
 ) {
     return addVariable(
-        serverOrClient,
+        connection,
         parentId,
         id,
         browseName,
@@ -573,7 +567,7 @@ using MethodCallback = std::function<void(Span<const Variant> input, Span<Varian
  */
 template <typename T>
 NodeId addMethod(
-    T& serverOrClient,
+    T& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
@@ -621,7 +615,7 @@ inline auto addMethodAsync(
  */
 template <typename T>
 inline NodeId addObjectType(
-    T& serverOrClient,
+    T& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
@@ -629,7 +623,7 @@ inline NodeId addObjectType(
     const NodeId& referenceType = ReferenceTypeId::HasSubtype
 ) {
     return addNode(
-        serverOrClient,
+        connection,
         NodeClass::ObjectType,
         parentId,
         id,
@@ -673,7 +667,7 @@ inline auto addObjectTypeAsync(
  */
 template <typename T>
 inline NodeId addVariableType(
-    T& serverOrClient,
+    T& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
@@ -682,7 +676,7 @@ inline NodeId addVariableType(
     const NodeId& referenceType = ReferenceTypeId::HasSubtype
 ) {
     return addNode(
-        serverOrClient,
+        connection,
         NodeClass::VariableType,
         parentId,
         id,
@@ -727,7 +721,7 @@ inline auto addVariableTypeAsync(
  */
 template <typename T>
 inline NodeId addReferenceType(
-    T& serverOrClient,
+    T& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
@@ -735,7 +729,7 @@ inline NodeId addReferenceType(
     const NodeId& referenceType = ReferenceTypeId::HasSubtype
 ) {
     return addNode(
-        serverOrClient,
+        connection,
         NodeClass::ReferenceType,
         parentId,
         id,
@@ -779,7 +773,7 @@ inline auto addReferenceTypeAsync(
  */
 template <typename T>
 inline NodeId addDataType(
-    T& serverOrClient,
+    T& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
@@ -787,7 +781,7 @@ inline NodeId addDataType(
     const NodeId& referenceType = ReferenceTypeId::HasSubtype
 ) {
     return addNode(
-        serverOrClient,
+        connection,
         NodeClass::DataType,
         parentId,
         id,
@@ -831,7 +825,7 @@ inline auto addDataTypeAsync(
  */
 template <typename T>
 inline NodeId addView(
-    T& serverOrClient,
+    T& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
@@ -839,7 +833,7 @@ inline NodeId addView(
     const NodeId& referenceType = ReferenceTypeId::Organizes
 ) {
     return addNode(
-        serverOrClient,
+        connection,
         NodeClass::View,
         parentId,
         id,
@@ -889,13 +883,9 @@ inline auto addViewAsync(
  * @see https://reference.opcfoundation.org/Core/Part3/v105/docs/6.4.4
  */
 template <typename T>
-inline void addModellingRule(T& serverOrClient, const NodeId& id, ModellingRule rule) {
+inline void addModellingRule(T& connection, const NodeId& id, ModellingRule rule) {
     return addReference(
-        serverOrClient,
-        id,
-        {0, static_cast<uint32_t>(rule)},
-        ReferenceTypeId::HasModellingRule,
-        true
+        connection, id, {0, static_cast<uint32_t>(rule)}, ReferenceTypeId::HasModellingRule, true
     );
 }
 

--- a/include/open62541pp/services/NodeManagement.h
+++ b/include/open62541pp/services/NodeManagement.h
@@ -38,10 +38,10 @@ namespace opcua::services {
 
 /**
  * Add one or more nodes (client only).
- * @param client Instance of type Client
+ * @param connection Instance of type Client
  * @param request Add nodes request
  */
-AddNodesResponse addNodes(Client& client, const AddNodesRequest& request);
+AddNodesResponse addNodes(Client& connection, const AddNodesRequest& request);
 
 /**
  * Asynchronously add one or more nodes (client only).
@@ -50,12 +50,12 @@ AddNodesResponse addNodes(Client& client, const AddNodesRequest& request);
  */
 template <typename CompletionToken = DefaultCompletionToken>
 auto addNodesAsync(
-    Client& client,
+    Client& connection,
     const AddNodesRequest& request,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::sendRequest<UA_AddNodesRequest, UA_AddNodesResponse>(
-        client,
+        connection,
         request,
         detail::WrapResponse<AddNodesResponse>{},
         std::forward<CompletionToken>(token)
@@ -84,7 +84,7 @@ NodeId addNode(
  */
 template <typename CompletionToken = DefaultCompletionToken>
 auto addNodeAsync(
-    Client& client,
+    Client& connection,
     NodeClass nodeClass,
     const NodeId& parentId,
     const NodeId& id,
@@ -107,7 +107,7 @@ auto addNodeAsync(
     request.nodesToAddSize = 1;
     request.nodesToAdd = &item;
     return detail::sendRequest<UA_AddNodesRequest, UA_AddNodesResponse>(
-        client,
+        connection,
         request,
         [](UA_AddNodesResponse& response) {
             auto& result = detail::getSingleResult(response);
@@ -128,10 +128,10 @@ auto addNodeAsync(
 
 /**
  * Add one or more references (client only).
- * @param client Instance of type Client
+ * @param connection Instance of type Client
  * @param request Add references request
  */
-AddReferencesResponse addReferences(Client& client, const AddReferencesRequest& request);
+AddReferencesResponse addReferences(Client& connection, const AddReferencesRequest& request);
 
 /**
  * Asynchronously add one or more references (client only).
@@ -140,12 +140,12 @@ AddReferencesResponse addReferences(Client& client, const AddReferencesRequest& 
  */
 template <typename CompletionToken = DefaultCompletionToken>
 auto addReferencesAsync(
-    Client& client,
+    Client& connection,
     const AddReferencesRequest& request,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::sendRequest<UA_AddReferencesRequest, UA_AddReferencesResponse>(
-        client,
+        connection,
         request,
         detail::WrapResponse<AddReferencesResponse>{},
         std::forward<CompletionToken>(token)
@@ -171,7 +171,7 @@ void addReference(
  */
 template <typename CompletionToken = DefaultCompletionToken>
 auto addReferenceAsync(
-    Client& client,
+    Client& connection,
     const NodeId& sourceId,
     const NodeId& targetId,
     const NodeId& referenceType,
@@ -188,7 +188,7 @@ auto addReferenceAsync(
     request.referencesToAddSize = 1;
     request.referencesToAdd = &item;
     return detail::sendRequest<UA_AddReferencesRequest, UA_AddReferencesResponse>(
-        client,
+        connection,
         request,
         [](UA_AddReferencesResponse& response) { throwIfBad(detail::getSingleResult(response)); },
         std::forward<CompletionToken>(token)
@@ -205,10 +205,10 @@ auto addReferenceAsync(
 
 /**
  * Delete one or more nodes (client only).
- * @param client Instance of type Client
+ * @param connection Instance of type Client
  * @param request Delete nodes request
  */
-DeleteNodesResponse deleteNodes(Client& client, const DeleteNodesRequest& request);
+DeleteNodesResponse deleteNodes(Client& connection, const DeleteNodesRequest& request);
 
 /**
  * Asynchronously delete one or more nodes (client only).
@@ -217,12 +217,12 @@ DeleteNodesResponse deleteNodes(Client& client, const DeleteNodesRequest& reques
  */
 template <typename CompletionToken = DefaultCompletionToken>
 auto deleteNodesAsync(
-    Client& client,
+    Client& connection,
     const DeleteNodesRequest& request,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::sendRequest<UA_DeleteNodesRequest, UA_DeleteNodesResponse>(
-        client,
+        connection,
         request,
         detail::WrapResponse<DeleteNodesResponse>{},
         std::forward<CompletionToken>(token)
@@ -242,7 +242,7 @@ void deleteNode(T& connection, const NodeId& id, bool deleteReferences = true);
  */
 template <typename CompletionToken = DefaultCompletionToken>
 auto deleteNodeAsync(
-    Client& client,
+    Client& connection,
     const NodeId& id,
     bool deleteReferences = true,
     CompletionToken&& token = DefaultCompletionToken()
@@ -254,7 +254,7 @@ auto deleteNodeAsync(
     request.nodesToDeleteSize = 1;
     request.nodesToDelete = &item;
     return detail::sendRequest<UA_DeleteNodesRequest, UA_DeleteNodesResponse>(
-        client,
+        connection,
         request,
         [](UA_DeleteNodesResponse& response) { throwIfBad(detail::getSingleResult(response)); },
         std::forward<CompletionToken>(token)
@@ -271,10 +271,12 @@ auto deleteNodeAsync(
 
 /**
  * Delete one or more references (client only).
- * @param client Instance of type Client
+ * @param connection Instance of type Client
  * @param request Delete references request
  */
-DeleteReferencesResponse deleteReferences(Client& client, const DeleteReferencesRequest& request);
+DeleteReferencesResponse deleteReferences(
+    Client& connection, const DeleteReferencesRequest& request
+);
 
 /**
  * Asynchronously delete one or more references (client only).
@@ -283,12 +285,12 @@ DeleteReferencesResponse deleteReferences(Client& client, const DeleteReferences
  */
 template <typename CompletionToken = DefaultCompletionToken>
 auto deleteReferencesAsync(
-    Client& client,
+    Client& connection,
     const DeleteReferencesRequest& request,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::sendRequest<UA_DeleteReferencesRequest, UA_DeleteReferencesResponse>(
-        client,
+        connection,
         request,
         detail::WrapResponse<DeleteReferencesResponse>{},
         std::forward<CompletionToken>(token)
@@ -315,7 +317,7 @@ void deleteReference(
  */
 template <typename CompletionToken = DefaultCompletionToken>
 auto deleteReferenceAsync(
-    Client& client,
+    Client& connection,
     const NodeId& sourceId,
     const NodeId& targetId,
     const NodeId& referenceType,
@@ -333,7 +335,7 @@ auto deleteReferenceAsync(
     request.referencesToDeleteSize = 1;
     request.referencesToDelete = &item;
     return detail::sendRequest<UA_DeleteReferencesRequest, UA_DeleteReferencesResponse>(
-        client,
+        connection,
         request,
         [](UA_DeleteReferencesResponse& response) {
             throwIfBad(detail::getSingleResult(response));
@@ -385,7 +387,7 @@ inline NodeId addObject(
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto addObjectAsync(
-    Client& client,
+    Client& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
@@ -395,7 +397,7 @@ inline auto addObjectAsync(
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     return addNodeAsync(
-        client,
+        connection,
         NodeClass::Object,
         parentId,
         id,
@@ -431,7 +433,7 @@ inline NodeId addFolder(
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto addFolderAsync(
-    Client& client,
+    Client& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
@@ -440,7 +442,7 @@ inline auto addFolderAsync(
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     return addObjectAsync(
-        client,
+        connection,
         parentId,
         id,
         browseName,
@@ -483,7 +485,7 @@ inline NodeId addVariable(
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto addVariableAsync(
-    Client& client,
+    Client& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
@@ -493,7 +495,7 @@ inline auto addVariableAsync(
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     return addNodeAsync(
-        client,
+        connection,
         NodeClass::Variable,
         parentId,
         id,
@@ -534,7 +536,7 @@ inline NodeId addProperty(
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto addPropertyAsync(
-    Client& client,
+    Client& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
@@ -542,7 +544,7 @@ inline auto addPropertyAsync(
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     return addVariableAsync(
-        client,
+        connection,
         parentId,
         id,
         browseName,
@@ -585,7 +587,7 @@ NodeId addMethod(
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto addMethodAsync(
-    Client& client,
+    Client& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
@@ -597,7 +599,7 @@ inline auto addMethodAsync(
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     return addNodeAsync(
-        client,
+        connection,
         NodeClass::Method,
         parentId,
         id,
@@ -641,7 +643,7 @@ inline NodeId addObjectType(
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto addObjectTypeAsync(
-    Client& client,
+    Client& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
@@ -650,7 +652,7 @@ inline auto addObjectTypeAsync(
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     return addNodeAsync(
-        client,
+        connection,
         NodeClass::ObjectType,
         parentId,
         id,
@@ -694,7 +696,7 @@ inline NodeId addVariableType(
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto addVariableTypeAsync(
-    Client& client,
+    Client& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
@@ -704,7 +706,7 @@ inline auto addVariableTypeAsync(
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     return addNodeAsync(
-        client,
+        connection,
         NodeClass::VariableType,
         parentId,
         id,
@@ -747,7 +749,7 @@ inline NodeId addReferenceType(
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto addReferenceTypeAsync(
-    Client& client,
+    Client& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
@@ -756,7 +758,7 @@ inline auto addReferenceTypeAsync(
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     return addNodeAsync(
-        client,
+        connection,
         NodeClass::ReferenceType,
         parentId,
         id,
@@ -799,7 +801,7 @@ inline NodeId addDataType(
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto addDataTypeAsync(
-    Client& client,
+    Client& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
@@ -808,7 +810,7 @@ inline auto addDataTypeAsync(
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     return addNodeAsync(
-        client,
+        connection,
         NodeClass::DataType,
         parentId,
         id,
@@ -851,7 +853,7 @@ inline NodeId addView(
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto addViewAsync(
-    Client& client,
+    Client& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
@@ -860,7 +862,7 @@ inline auto addViewAsync(
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     return addNodeAsync(
-        client,
+        connection,
         NodeClass::View,
         parentId,
         id,
@@ -896,13 +898,13 @@ inline void addModellingRule(T& connection, const NodeId& id, ModellingRule rule
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto addModellingRuleAsync(
-    Client& client,
+    Client& connection,
     const NodeId& id,
     ModellingRule rule,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     return addReferenceAsync(
-        client,
+        connection,
         id,
         {0, static_cast<uint32_t>(rule)},
         ReferenceTypeId::HasModellingRule,

--- a/include/open62541pp/services/Subscription.h
+++ b/include/open62541pp/services/Subscription.h
@@ -64,14 +64,14 @@ using DeleteSubscriptionCallback = std::function<void(uint32_t subId)>;
 /**
  * Create a subscription.
  * @copydetails SubscriptionParameters
- * @param client Instance of type Client
+ * @param connection Instance of type Client
  * @param parameters Subscription parameters, may be revised by server
  * @param publishingEnabled Enable/disable publishing of the subscription
  * @param deleteCallback Invoked when the subscription is deleted
  * @returns Server-assigned identifier of the subscription
  */
 [[nodiscard]] uint32_t createSubscription(
-    Client& client,
+    Client& connection,
     SubscriptionParameters& parameters,
     bool publishingEnabled = true,
     DeleteSubscriptionCallback deleteCallback = {}
@@ -88,12 +88,12 @@ using DeleteSubscriptionCallback = std::function<void(uint32_t subId)>;
 /**
  * Modify a subscription.
  * @copydetails SubscriptionParameters
- * @param client Instance of type Client
+ * @param connection Instance of type Client
  * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
  * @param parameters Subscription parameters, may be revised by server
  */
 void modifySubscription(
-    Client& client, uint32_t subscriptionId, SubscriptionParameters& parameters
+    Client& connection, uint32_t subscriptionId, SubscriptionParameters& parameters
 );
 
 /**
@@ -108,11 +108,11 @@ void modifySubscription(
 
 /**
  * Enable/disable publishing of notification messages.
- * @param client Instance of type Client
+ * @param connection Instance of type Client
  * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
  * @param publishing Enable/disable publishing
  */
-void setPublishingMode(Client& client, uint32_t subscriptionId, bool publishing);
+void setPublishingMode(Client& connection, uint32_t subscriptionId, bool publishing);
 
 /**
  * @}
@@ -124,10 +124,10 @@ void setPublishingMode(Client& client, uint32_t subscriptionId, bool publishing)
 
 /**
  * Delete a subscription.
- * @param client Instance of type Client
+ * @param connection Instance of type Client
  * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
  */
-void deleteSubscription(Client& client, uint32_t subscriptionId);
+void deleteSubscription(Client& connection, uint32_t subscriptionId);
 
 /**
  * @}

--- a/src/Event.cpp
+++ b/src/Event.cpp
@@ -12,9 +12,9 @@ namespace opcua {
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS
 
-Event::Event(Server& server, const NodeId& eventType)
-    : connection_(server) {
-    throwIfBad(UA_Server_createEvent(server.handle(), eventType, id_.handle()));
+Event::Event(Server& connection, const NodeId& eventType)
+    : connection_(connection) {
+    throwIfBad(UA_Server_createEvent(connection.handle(), eventType, id_.handle()));
 }
 
 Event::~Event() {

--- a/src/services/Attribute.cpp
+++ b/src/services/Attribute.cpp
@@ -5,17 +5,17 @@
 
 namespace opcua::services {
 
-ReadResponse read(Client& client, const ReadRequest& request) {
-    return readAsync(client, request, detail::SyncOperation{});
+ReadResponse read(Client& connection, const ReadRequest& request) {
+    return readAsync(connection, request, detail::SyncOperation{});
 }
 
 template <>
 DataValue readAttribute<Server>(
-    Server& server, const NodeId& id, AttributeId attributeId, TimestampsToReturn timestamps
+    Server& connection, const NodeId& id, AttributeId attributeId, TimestampsToReturn timestamps
 ) {
     const auto item = detail::createReadValueId(id, attributeId);
     auto result = UA_Server_read(
-        server.handle(), &item, static_cast<UA_TimestampsToReturn>(timestamps)
+        connection.handle(), &item, static_cast<UA_TimestampsToReturn>(timestamps)
     );
     detail::checkReadResult(result);
     return result;
@@ -23,29 +23,29 @@ DataValue readAttribute<Server>(
 
 template <>
 DataValue readAttribute<Client>(
-    Client& client, const NodeId& id, AttributeId attributeId, TimestampsToReturn timestamps
+    Client& connection, const NodeId& id, AttributeId attributeId, TimestampsToReturn timestamps
 ) {
-    return readAttributeAsync(client, id, attributeId, timestamps, detail::SyncOperation{});
+    return readAttributeAsync(connection, id, attributeId, timestamps, detail::SyncOperation{});
 }
 
-WriteResponse write(Client& client, const WriteRequest& request) {
-    return writeAsync(client, request, detail::SyncOperation{});
+WriteResponse write(Client& connection, const WriteRequest& request) {
+    return writeAsync(connection, request, detail::SyncOperation{});
 }
 
 template <>
 void writeAttribute<Server>(
-    Server& server, const NodeId& id, AttributeId attributeId, const DataValue& value
+    Server& connection, const NodeId& id, AttributeId attributeId, const DataValue& value
 ) {
     const auto item = detail::createWriteValue(id, attributeId, value);
-    const auto status = UA_Server_write(server.handle(), &item);
+    const auto status = UA_Server_write(connection.handle(), &item);
     throwIfBad(status);
 }
 
 template <>
 void writeAttribute<Client>(
-    Client& client, const NodeId& id, AttributeId attributeId, const DataValue& value
+    Client& connection, const NodeId& id, AttributeId attributeId, const DataValue& value
 ) {
-    writeAttributeAsync(client, id, attributeId, value, detail::SyncOperation{});
+    writeAttributeAsync(connection, id, attributeId, value, detail::SyncOperation{});
 }
 
 }  // namespace opcua::services

--- a/src/services/Method.cpp
+++ b/src/services/Method.cpp
@@ -8,30 +8,30 @@
 
 namespace opcua::services {
 
-CallResponse call(Client& client, const CallRequest& request) {
-    return callAsync(client, request, detail::SyncOperation{});
+CallResponse call(Client& connection, const CallRequest& request) {
+    return callAsync(connection, request, detail::SyncOperation{});
 }
 
 template <>
 std::vector<Variant> call(
-    Server& server,
+    Server& connection,
     const NodeId& objectId,
     const NodeId& methodId,
     Span<const Variant> inputArguments
 ) {
     UA_CallMethodRequest item = detail::createCallMethodRequest(objectId, methodId, inputArguments);
-    CallMethodResult result = UA_Server_call(server.handle(), &item);
+    CallMethodResult result = UA_Server_call(connection.handle(), &item);
     return detail::getOutputArguments(result);
 }
 
 template <>
 std::vector<Variant> call(
-    Client& client,
+    Client& connection,
     const NodeId& objectId,
     const NodeId& methodId,
     Span<const Variant> inputArguments
 ) {
-    return callAsync(client, objectId, methodId, inputArguments, detail::SyncOperation{});
+    return callAsync(connection, objectId, methodId, inputArguments, detail::SyncOperation{});
 }
 
 }  // namespace opcua::services

--- a/src/services/Subscription.cpp
+++ b/src/services/Subscription.cpp
@@ -19,19 +19,19 @@
 namespace opcua::services {
 
 uint32_t createSubscription(
-    Client& client,
+    Client& connection,
     SubscriptionParameters& parameters,
     bool publishingEnabled,
     DeleteSubscriptionCallback deleteCallback
 ) {
     auto context = std::make_unique<detail::SubscriptionContext>();
-    context->catcher = &opcua::detail::getContext(client).exceptionCatcher;
+    context->catcher = &opcua::detail::getContext(connection).exceptionCatcher;
     context->deleteCallback = std::move(deleteCallback);
 
     using Response =
         TypeWrapper<UA_CreateSubscriptionResponse, UA_TYPES_CREATESUBSCRIPTIONRESPONSE>;
     const Response response = UA_Client_Subscriptions_create(
-        client.handle(),
+        connection.handle(),
         detail::createCreateSubscriptionRequest(parameters, publishingEnabled),
         context.get(),
         nullptr,  // statusChangeCallback
@@ -41,25 +41,25 @@ uint32_t createSubscription(
     detail::reviseSubscriptionParameters(parameters, asNative(response));
 
     const auto subscriptionId = response->subscriptionId;
-    opcua::detail::getContext(client).subscriptions.insert(subscriptionId, std::move(context));
+    opcua::detail::getContext(connection).subscriptions.insert(subscriptionId, std::move(context));
     return subscriptionId;
 }
 
 void modifySubscription(
-    Client& client, uint32_t subscriptionId, SubscriptionParameters& parameters
+    Client& connection, uint32_t subscriptionId, SubscriptionParameters& parameters
 ) {
     using Response =
         TypeWrapper<UA_ModifySubscriptionResponse, UA_TYPES_MODIFYSUBSCRIPTIONRESPONSE>;
     const Response response = UA_Client_Subscriptions_modify(
-        client.handle(), detail::createModifySubscriptionRequest(subscriptionId, parameters)
+        connection.handle(), detail::createModifySubscriptionRequest(subscriptionId, parameters)
     );
     throwIfBad(response->responseHeader.serviceResult);
     detail::reviseSubscriptionParameters(parameters, asNative(response));
 }
 
-void setPublishingMode(Client& client, uint32_t subscriptionId, bool publishing) {
+void setPublishingMode(Client& connection, uint32_t subscriptionId, bool publishing) {
     detail::sendRequest<UA_SetPublishingModeRequest, UA_SetPublishingModeResponse>(
-        client,
+        connection,
         detail::createSetPublishingModeRequest({&subscriptionId, 1}, publishing),
         [](UA_SetPublishingModeResponse& response) {
             throwIfBad(detail::getSingleResult(response));
@@ -68,8 +68,8 @@ void setPublishingMode(Client& client, uint32_t subscriptionId, bool publishing)
     );
 }
 
-void deleteSubscription(Client& client, uint32_t subscriptionId) {
-    const auto status = UA_Client_Subscriptions_deleteSingle(client.handle(), subscriptionId);
+void deleteSubscription(Client& connection, uint32_t subscriptionId) {
+    const auto status = UA_Client_Subscriptions_deleteSingle(connection.handle(), subscriptionId);
     throwIfBad(status);
 }
 

--- a/tests/Logger.cpp
+++ b/tests/Logger.cpp
@@ -9,14 +9,14 @@
 using namespace opcua;
 
 TEST_CASE_TEMPLATE("Log with custom logger", T, Server, Client) {
-    T serverOrClient;
+    T connection;
 
     static size_t counter = 0;
     static LogLevel lastLogLevel{};
     static LogCategory lastLogCategory{};
     static std::string lastMessage{};
 
-    serverOrClient.setLogger([&](LogLevel level, LogCategory category, std::string_view message) {
+    connection.setLogger([&](LogLevel level, LogCategory category, std::string_view message) {
         counter++;
         lastLogLevel = level;
         lastLogCategory = category;
@@ -24,11 +24,11 @@ TEST_CASE_TEMPLATE("Log with custom logger", T, Server, Client) {
     });
 
     // passing a nullptr should do nothing
-    serverOrClient.setLogger(nullptr);
+    connection.setLogger(nullptr);
 
     SUBCASE("Wrapper") {
         counter = 0;
-        log(serverOrClient, LogLevel::Info, LogCategory::Server, "Message");
+        log(connection, LogLevel::Info, LogCategory::Server, "Message");
         CHECK(counter == 1);
         CHECK(lastLogLevel == LogLevel::Info);
         CHECK(lastLogCategory == LogCategory::Server);
@@ -36,7 +36,7 @@ TEST_CASE_TEMPLATE("Log with custom logger", T, Server, Client) {
     }
 
     SUBCASE("Native") {
-        auto native = serverOrClient.handle();
+        auto native = connection.handle();
         counter = 0;
         log(native, LogLevel::Warning, LogCategory::Server, "Message from native");
         CHECK(counter == 1);
@@ -46,7 +46,7 @@ TEST_CASE_TEMPLATE("Log with custom logger", T, Server, Client) {
     }
 
     SUBCASE("Native nullptr") {
-        auto native = serverOrClient.handle();
+        auto native = connection.handle();
         native = nullptr;
         counter = 0;
         log(native, LogLevel::Warning, LogCategory::Server, "Message from null");

--- a/tests/Node.cpp
+++ b/tests/Node.cpp
@@ -10,40 +10,40 @@
 
 using namespace opcua;
 
-TEST_CASE_TEMPLATE("Node", ServerOrClient, Server, Client) {
+TEST_CASE_TEMPLATE("Node", T, Server, Client) {
     ServerClientSetup setup;
     setup.client.connect(setup.endpointUrl);
-    auto& serverOrClient = setup.getInstance<ServerOrClient>();
+    auto& connection = setup.getInstance<T>();
 
     const NodeId varId{1, 1};
     services::addVariable(setup.server, {0, UA_NS0ID_OBJECTSFOLDER}, varId, "variable");
     services::writeAccessLevel(setup.server, varId, 0xFF);
     services::writeWriteMask(setup.server, varId, 0xFFFFFFFF);  // set all bits to 1 -> allow all
 
-    auto rootNode = serverOrClient.getRootNode();
-    auto objNode = serverOrClient.getObjectsNode();
-    auto varNode = serverOrClient.getNode(varId);
-    auto refNode = serverOrClient.getNode(ReferenceTypeId::References);
+    auto rootNode = connection.getRootNode();
+    auto objNode = connection.getObjectsNode();
+    auto varNode = connection.getNode(varId);
+    auto refNode = connection.getNode(ReferenceTypeId::References);
 
     SUBCASE("connection") {
-        CHECK(rootNode.connection() == serverOrClient);
+        CHECK(rootNode.connection() == connection);
     }
 
     SUBCASE("id") {
         const NodeId id(0, UA_NS0ID_OBJECTSFOLDER);
-        CHECK(Node(serverOrClient, id).id() == id);
+        CHECK(Node(connection, id).id() == id);
     }
 
     SUBCASE("exists") {
-        CHECK(Node(serverOrClient, NodeId(0, UA_NS0ID_OBJECTSFOLDER)).exists());
-        CHECK_FALSE(Node(serverOrClient, NodeId(0, "DoesNotExist")).exists());
+        CHECK(Node(connection, NodeId(0, UA_NS0ID_OBJECTSFOLDER)).exists());
+        CHECK_FALSE(Node(connection, NodeId(0, "DoesNotExist")).exists());
     }
 
     SUBCASE("Node class of default nodes") {
-        CHECK(serverOrClient.getRootNode().readNodeClass() == NodeClass::Object);
-        CHECK(serverOrClient.getObjectsNode().readNodeClass() == NodeClass::Object);
-        CHECK(serverOrClient.getTypesNode().readNodeClass() == NodeClass::Object);
-        CHECK(serverOrClient.getViewsNode().readNodeClass() == NodeClass::Object);
+        CHECK(connection.getRootNode().readNodeClass() == NodeClass::Object);
+        CHECK(connection.getObjectsNode().readNodeClass() == NodeClass::Object);
+        CHECK(connection.getTypesNode().readNodeClass() == NodeClass::Object);
+        CHECK(connection.getViewsNode().readNodeClass() == NodeClass::Object);
     }
 
     SUBCASE("Add non-type nodes") {
@@ -60,12 +60,12 @@ TEST_CASE_TEMPLATE("Node", ServerOrClient, Server, Client) {
 
     SUBCASE("Add type nodes") {
         CHECK(
-            serverOrClient.getNode(ObjectTypeId::BaseObjectType)
+            connection.getNode(ObjectTypeId::BaseObjectType)
                 .addObjectType({1, 1000}, "objecttype")
                 .readNodeClass() == NodeClass::ObjectType
         );
         CHECK(
-            serverOrClient.getNode(VariableTypeId::BaseVariableType)
+            connection.getNode(VariableTypeId::BaseVariableType)
                 .addVariableType({1, 1001}, "variabletype")
                 .readNodeClass() == NodeClass::VariableType
         );

--- a/tests/Services.cpp
+++ b/tests/Services.cpp
@@ -23,7 +23,7 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
     ServerClientSetup setup;
     setup.client.connect(setup.endpointUrl);
     auto& server = setup.server;
-    auto& serverOrClient = setup.getInstance<T>();
+    auto& connection = setup.getInstance<T>();
 
     const NodeId objectsId{0, UA_NS0ID_OBJECTSFOLDER};
     const NodeId newId{1, 1000};
@@ -31,11 +31,11 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
     SUBCASE("addObject") {
         NodeId id;
         if constexpr (isAsync<T>) {
-            auto future = services::addObjectAsync(serverOrClient, objectsId, newId, "object");
+            auto future = services::addObjectAsync(connection, objectsId, newId, "object");
             setup.client.runIterate();
             id = future.get().value();
         } else {
-            id = services::addObject(serverOrClient, objectsId, newId, "object");
+            id = services::addObject(connection, objectsId, newId, "object");
         }
         CHECK_EQ(id, newId);
         CHECK_EQ(services::readNodeClass(server, newId), NodeClass::Object);
@@ -44,11 +44,11 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
     SUBCASE("addFolder") {
         NodeId id;
         if constexpr (isAsync<T>) {
-            auto future = services::addFolderAsync(serverOrClient, objectsId, newId, "folder");
+            auto future = services::addFolderAsync(connection, objectsId, newId, "folder");
             setup.client.runIterate();
             id = future.get().value();
         } else {
-            id = services::addFolder(serverOrClient, objectsId, newId, "folder");
+            id = services::addFolder(connection, objectsId, newId, "folder");
         }
         CHECK_EQ(id, newId);
         CHECK_EQ(services::readNodeClass(server, newId), NodeClass::Object);
@@ -57,11 +57,11 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
     SUBCASE("addVariable") {
         NodeId id;
         if constexpr (isAsync<T>) {
-            auto future = services::addVariableAsync(serverOrClient, objectsId, newId, "variable");
+            auto future = services::addVariableAsync(connection, objectsId, newId, "variable");
             setup.client.runIterate();
             id = future.get().value();
         } else {
-            id = services::addVariable(serverOrClient, objectsId, newId, "variable");
+            id = services::addVariable(connection, objectsId, newId, "variable");
         }
         CHECK_EQ(id, newId);
         CHECK_EQ(services::readNodeClass(server, newId), NodeClass::Variable);
@@ -70,11 +70,11 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
     SUBCASE("addProperty") {
         NodeId id;
         if constexpr (isAsync<T>) {
-            auto future = services::addPropertyAsync(serverOrClient, objectsId, newId, "property");
+            auto future = services::addPropertyAsync(connection, objectsId, newId, "property");
             setup.client.runIterate();
             id = future.get().value();
         } else {
-            id = services::addProperty(serverOrClient, objectsId, newId, "property");
+            id = services::addProperty(connection, objectsId, newId, "property");
         }
         CHECK_EQ(id, newId);
         CHECK_EQ(services::readNodeClass(server, newId), NodeClass::Variable);
@@ -85,12 +85,12 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
         NodeId id;
         if constexpr (isAsync<T>) {
             auto future = services::addMethodAsync(
-                serverOrClient, objectsId, newId, "method", {}, {}, {}
+                connection, objectsId, newId, "method", {}, {}, {}
             );
             setup.client.runIterate();
             id = future.get().value();
         } else {
-            id = services::addMethod(serverOrClient, objectsId, newId, "method", {}, {}, {});
+            id = services::addMethod(connection, objectsId, newId, "method", {}, {}, {});
         }
         CHECK_EQ(id, newId);
         CHECK_EQ(services::readNodeClass(server, newId), NodeClass::Method);
@@ -101,13 +101,13 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
         NodeId id;
         if constexpr (isAsync<T>) {
             auto future = services::addObjectTypeAsync(
-                serverOrClient, {0, UA_NS0ID_BASEOBJECTTYPE}, newId, "objecttype"
+                connection, {0, UA_NS0ID_BASEOBJECTTYPE}, newId, "objecttype"
             );
             setup.client.runIterate();
             id = future.get().value();
         } else {
             id = services::addObjectType(
-                serverOrClient, {0, UA_NS0ID_BASEOBJECTTYPE}, newId, "objecttype"
+                connection, {0, UA_NS0ID_BASEOBJECTTYPE}, newId, "objecttype"
             );
         }
         CHECK_EQ(id, newId);
@@ -118,13 +118,13 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
         NodeId id;
         if constexpr (isAsync<T>) {
             auto future = services::addVariableTypeAsync(
-                serverOrClient, {0, UA_NS0ID_BASEVARIABLETYPE}, newId, "variabletype"
+                connection, {0, UA_NS0ID_BASEVARIABLETYPE}, newId, "variabletype"
             );
             setup.client.runIterate();
             id = future.get().value();
         } else {
             id = services::addVariableType(
-                serverOrClient, {0, UA_NS0ID_BASEVARIABLETYPE}, newId, "variabletype"
+                connection, {0, UA_NS0ID_BASEVARIABLETYPE}, newId, "variabletype"
             );
         }
         CHECK_EQ(id, newId);
@@ -135,13 +135,13 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
         NodeId id;
         if constexpr (isAsync<T>) {
             auto future = services::addReferenceTypeAsync(
-                serverOrClient, {0, UA_NS0ID_ORGANIZES}, newId, "referencetype"
+                connection, {0, UA_NS0ID_ORGANIZES}, newId, "referencetype"
             );
             setup.client.runIterate();
             id = future.get().value();
         } else {
             id = services::addReferenceType(
-                serverOrClient, {0, UA_NS0ID_ORGANIZES}, newId, "referencetype"
+                connection, {0, UA_NS0ID_ORGANIZES}, newId, "referencetype"
             );
         }
         CHECK_EQ(id, newId);
@@ -152,12 +152,12 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
         NodeId id;
         if constexpr (isAsync<T>) {
             auto future = services::addDataTypeAsync(
-                serverOrClient, {0, UA_NS0ID_STRUCTURE}, newId, "datatype"
+                connection, {0, UA_NS0ID_STRUCTURE}, newId, "datatype"
             );
             setup.client.runIterate();
             id = future.get().value();
         } else {
-            id = services::addDataType(serverOrClient, {0, UA_NS0ID_STRUCTURE}, newId, "datatype");
+            id = services::addDataType(connection, {0, UA_NS0ID_STRUCTURE}, newId, "datatype");
         }
         CHECK_EQ(id, newId);
         CHECK_EQ(services::readNodeClass(server, newId), NodeClass::DataType);
@@ -167,31 +167,31 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
         NodeId id;
         if constexpr (isAsync<T>) {
             auto future = services::addViewAsync(
-                serverOrClient, {0, UA_NS0ID_VIEWSFOLDER}, newId, "view"
+                connection, {0, UA_NS0ID_VIEWSFOLDER}, newId, "view"
             );
             setup.client.runIterate();
             id = future.get().value();
         } else {
-            id = services::addView(serverOrClient, {0, UA_NS0ID_VIEWSFOLDER}, newId, "view");
+            id = services::addView(connection, {0, UA_NS0ID_VIEWSFOLDER}, newId, "view");
         }
         CHECK_EQ(id, newId);
         CHECK_EQ(services::readNodeClass(server, newId), NodeClass::View);
     }
 
     SUBCASE("Add/delete reference") {
-        services::addFolder(serverOrClient, objectsId, {1, 1000}, "folder");
-        services::addObject(serverOrClient, objectsId, {1, 1001}, "object");
+        services::addFolder(connection, objectsId, {1, 1000}, "folder");
+        services::addObject(connection, objectsId, {1, 1001}, "object");
 
         auto addReference = [&] {
             if constexpr (isAsync<T>) {
                 auto future = services::addReferenceAsync(
-                    serverOrClient, {1, 1000}, {1, 1001}, ReferenceTypeId::Organizes
+                    connection, {1, 1000}, {1, 1001}, ReferenceTypeId::Organizes
                 );
                 setup.client.runIterate();
                 future.get().code().throwIfBad();
             } else {
                 services::addReference(
-                    serverOrClient, {1, 1000}, {1, 1001}, ReferenceTypeId::Organizes
+                    connection, {1, 1000}, {1, 1001}, ReferenceTypeId::Organizes
                 );
             }
         };
@@ -201,13 +201,13 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
         auto deleteReference = [&] {
             if constexpr (isAsync<T>) {
                 auto future = services::deleteReferenceAsync(
-                    serverOrClient, {1, 1000}, {1, 1001}, ReferenceTypeId::Organizes, true, true
+                    connection, {1, 1000}, {1, 1001}, ReferenceTypeId::Organizes, true, true
                 );
                 setup.client.runIterate();
                 future.get().code().throwIfBad();
             } else {
                 services::deleteReference(
-                    serverOrClient, {1, 1000}, {1, 1001}, ReferenceTypeId::Organizes, true, true
+                    connection, {1, 1000}, {1, 1001}, ReferenceTypeId::Organizes, true, true
                 );
             }
         };
@@ -216,15 +216,15 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
     }
 
     SUBCASE("Delete node") {
-        services::addObject(serverOrClient, objectsId, {1, 1000}, "object");
+        services::addObject(connection, objectsId, {1, 1000}, "object");
 
         auto deleteNode = [&] {
             if constexpr (isAsync<T>) {
-                auto future = services::deleteNodeAsync(serverOrClient, {1, 1000});
+                auto future = services::deleteNodeAsync(connection, {1, 1000});
                 setup.client.runIterate();
                 future.get().code().throwIfBad();
             } else {
-                services::deleteNode(serverOrClient, {1, 1000});
+                services::deleteNode(connection, {1, 1000});
             }
         };
         CHECK_NOTHROW(deleteNode());
@@ -233,7 +233,7 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
 
     SUBCASE("Random node id") {
         // https://www.open62541.org/doc/1.3/server.html#node-addition-and-deletion
-        const auto id = services::addObject(serverOrClient, objectsId, {1, 0}, "random");
+        const auto id = services::addObject(connection, objectsId, {1, 0}, "random");
         CHECK(id != NodeId(1, 0));
         CHECK(id.getNamespaceIndex() == 1);
     }
@@ -464,7 +464,7 @@ TEST_CASE_TEMPLATE("Attribute service set write/read", T, Server, Client, Async<
     ServerClientSetup setup;
     setup.client.connect(setup.endpointUrl);
     auto& client = setup.client;
-    auto& serverOrClient = setup.getInstance<T>();
+    auto& connection = setup.getInstance<T>();
 
     // create variable node
     const NodeId id{1, 1000};
@@ -482,23 +482,21 @@ TEST_CASE_TEMPLATE("Attribute service set write/read", T, Server, Client, Async<
     // write
     if constexpr (isAsync<T>) {
         auto future = services::writeAttributeAsync(
-            serverOrClient, id, AttributeId::Value, DataValue::fromScalar(value)
+            connection, id, AttributeId::Value, DataValue::fromScalar(value)
         );
         client.runIterate();
         future.get().code().throwIfBad();
     } else {
-        services::writeAttribute(
-            serverOrClient, id, AttributeId::Value, DataValue::fromScalar(value)
-        );
+        services::writeAttribute(connection, id, AttributeId::Value, DataValue::fromScalar(value));
     }
 
     // read
     if constexpr (isAsync<T>) {
-        auto future = services::readAttributeAsync(serverOrClient, id, AttributeId::Value);
+        auto future = services::readAttributeAsync(connection, id, AttributeId::Value);
         client.runIterate();
         result = future.get().value();
     } else {
-        result = services::readAttribute(serverOrClient, id, AttributeId::Value);
+        result = services::readAttribute(connection, id, AttributeId::Value);
     }
 
     CHECK(result.getValue().getScalar<double>() == value);
@@ -509,7 +507,7 @@ TEST_CASE_TEMPLATE("View service set", T, Server, Client, Async<Client>) {
     setup.client.connect(setup.endpointUrl);
     auto& server = setup.server;
     auto& client = setup.client;
-    auto& serverOrClient = setup.getInstance<T>();
+    auto& connection = setup.getInstance<T>();
 
     // add node to query references
     const NodeId id{1, 1000};
@@ -520,11 +518,11 @@ TEST_CASE_TEMPLATE("View service set", T, Server, Client, Async<Client>) {
         BrowseResult result;
 
         if constexpr (isAsync<T>) {
-            auto future = services::browseAsync(serverOrClient, bd);
+            auto future = services::browseAsync(connection, bd);
             client.runIterate();
             result = future.get().value();
         } else {
-            result = services::browse(serverOrClient, bd);
+            result = services::browse(connection, bd);
         }
 
         CHECK(result.getStatusCode().isGood());
@@ -550,7 +548,7 @@ TEST_CASE_TEMPLATE("View service set", T, Server, Client, Async<Client>) {
         BrowseResult result;
 
         // restrict browse result to max 1 reference, more with browseNext
-        result = services::browse(serverOrClient, bd, 1);
+        result = services::browse(connection, bd, 1);
         CHECK(result.getStatusCode().isGood());
         CHECK(result.getContinuationPoint().empty() == false);
         CHECK(result.getReferences().size() == 1);
@@ -558,13 +556,13 @@ TEST_CASE_TEMPLATE("View service set", T, Server, Client, Async<Client>) {
         auto browseNext = [&](bool releaseContinuationPoint) {
             if constexpr (isAsync<T>) {
                 auto future = services::browseNextAsync(
-                    serverOrClient, releaseContinuationPoint, result.getContinuationPoint()
+                    connection, releaseContinuationPoint, result.getContinuationPoint()
                 );
                 client.runIterate();
                 result = future.get().value();
             } else {
                 result = services::browseNext(
-                    serverOrClient, releaseContinuationPoint, result.getContinuationPoint()
+                    connection, releaseContinuationPoint, result.getContinuationPoint()
                 );
             }
         };
@@ -592,7 +590,7 @@ TEST_CASE_TEMPLATE("View service set", T, Server, Client, Async<Client>) {
                 UA_NODECLASS_VARIABLE
             );
 
-            const auto results = services::browseRecursive(serverOrClient, bd);
+            const auto results = services::browseRecursive(connection, bd);
             CHECK(!results.empty());
 
             auto contains = [&](const NodeId& element) {
@@ -608,21 +606,21 @@ TEST_CASE_TEMPLATE("View service set", T, Server, Client, Async<Client>) {
 
     SUBCASE("browseAll") {
         const BrowseDescription bd(id, BrowseDirection::Both);
-        CHECK(services::browseAll(serverOrClient, bd, 0).size() == 2);
-        CHECK(services::browseAll(serverOrClient, bd, 1).size() == 1);
+        CHECK(services::browseAll(connection, bd, 0).size() == 2);
+        CHECK(services::browseAll(connection, bd, 1).size() == 1);
     }
 
     SUBCASE("browseSimplifiedBrowsePath") {
         BrowsePathResult result;
         if constexpr (isAsync<T>) {
             auto future = services::browseSimplifiedBrowsePathAsync(
-                serverOrClient, {0, UA_NS0ID_ROOTFOLDER}, {{0, "Objects"}, {1, "Variable"}}
+                connection, {0, UA_NS0ID_ROOTFOLDER}, {{0, "Objects"}, {1, "Variable"}}
             );
             client.runIterate();
             result = future.get().value();
         } else {
             result = services::browseSimplifiedBrowsePath(
-                serverOrClient, {0, UA_NS0ID_ROOTFOLDER}, {{0, "Objects"}, {1, "Variable"}}
+                connection, {0, UA_NS0ID_ROOTFOLDER}, {{0, "Objects"}, {1, "Variable"}}
             );
         }
         CHECK(result.getStatusCode().isGood());
@@ -662,7 +660,7 @@ TEST_CASE_TEMPLATE("View service set", T, Server, Client, Async<Client>) {
 TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
     ServerClientSetup setup;
     setup.client.connect(setup.endpointUrl);
-    auto& serverOrClient = setup.getInstance<T>();
+    auto& connection = setup.getInstance<T>();
 
     const NodeId objectsId{ObjectId::ObjectsFolder};
     const NodeId methodId{1, 1000};
@@ -713,7 +711,7 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
                     }
                 )}
             );
-            const CallResponse response = call(serverOrClient, request);
+            const CallResponse response = call(connection, request);
             CHECK(response.getResults().size() == 1);
             CHECK(response.getResults()[0].getStatusCode().isGood());
             CHECK(response.getResults()[0].getOutputArguments().size() == 1);
@@ -723,7 +721,7 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
 
     SUBCASE("Check result") {
         const std::vector<Variant> outputs = call(
-            serverOrClient,
+            connection,
             objectsId,
             methodId,
             Span<const Variant>{
@@ -739,7 +737,7 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
         throwException = true;
         CHECK_THROWS_WITH(
             call(
-                serverOrClient,
+                connection,
                 objectsId,
                 methodId,
                 Span<const Variant>{
@@ -754,7 +752,7 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
     SUBCASE("Invalid input arguments") {
         CHECK_THROWS_WITH(
             call(
-                serverOrClient,
+                connection,
                 objectsId,
                 methodId,
                 Span<const Variant>{
@@ -765,11 +763,11 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
             "BadInvalidArgument"
         );
         CHECK_THROWS_WITH(
-            call(serverOrClient, objectsId, methodId, Span<const Variant>{}), "BadArgumentsMissing"
+            call(connection, objectsId, methodId, Span<const Variant>{}), "BadArgumentsMissing"
         );
         CHECK_THROWS_WITH(
             call(
-                serverOrClient,
+                connection,
                 objectsId,
                 methodId,
                 Span<const Variant>{

--- a/tools/gen_attribute_highlevel.py
+++ b/tools/gen_attribute_highlevel.py
@@ -64,8 +64,8 @@ TEMPLATE_READ = """
  * @ingroup Read
  */
 template <typename T>
-inline {type} read{attr}(T& serverOrClient, const NodeId& id) {{
-    return detail::readAttributeImpl<AttributeId::{attr}>(serverOrClient, id);
+inline {type} read{attr}(T& connection, const NodeId& id) {{
+    return detail::readAttributeImpl<AttributeId::{attr}>(connection, id);
 }}
 
 /**
@@ -75,10 +75,10 @@ inline {type} read{attr}(T& serverOrClient, const NodeId& id) {{
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto read{attr}Async(
-    Client& client, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
 ) {{
     return detail::readAttributeAsyncImpl<AttributeId::{attr}>(
-        client, id, std::forward<CompletionToken>(token)
+        connection, id, std::forward<CompletionToken>(token)
     );
 }}
 """.lstrip()
@@ -89,8 +89,8 @@ TEMPLATE_WRITE = """
  * @ingroup Write
  */
 template <typename T>
-inline void write{attr}(T& serverOrClient, const NodeId& id, {param_type} {param_name}) {{
-    detail::writeAttributeImpl<AttributeId::{attr}>(serverOrClient, id, {param_name});
+inline void write{attr}(T& connection, const NodeId& id, {param_type} {param_name}) {{
+    detail::writeAttributeImpl<AttributeId::{attr}>(connection, id, {param_name});
 }}
 
 /**
@@ -100,13 +100,13 @@ inline void write{attr}(T& serverOrClient, const NodeId& id, {param_type} {param
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto write{attr}Async(
-    Client& client,
+    Client& connection,
     const NodeId& id,
     {param_type} {param_name},
     CompletionToken&& token = DefaultCompletionToken()
 ) {{
     detail::writeAttributeAsyncImpl<AttributeId::{attr}>(
-        client, id, {param_name}, std::forward<CompletionToken>(token)
+        connection, id, {param_name}, std::forward<CompletionToken>(token)
     );
 }}
 """.lstrip()


### PR DESCRIPTION
Mainly to copy/reuse parameter descriptions for the documentation.