### PR TITLE
feat!: use `Result` return type for all functions in services namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ if(MSVC)
         /w14640
         /wd4127  # conditional expression is constant
         /wd4661  # explicit template instantiations in cpp files
+        /wd4702  # unreachable code, false positive
         /wd4996  # deprecation gmtime, localtime
     )
     if(UAPP_WARNINGS_AS_ERRORS)

--- a/include/open62541pp/MonitoredItem.h
+++ b/include/open62541pp/MonitoredItem.h
@@ -95,20 +95,26 @@ public:
     /// @note Not implemented for Server.
     /// @see services::modifyMonitoredItem
     void setMonitoringParameters(MonitoringParametersEx& parameters) {
-        services::modifyMonitoredItem(connection_, subscriptionId_, monitoredItemId_, parameters);
+        services::modifyMonitoredItem(connection_, subscriptionId_, monitoredItemId_, parameters)
+            .code()
+            .throwIfBad();
     }
 
     /// Set the monitoring mode of this monitored item.
     /// @note Not implemented for Server.
     /// @see services::setMonitoringMode
     void setMonitoringMode(MonitoringMode monitoringMode) {
-        services::setMonitoringMode(connection_, subscriptionId_, monitoredItemId_, monitoringMode);
+        services::setMonitoringMode(connection_, subscriptionId_, monitoredItemId_, monitoringMode)
+            .code()
+            .throwIfBad();
     }
 
     /// Delete this monitored item.
     /// @see services::deleteMonitoredItem
     void deleteMonitoredItem() {
-        services::deleteMonitoredItem(connection_, subscriptionId_, monitoredItemId_);
+        services::deleteMonitoredItem(connection_, subscriptionId_, monitoredItemId_)
+            .code()
+            .throwIfBad();
     }
 
 private:
@@ -122,8 +128,8 @@ private:
 template <typename T>
 inline bool operator==(const MonitoredItem<T>& lhs, const MonitoredItem<T>& rhs) noexcept {
     return (lhs.connection() == rhs.connection()) &&
-           (lhs.subscriptionId() == rhs.subscriptionId()) &&
-           (lhs.monitoredItemId() == rhs.monitoredItemId());
+        (lhs.subscriptionId() == rhs.subscriptionId()) &&
+        (lhs.monitoredItemId() == rhs.monitoredItemId());
 }
 
 template <typename T>

--- a/include/open62541pp/MonitoredItem.h
+++ b/include/open62541pp/MonitoredItem.h
@@ -96,8 +96,7 @@ public:
     /// @see services::modifyMonitoredItem
     void setMonitoringParameters(MonitoringParametersEx& parameters) {
         services::modifyMonitoredItem(connection_, subscriptionId_, monitoredItemId_, parameters)
-            .code()
-            .throwIfBad();
+            .value();
     }
 
     /// Set the monitoring mode of this monitored item.
@@ -105,16 +104,13 @@ public:
     /// @see services::setMonitoringMode
     void setMonitoringMode(MonitoringMode monitoringMode) {
         services::setMonitoringMode(connection_, subscriptionId_, monitoredItemId_, monitoringMode)
-            .code()
-            .throwIfBad();
+            .value();
     }
 
     /// Delete this monitored item.
     /// @see services::deleteMonitoredItem
     void deleteMonitoredItem() {
-        services::deleteMonitoredItem(connection_, subscriptionId_, monitoredItemId_)
-            .code()
-            .throwIfBad();
+        services::deleteMonitoredItem(connection_, subscriptionId_, monitoredItemId_).value();
     }
 
 private:

--- a/include/open62541pp/Node.h
+++ b/include/open62541pp/Node.h
@@ -96,10 +96,10 @@ public:
         const ObjectAttributes& attributes = {},
         const NodeId& referenceType = ReferenceTypeId::HasComponent
     ) {
-        NodeId resultingId = services::addFolder(
+        auto result = services::addFolder(
             connection_, id_, id, browseName, attributes, referenceType
         );
-        return {connection_, resultingId};
+        return {connection_, result.value()};
     }
 
     /// @wrapper{services::addObject}
@@ -110,10 +110,10 @@ public:
         const NodeId& objectType = ObjectTypeId::BaseObjectType,
         const NodeId& referenceType = ReferenceTypeId::HasComponent
     ) {
-        NodeId resultingId = services::addObject(
+        auto result = services::addObject(
             connection_, id_, id, browseName, attributes, objectType, referenceType
         );
-        return {connection_, resultingId};
+        return {connection_, result.value()};
     }
 
     /// @wrapper{services::addVariable}
@@ -124,18 +124,18 @@ public:
         const NodeId& variableType = VariableTypeId::BaseDataVariableType,
         const NodeId& referenceType = ReferenceTypeId::HasComponent
     ) {
-        NodeId resultingId = services::addVariable(
+        auto result = services::addVariable(
             connection_, id_, id, browseName, attributes, variableType, referenceType
         );
-        return {connection_, resultingId};
+        return {connection_, result.value()};
     }
 
     /// @wrapper{services::addProperty}
     Node addProperty(
         const NodeId& id, std::string_view browseName, const VariableAttributes& attributes = {}
     ) {
-        NodeId resultingId = services::addProperty(connection_, id_, id, browseName, attributes);
-        return {connection_, resultingId};
+        auto result = services::addProperty(connection_, id_, id, browseName, attributes);
+        return {connection_, result.value()};
     }
 
 #ifdef UA_ENABLE_METHODCALLS
@@ -149,7 +149,7 @@ public:
         const MethodAttributes& attributes = {},
         const NodeId& referenceType = ReferenceTypeId::HasComponent
     ) {
-        NodeId resultingId = services::addMethod(
+        auto result = services::addMethod(
             connection_,
             id_,
             id,
@@ -160,7 +160,7 @@ public:
             attributes,
             referenceType
         );
-        return {connection_, resultingId};
+        return {connection_, result.value()};
     }
 #endif
 
@@ -171,10 +171,10 @@ public:
         const ObjectTypeAttributes& attributes = {},
         const NodeId& referenceType = ReferenceTypeId::HasSubtype
     ) {
-        NodeId resultingId = services::addObjectType(
+        auto result = services::addObjectType(
             connection_, id_, id, browseName, attributes, referenceType
         );
-        return {connection_, resultingId};
+        return {connection_, result.value()};
     }
 
     /// @wrapper{services::addVariableType}
@@ -185,10 +185,10 @@ public:
         const NodeId& variableType = VariableTypeId::BaseDataVariableType,
         const NodeId& referenceType = ReferenceTypeId::HasSubtype
     ) {
-        NodeId resultingId = services::addVariableType(
+        auto result = services::addVariableType(
             connection_, id_, id, browseName, attributes, variableType, referenceType
         );
-        return {connection_, resultingId};
+        return {connection_, result.value()};
     }
 
     /// @wrapper{services::addReferenceType}
@@ -198,10 +198,10 @@ public:
         const ReferenceTypeAttributes& attributes = {},
         const NodeId& referenceType = ReferenceTypeId::HasSubtype
     ) {
-        NodeId resultingId = services::addReferenceType(
+        auto result = services::addReferenceType(
             connection_, id_, id, browseName, attributes, referenceType
         );
-        return {connection_, resultingId};
+        return {connection_, result.value()};
     }
 
     /// @wrapper{services::addDataType}
@@ -211,10 +211,10 @@ public:
         const DataTypeAttributes& attributes = {},
         const NodeId& referenceType = ReferenceTypeId::HasSubtype
     ) {
-        NodeId resultingId = services::addDataType(
+        auto result = services::addDataType(
             connection_, id_, id, browseName, attributes, referenceType
         );
-        return {connection_, resultingId};
+        return {connection_, result.value()};
     }
 
     /// @wrapper{services::addView}
@@ -224,27 +224,29 @@ public:
         const ViewAttributes& attributes = {},
         const NodeId& referenceType = ReferenceTypeId::Organizes
     ) {
-        NodeId resultingId = services::addView(
+        auto result = services::addView(
             connection_, id_, id, browseName, attributes, referenceType
         );
-        return {connection_, resultingId};
+        return {connection_, result.value()};
     }
 
     /// @wrapper{services::addReference}
     Node& addReference(const NodeId& targetId, const NodeId& referenceType, bool forward = true) {
-        services::addReference(connection_, id_, targetId, referenceType, forward);
+        services::addReference(connection_, id_, targetId, referenceType, forward)
+            .code()
+            .throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::addModellingRule}
     Node& addModellingRule(ModellingRule rule) {
-        services::addModellingRule(connection_, id_, rule);
+        services::addModellingRule(connection_, id_, rule).code().throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::deleteNode}
     void deleteNode(bool deleteReferences = true) {
-        services::deleteNode(connection_, id_, deleteReferences);
+        services::deleteNode(connection_, id_, deleteReferences).code().throwIfBad();
     }
 
     /// @wrapper{services::deleteReference}
@@ -256,7 +258,9 @@ public:
     ) {
         services::deleteReference(
             connection_, id_, targetId, referenceType, isForward, deleteBidirectional
-        );
+        )
+            .code()
+            .throwIfBad();
         return *this;
     }
 
@@ -267,17 +271,15 @@ public:
         bool includeSubtypes = true,
         Bitmask<NodeClass> nodeClassMask = NodeClass::Unspecified
     ) {
-        return services::browseAll(
-            connection_,
-            BrowseDescription(
-                id_,
-                browseDirection,
-                referenceType,
-                includeSubtypes,
-                nodeClassMask,
-                BrowseResultMask::All
-            )
+        const BrowseDescription bd(
+            id_,
+            browseDirection,
+            referenceType,
+            includeSubtypes,
+            nodeClassMask,
+            BrowseResultMask::All
         );
+        return services::browseAll(connection_, bd).value();
     }
 
     /// Browse referenced nodes (only local nodes).
@@ -287,17 +289,15 @@ public:
         bool includeSubtypes = true,
         Bitmask<NodeClass> nodeClassMask = NodeClass::Unspecified
     ) {
-        auto refs = services::browseAll(
-            connection_,
-            BrowseDescription(
-                id_,
-                browseDirection,
-                referenceType,
-                includeSubtypes,
-                nodeClassMask,
-                BrowseResultMask::TargetInfo  // only node id required here
-            )
+        const BrowseDescription bd(
+            id_,
+            browseDirection,
+            referenceType,
+            includeSubtypes,
+            nodeClassMask,
+            BrowseResultMask::TargetInfo  // only node id required here
         );
+        auto refs = services::browseAll(connection_, bd).value();
         std::vector<Node> nodes;
         nodes.reserve(refs.size());
         for (auto&& ref : refs) {
@@ -320,7 +320,7 @@ public:
     /// The relative path is specified using browse names.
     /// @exception BadStatus (BadNoMatch) If path not found
     Node browseChild(Span<const QualifiedName> path) {
-        auto result = services::browseSimplifiedBrowsePath(connection_, id_, path);
+        auto result = services::browseSimplifiedBrowsePath(connection_, id_, path).value();
         for (auto&& target : result.getTargets()) {
             if (target.getTargetId().isLocal()) {
                 return {connection_, std::move(target.getTargetId().getNodeId())};
@@ -350,73 +350,73 @@ public:
     /// @param methodId NodeId of the method (`HasComponent` reference to current node required)
     /// @param inputArguments Input argument values
     std::vector<Variant> callMethod(const NodeId& methodId, Span<const Variant> inputArguments) {
-        return services::call(connection_, id_, methodId, inputArguments);
+        return services::call(connection_, id_, methodId, inputArguments).value();
     }
 #endif
 
     /// @wrapper{services::readNodeClass}
     NodeClass readNodeClass() {
-        return services::readNodeClass(connection_, id_);
+        return services::readNodeClass(connection_, id_).value();
     }
 
     /// @wrapper{services::readBrowseName}
     QualifiedName readBrowseName() {
-        return services::readBrowseName(connection_, id_);
+        return services::readBrowseName(connection_, id_).value();
     }
 
     /// @wrapper{services::readDisplayName}
     LocalizedText readDisplayName() {
-        return services::readDisplayName(connection_, id_);
+        return services::readDisplayName(connection_, id_).value();
     }
 
     /// @wrapper{services::readDescription}
     LocalizedText readDescription() {
-        return services::readDescription(connection_, id_);
+        return services::readDescription(connection_, id_).value();
     }
 
     /// @wrapper{services::readWriteMask}
     Bitmask<WriteMask> readWriteMask() {
-        return services::readWriteMask(connection_, id_);
+        return services::readWriteMask(connection_, id_).value();
     }
 
     /// @wrapper{services::readUserWriteMask}
     Bitmask<WriteMask> readUserWriteMask() {
-        return services::readUserWriteMask(connection_, id_);
+        return services::readUserWriteMask(connection_, id_).value();
     }
 
     /// @wrapper{services::readIsAbstract}
     bool readIsAbstract() {
-        return services::readIsAbstract(connection_, id_);
+        return services::readIsAbstract(connection_, id_).value();
     }
 
     /// @wrapper{services::readSymmetric}
     bool readSymmetric() {
-        return services::readSymmetric(connection_, id_);
+        return services::readSymmetric(connection_, id_).value();
     }
 
     /// @wrapper{services::readInverseName}
     LocalizedText readInverseName() {
-        return services::readInverseName(connection_, id_);
+        return services::readInverseName(connection_, id_).value();
     }
 
     /// @wrapper{services::readContainsNoLoops}
     bool readContainsNoLoops() {
-        return services::readContainsNoLoops(connection_, id_);
+        return services::readContainsNoLoops(connection_, id_).value();
     }
 
     /// @wrapper{services::readEventNotifier}
     Bitmask<EventNotifier> readEventNotifier() {
-        return services::readEventNotifier(connection_, id_);
+        return services::readEventNotifier(connection_, id_).value();
     }
 
     /// @wrapper{services::readDataValue}
     DataValue readDataValue() {
-        return services::readDataValue(connection_, id_);
+        return services::readDataValue(connection_, id_).value();
     }
 
     /// @wrapper{services::readValue}
     Variant readValue() {
-        return services::readValue(connection_, id_);
+        return services::readValue(connection_, id_).value();
     }
 
     /// Read scalar value from variable node.
@@ -433,47 +433,47 @@ public:
 
     /// @wrapper{services::readDataType}
     NodeId readDataType() {
-        return services::readDataType(connection_, id_);
+        return services::readDataType(connection_, id_).value();
     }
 
     /// @wrapper{services::readValueRank}
     ValueRank readValueRank() {
-        return services::readValueRank(connection_, id_);
+        return services::readValueRank(connection_, id_).value();
     }
 
     /// @wrapper{services::readArrayDimensions}
     std::vector<uint32_t> readArrayDimensions() {
-        return services::readArrayDimensions(connection_, id_);
+        return services::readArrayDimensions(connection_, id_).value();
     }
 
     /// @wrapper{services::readAccessLevel}
     Bitmask<AccessLevel> readAccessLevel() {
-        return services::readAccessLevel(connection_, id_);
+        return services::readAccessLevel(connection_, id_).value();
     }
 
     /// @wrapper{services::readUserAccessLevel}
     Bitmask<AccessLevel> readUserAccessLevel() {
-        return services::readUserAccessLevel(connection_, id_);
+        return services::readUserAccessLevel(connection_, id_).value();
     }
 
     /// @wrapper{services::readMinimumSamplingInterval}
     double readMinimumSamplingInterval() {
-        return services::readMinimumSamplingInterval(connection_, id_);
+        return services::readMinimumSamplingInterval(connection_, id_).value();
     }
 
     /// @wrapper{services::readHistorizing}
     bool readHistorizing() {
-        return services::readHistorizing(connection_, id_);
+        return services::readHistorizing(connection_, id_).value();
     }
 
     /// @wrapper{services::readExecutable}
     bool readExecutable() {
-        return services::readExecutable(connection_, id_);
+        return services::readExecutable(connection_, id_).value();
     }
 
     /// @wrapper{services::readUserExecutable}
     bool readUserExecutable() {
-        return services::readUserExecutable(connection_, id_);
+        return services::readUserExecutable(connection_, id_).value();
     }
 
     /// Read the value of an object property.
@@ -484,67 +484,67 @@ public:
 
     /// @wrapper{services::writeDisplayName}
     Node& writeDisplayName(const LocalizedText& name) {
-        services::writeDisplayName(connection_, id_, name);
+        services::writeDisplayName(connection_, id_, name).code().throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeDescription}
     Node& writeDescription(const LocalizedText& desc) {
-        services::writeDescription(connection_, id_, desc);
+        services::writeDescription(connection_, id_, desc).code().throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeWriteMask}
     Node& writeWriteMask(Bitmask<WriteMask> mask) {
-        services::writeWriteMask(connection_, id_, mask);
+        services::writeWriteMask(connection_, id_, mask).code().throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeWriteMask}
     Node& writeUserWriteMask(Bitmask<WriteMask> mask) {
-        services::writeUserWriteMask(connection_, id_, mask);
+        services::writeUserWriteMask(connection_, id_, mask).code().throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeIsAbstract}
     Node& writeIsAbstract(bool isAbstract) {
-        services::writeIsAbstract(connection_, id_, isAbstract);
+        services::writeIsAbstract(connection_, id_, isAbstract).code().throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeSymmetric}
     Node& writeSymmetric(bool symmetric) {
-        services::writeSymmetric(connection_, id_, symmetric);
+        services::writeSymmetric(connection_, id_, symmetric).code().throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeInverseName}
     Node& writeInverseName(const LocalizedText& name) {
-        services::writeInverseName(connection_, id_, name);
+        services::writeInverseName(connection_, id_, name).code().throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeContainsNoLoops}
     Node& writeContainsNoLoops(bool containsNoLoops) {
-        services::writeContainsNoLoops(connection_, id_, containsNoLoops);
+        services::writeContainsNoLoops(connection_, id_, containsNoLoops).code().throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeEventNotifier}
     Node& writeEventNotifier(Bitmask<EventNotifier> mask) {
-        services::writeEventNotifier(connection_, id_, mask);
+        services::writeEventNotifier(connection_, id_, mask).code().throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeDataValue}
     Node& writeDataValue(const DataValue& value) {
-        services::writeDataValue(connection_, id_, value);
+        services::writeDataValue(connection_, id_, value).code().throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeValue}
     Node& writeValue(const Variant& value) {
-        services::writeValue(connection_, id_, value);
+        services::writeValue(connection_, id_, value).code().throwIfBad();
         return *this;
     }
 
@@ -574,7 +574,7 @@ public:
 
     /// @wrapper{services::writeDataType}
     Node& writeDataType(const NodeId& typeId) {
-        services::writeDataType(connection_, id_, typeId);
+        services::writeDataType(connection_, id_, typeId).code().throwIfBad();
         return *this;
     }
 
@@ -587,49 +587,49 @@ public:
 
     /// @wrapper{services::writeValueRank}
     Node& writeValueRank(ValueRank valueRank) {
-        services::writeValueRank(connection_, id_, valueRank);
+        services::writeValueRank(connection_, id_, valueRank).code().throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeArrayDimensions}
     Node& writeArrayDimensions(Span<const uint32_t> dimensions) {
-        services::writeArrayDimensions(connection_, id_, dimensions);
+        services::writeArrayDimensions(connection_, id_, dimensions).code().throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeAccessLevel}
     Node& writeAccessLevel(Bitmask<AccessLevel> mask) {
-        services::writeAccessLevel(connection_, id_, mask);
+        services::writeAccessLevel(connection_, id_, mask).code().throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeUserAccessLevel}
     Node& writeUserAccessLevel(Bitmask<AccessLevel> mask) {
-        services::writeUserAccessLevel(connection_, id_, mask);
+        services::writeUserAccessLevel(connection_, id_, mask).code().throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeMinimumSamplingInterval}
     Node& writeMinimumSamplingInterval(double milliseconds) {
-        services::writeMinimumSamplingInterval(connection_, id_, milliseconds);
+        services::writeMinimumSamplingInterval(connection_, id_, milliseconds).code().throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeHistorizing}
     Node& writeHistorizing(bool historizing) {
-        services::writeHistorizing(connection_, id_, historizing);
+        services::writeHistorizing(connection_, id_, historizing).code().throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeExecutable}
     Node& writeExecutable(bool executable) {
-        services::writeExecutable(connection_, id_, executable);
+        services::writeExecutable(connection_, id_, executable).code().throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeUserExecutable}
     Node& writeUserExecutable(bool userExecutable) {
-        services::writeUserExecutable(connection_, id_, userExecutable);
+        services::writeUserExecutable(connection_, id_, userExecutable).code().throwIfBad();
         return *this;
     }
 
@@ -643,10 +643,11 @@ public:
 
 private:
     Node browseObjectProperty(const QualifiedName& propertyName) {
-        auto result = services::translateBrowsePathToNodeIds(
-            connection_,
-            BrowsePath(id_, {{ReferenceTypeId::HasProperty, false, true, propertyName}})
-        );
+        auto result =
+            services::translateBrowsePathToNodeIds(
+                connection_,
+                BrowsePath(id_, {{ReferenceTypeId::HasProperty, false, true, propertyName}})
+            ).value();
         result.getStatusCode().throwIfBad();
         for (auto&& target : result.getTargets()) {
             if (target.getTargetId().isLocal()) {

--- a/include/open62541pp/Node.h
+++ b/include/open62541pp/Node.h
@@ -232,21 +232,19 @@ public:
 
     /// @wrapper{services::addReference}
     Node& addReference(const NodeId& targetId, const NodeId& referenceType, bool forward = true) {
-        services::addReference(connection_, id_, targetId, referenceType, forward)
-            .code()
-            .throwIfBad();
+        services::addReference(connection_, id_, targetId, referenceType, forward).value();
         return *this;
     }
 
     /// @wrapper{services::addModellingRule}
     Node& addModellingRule(ModellingRule rule) {
-        services::addModellingRule(connection_, id_, rule).code().throwIfBad();
+        services::addModellingRule(connection_, id_, rule).value();
         return *this;
     }
 
     /// @wrapper{services::deleteNode}
     void deleteNode(bool deleteReferences = true) {
-        services::deleteNode(connection_, id_, deleteReferences).code().throwIfBad();
+        services::deleteNode(connection_, id_, deleteReferences).value();
     }
 
     /// @wrapper{services::deleteReference}
@@ -259,8 +257,7 @@ public:
         services::deleteReference(
             connection_, id_, targetId, referenceType, isForward, deleteBidirectional
         )
-            .code()
-            .throwIfBad();
+            .value();
         return *this;
     }
 
@@ -484,67 +481,67 @@ public:
 
     /// @wrapper{services::writeDisplayName}
     Node& writeDisplayName(const LocalizedText& name) {
-        services::writeDisplayName(connection_, id_, name).code().throwIfBad();
+        services::writeDisplayName(connection_, id_, name).value();
         return *this;
     }
 
     /// @wrapper{services::writeDescription}
     Node& writeDescription(const LocalizedText& desc) {
-        services::writeDescription(connection_, id_, desc).code().throwIfBad();
+        services::writeDescription(connection_, id_, desc).value();
         return *this;
     }
 
     /// @wrapper{services::writeWriteMask}
     Node& writeWriteMask(Bitmask<WriteMask> mask) {
-        services::writeWriteMask(connection_, id_, mask).code().throwIfBad();
+        services::writeWriteMask(connection_, id_, mask).value();
         return *this;
     }
 
     /// @wrapper{services::writeWriteMask}
     Node& writeUserWriteMask(Bitmask<WriteMask> mask) {
-        services::writeUserWriteMask(connection_, id_, mask).code().throwIfBad();
+        services::writeUserWriteMask(connection_, id_, mask).value();
         return *this;
     }
 
     /// @wrapper{services::writeIsAbstract}
     Node& writeIsAbstract(bool isAbstract) {
-        services::writeIsAbstract(connection_, id_, isAbstract).code().throwIfBad();
+        services::writeIsAbstract(connection_, id_, isAbstract).value();
         return *this;
     }
 
     /// @wrapper{services::writeSymmetric}
     Node& writeSymmetric(bool symmetric) {
-        services::writeSymmetric(connection_, id_, symmetric).code().throwIfBad();
+        services::writeSymmetric(connection_, id_, symmetric).value();
         return *this;
     }
 
     /// @wrapper{services::writeInverseName}
     Node& writeInverseName(const LocalizedText& name) {
-        services::writeInverseName(connection_, id_, name).code().throwIfBad();
+        services::writeInverseName(connection_, id_, name).value();
         return *this;
     }
 
     /// @wrapper{services::writeContainsNoLoops}
     Node& writeContainsNoLoops(bool containsNoLoops) {
-        services::writeContainsNoLoops(connection_, id_, containsNoLoops).code().throwIfBad();
+        services::writeContainsNoLoops(connection_, id_, containsNoLoops).value();
         return *this;
     }
 
     /// @wrapper{services::writeEventNotifier}
     Node& writeEventNotifier(Bitmask<EventNotifier> mask) {
-        services::writeEventNotifier(connection_, id_, mask).code().throwIfBad();
+        services::writeEventNotifier(connection_, id_, mask).value();
         return *this;
     }
 
     /// @wrapper{services::writeDataValue}
     Node& writeDataValue(const DataValue& value) {
-        services::writeDataValue(connection_, id_, value).code().throwIfBad();
+        services::writeDataValue(connection_, id_, value).value();
         return *this;
     }
 
     /// @wrapper{services::writeValue}
     Node& writeValue(const Variant& value) {
-        services::writeValue(connection_, id_, value).code().throwIfBad();
+        services::writeValue(connection_, id_, value).value();
         return *this;
     }
 
@@ -574,7 +571,7 @@ public:
 
     /// @wrapper{services::writeDataType}
     Node& writeDataType(const NodeId& typeId) {
-        services::writeDataType(connection_, id_, typeId).code().throwIfBad();
+        services::writeDataType(connection_, id_, typeId).value();
         return *this;
     }
 
@@ -587,49 +584,49 @@ public:
 
     /// @wrapper{services::writeValueRank}
     Node& writeValueRank(ValueRank valueRank) {
-        services::writeValueRank(connection_, id_, valueRank).code().throwIfBad();
+        services::writeValueRank(connection_, id_, valueRank).value();
         return *this;
     }
 
     /// @wrapper{services::writeArrayDimensions}
     Node& writeArrayDimensions(Span<const uint32_t> dimensions) {
-        services::writeArrayDimensions(connection_, id_, dimensions).code().throwIfBad();
+        services::writeArrayDimensions(connection_, id_, dimensions).value();
         return *this;
     }
 
     /// @wrapper{services::writeAccessLevel}
     Node& writeAccessLevel(Bitmask<AccessLevel> mask) {
-        services::writeAccessLevel(connection_, id_, mask).code().throwIfBad();
+        services::writeAccessLevel(connection_, id_, mask).value();
         return *this;
     }
 
     /// @wrapper{services::writeUserAccessLevel}
     Node& writeUserAccessLevel(Bitmask<AccessLevel> mask) {
-        services::writeUserAccessLevel(connection_, id_, mask).code().throwIfBad();
+        services::writeUserAccessLevel(connection_, id_, mask).value();
         return *this;
     }
 
     /// @wrapper{services::writeMinimumSamplingInterval}
     Node& writeMinimumSamplingInterval(double milliseconds) {
-        services::writeMinimumSamplingInterval(connection_, id_, milliseconds).code().throwIfBad();
+        services::writeMinimumSamplingInterval(connection_, id_, milliseconds).value();
         return *this;
     }
 
     /// @wrapper{services::writeHistorizing}
     Node& writeHistorizing(bool historizing) {
-        services::writeHistorizing(connection_, id_, historizing).code().throwIfBad();
+        services::writeHistorizing(connection_, id_, historizing).value();
         return *this;
     }
 
     /// @wrapper{services::writeExecutable}
     Node& writeExecutable(bool executable) {
-        services::writeExecutable(connection_, id_, executable).code().throwIfBad();
+        services::writeExecutable(connection_, id_, executable).value();
         return *this;
     }
 
     /// @wrapper{services::writeUserExecutable}
     Node& writeUserExecutable(bool userExecutable) {
-        services::writeUserExecutable(connection_, id_, userExecutable).code().throwIfBad();
+        services::writeUserExecutable(connection_, id_, userExecutable).value();
         return *this;
     }
 

--- a/include/open62541pp/Subscription.h
+++ b/include/open62541pp/Subscription.h
@@ -108,14 +108,14 @@ public:
     /// @note Not implemented for Server.
     /// @see services::modifySubscription
     void setSubscriptionParameters(SubscriptionParameters& parameters) {
-        services::modifySubscription(connection_, subscriptionId_, parameters);
+        services::modifySubscription(connection_, subscriptionId_, parameters).code().throwIfBad();
     }
 
     /// Enable/disable publishing of notification messages.
     /// @note Not implemented for Server.
     /// @see services::setPublishingMode
     void setPublishingMode(bool publishing) {
-        services::setPublishingMode(connection_, subscriptionId_, publishing);
+        services::setPublishingMode(connection_, subscriptionId_, publishing).code().throwIfBad();
     }
 
     /// Create a monitored item for data change notifications.
@@ -127,7 +127,7 @@ public:
         MonitoringParametersEx& parameters,
         DataChangeNotificationCallback onDataChange
     ) {
-        const uint32_t monitoredItemId = services::createMonitoredItemDataChange(
+        const auto result = services::createMonitoredItemDataChange(
             connection_,
             subscriptionId_,
             {id, attribute},
@@ -135,7 +135,7 @@ public:
             parameters,
             std::move(onDataChange)
         );
-        return {connection_, subscriptionId_, monitoredItemId};
+        return {connection_, subscriptionId_, result.value()};
     }
 
     /// @deprecated Use overload with DataChangeNotificationCallback instead
@@ -182,7 +182,7 @@ public:
         MonitoringParametersEx& parameters,
         EventNotificationCallback onEvent  // NOLINT(*-unnecessary-value-param), false positive?
     ) {
-        const uint32_t monitoredItemId = services::createMonitoredItemEvent(
+        const auto result = services::createMonitoredItemEvent(
             connection_,
             subscriptionId_,
             {id, AttributeId::EventNotifier},
@@ -190,7 +190,7 @@ public:
             parameters,
             std::move(onEvent)
         );
-        return {connection_, subscriptionId_, monitoredItemId};
+        return {connection_, subscriptionId_, result.value()};
     }
 
     /// @deprecated Use overload with EventNotificationCallback instead
@@ -227,7 +227,7 @@ public:
     /// Delete this subscription.
     /// @note Not implemented for Server.
     void deleteSubscription() {
-        services::deleteSubscription(connection_, subscriptionId_);
+        services::deleteSubscription(connection_, subscriptionId_).code().throwIfBad();
     }
 
 private:

--- a/include/open62541pp/Subscription.h
+++ b/include/open62541pp/Subscription.h
@@ -108,14 +108,14 @@ public:
     /// @note Not implemented for Server.
     /// @see services::modifySubscription
     void setSubscriptionParameters(SubscriptionParameters& parameters) {
-        services::modifySubscription(connection_, subscriptionId_, parameters).code().throwIfBad();
+        services::modifySubscription(connection_, subscriptionId_, parameters).value();
     }
 
     /// Enable/disable publishing of notification messages.
     /// @note Not implemented for Server.
     /// @see services::setPublishingMode
     void setPublishingMode(bool publishing) {
-        services::setPublishingMode(connection_, subscriptionId_, publishing).code().throwIfBad();
+        services::setPublishingMode(connection_, subscriptionId_, publishing).value();
     }
 
     /// Create a monitored item for data change notifications.
@@ -227,7 +227,7 @@ public:
     /// Delete this subscription.
     /// @note Not implemented for Server.
     void deleteSubscription() {
-        services::deleteSubscription(connection_, subscriptionId_).code().throwIfBad();
+        services::deleteSubscription(connection_, subscriptionId_).value();
     }
 
 private:

--- a/include/open62541pp/services/Attribute.h
+++ b/include/open62541pp/services/Attribute.h
@@ -63,7 +63,7 @@ inline ReadResponse read(
 /**
  * Asynchronously read one or more attributes of one or more nodes (client only).
  * @copydetails read
- * @param token @completiontoken{void(Result<ReadResponse>&)}
+ * @param token @completiontoken{void(ReadResponse&)}
  */
 template <typename CompletionToken = DefaultCompletionToken>
 auto readAsync(
@@ -72,10 +72,7 @@ auto readAsync(
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::sendRequest<UA_ReadRequest, UA_ReadResponse>(
-        connection,
-        request,
-        detail::WrapResponse<ReadResponse>{},
-        std::forward<CompletionToken>(token)
+        connection, request, detail::Wrap<ReadResponse>{}, std::forward<CompletionToken>(token)
     );
 }
 
@@ -104,7 +101,7 @@ inline auto readAsync(
  * @param timestamps Timestamps to return
  */
 template <typename T>
-DataValue readAttribute(
+Result<DataValue> readAttribute(
     T& connection,
     const NodeId& id,
     AttributeId attributeId,
@@ -129,7 +126,9 @@ auto readAttributeAsync(
     return detail::sendRequest<UA_ReadRequest, UA_ReadResponse>(
         connection,
         request,
-        [](UA_ReadResponse& response) { return detail::getReadResult(response); },
+        [](UA_ReadResponse& response) {
+            return detail::getSingleResult(response).transform(detail::Wrap<DataValue>{});
+        },
         std::forward<CompletionToken>(token)
     );
 }
@@ -181,10 +180,7 @@ auto writeAsync(
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::sendRequest<UA_WriteRequest, UA_WriteResponse>(
-        connection,
-        request,
-        detail::WrapResponse<WriteResponse>{},
-        std::forward<CompletionToken>(token)
+        connection, request, detail::Wrap<WriteResponse>{}, std::forward<CompletionToken>(token)
     );
 }
 
@@ -210,7 +206,7 @@ inline auto writeAsync(
  * @param value Value to write
  */
 template <typename T>
-void writeAttribute(
+Result<void> writeAttribute(
     T& connection, const NodeId& id, AttributeId attributeId, const DataValue& value
 );
 
@@ -232,7 +228,9 @@ auto writeAttributeAsync(
     return detail::sendRequest<UA_WriteRequest, UA_WriteResponse>(
         connection,
         request,
-        [](UA_WriteResponse& response) { throwIfBad(detail::getSingleResult(response)); },
+        [](UA_WriteResponse& response) {
+            return detail::getSingleResult(response).andThen(detail::asResult);
+        },
         std::forward<CompletionToken>(token)
     );
 }
@@ -248,7 +246,7 @@ namespace detail {
 template <AttributeId Attribute, typename T>
 inline auto readAttributeImpl(T& connection, const NodeId& id) {
     using Handler = typename detail::AttributeHandler<Attribute>;
-    return Handler::fromDataValue(readAttribute(connection, id, Attribute));
+    return readAttribute(connection, id, Attribute).andThen(Handler::fromDataValue);
 }
 
 template <AttributeId Attribute, typename CompletionToken>
@@ -260,16 +258,16 @@ inline auto readAttributeAsyncImpl(Client& connection, const NodeId& id, Complet
         request,
         [](UA_ReadResponse& response) {
             using Handler = typename detail::AttributeHandler<Attribute>;
-            return Handler::fromDataValue(detail::getReadResult(response));
+            return detail::getSingleResult(response).andThen(Handler::fromDataValue);
         },
         std::forward<CompletionToken>(token)
     );
 }
 
 template <AttributeId Attribute, typename T, typename U>
-inline void writeAttributeImpl(T& connection, const NodeId& id, U&& value) {
+inline Result<void> writeAttributeImpl(T& connection, const NodeId& id, U&& value) {
     using Handler = detail::AttributeHandler<Attribute>;
-    writeAttribute(connection, id, Attribute, Handler::toDataValue(std::forward<U>(value)));
+    return writeAttribute(connection, id, Attribute, Handler::toDataValue(std::forward<U>(value)));
 }
 
 template <AttributeId Attribute, typename T, typename U, typename CompletionToken>
@@ -295,7 +293,7 @@ inline auto writeAttributeAsyncImpl(
  * @ingroup Read
  */
 template <typename T>
-inline DataValue readDataValue(T& connection, const NodeId& id) {
+inline Result<DataValue> readDataValue(T& connection, const NodeId& id) {
     return readAttribute(connection, id, AttributeId::Value, TimestampsToReturn::Both);
 }
 
@@ -324,8 +322,8 @@ inline auto readDataValueAsync(Client& connection, const NodeId& id, CompletionT
  * @ingroup Write
  */
 template <typename T>
-inline void writeDataValue(T& connection, const NodeId& id, const DataValue& value) {
-    writeAttribute(connection, id, AttributeId::Value, value);
+inline Result<void> writeDataValue(T& connection, const NodeId& id, const DataValue& value) {
+    return writeAttribute(connection, id, AttributeId::Value, value);
 }
 
 /**
@@ -341,7 +339,7 @@ inline auto writeDataValueAsync(
     const DataValue& value,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
-    writeAttributeAsync(
+    return writeAttributeAsync(
         connection, id, AttributeId::Value, value, std::forward<CompletionToken>(token)
     );
 }

--- a/include/open62541pp/services/Attribute.h
+++ b/include/open62541pp/services/Attribute.h
@@ -47,7 +47,7 @@ namespace opcua::services {
  * @param connection Instance of type Client
  * @param request Read request
  */
-ReadResponse read(Client& connection, const ReadRequest& request);
+ReadResponse read(Client& connection, const ReadRequest& request) noexcept;
 
 /**
  * @overload
@@ -56,7 +56,7 @@ inline ReadResponse read(
     Client& connection,
     Span<const ReadValueId> nodesToRead,
     TimestampsToReturn timestamps = TimestampsToReturn::Neither
-) {
+) noexcept {
     return read(connection, detail::createReadRequest(timestamps, nodesToRead));
 }
 
@@ -106,7 +106,7 @@ Result<DataValue> readAttribute(
     const NodeId& id,
     AttributeId attributeId,
     TimestampsToReturn timestamps = TimestampsToReturn::Neither
-);
+) noexcept;
 
 /**
  * Asynchronously read node attribute.
@@ -159,12 +159,12 @@ auto readAttributeAsync(
  * @param connection Instance of type Client
  * @param request Write request
  */
-WriteResponse write(Client& connection, const WriteRequest& request);
+WriteResponse write(Client& connection, const WriteRequest& request) noexcept;
 
 /**
  * @overload
  */
-inline WriteResponse write(Client& connection, Span<const WriteValue> nodesToWrite) {
+inline WriteResponse write(Client& connection, Span<const WriteValue> nodesToWrite) noexcept {
     return write(connection, detail::createWriteRequest(nodesToWrite));
 }
 
@@ -208,7 +208,7 @@ inline auto writeAsync(
 template <typename T>
 Result<void> writeAttribute(
     T& connection, const NodeId& id, AttributeId attributeId, const DataValue& value
-);
+) noexcept;
 
 /**
  * Asynchronously write node attribute.
@@ -244,7 +244,7 @@ auto writeAttributeAsync(
 namespace detail {
 
 template <AttributeId Attribute, typename T>
-inline auto readAttributeImpl(T& connection, const NodeId& id) {
+inline auto readAttributeImpl(T& connection, const NodeId& id) noexcept {
     using Handler = typename detail::AttributeHandler<Attribute>;
     return readAttribute(connection, id, Attribute).andThen(Handler::fromDataValue);
 }
@@ -265,7 +265,7 @@ inline auto readAttributeAsyncImpl(Client& connection, const NodeId& id, Complet
 }
 
 template <AttributeId Attribute, typename T, typename U>
-inline Result<void> writeAttributeImpl(T& connection, const NodeId& id, U&& value) {
+inline Result<void> writeAttributeImpl(T& connection, const NodeId& id, U&& value) noexcept {
     using Handler = detail::AttributeHandler<Attribute>;
     return writeAttribute(connection, id, Attribute, Handler::toDataValue(std::forward<U>(value)));
 }
@@ -293,7 +293,7 @@ inline auto writeAttributeAsyncImpl(
  * @ingroup Read
  */
 template <typename T>
-inline Result<DataValue> readDataValue(T& connection, const NodeId& id) {
+inline Result<DataValue> readDataValue(T& connection, const NodeId& id) noexcept {
     return readAttribute(connection, id, AttributeId::Value, TimestampsToReturn::Both);
 }
 
@@ -322,7 +322,9 @@ inline auto readDataValueAsync(Client& connection, const NodeId& id, CompletionT
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeDataValue(T& connection, const NodeId& id, const DataValue& value) {
+inline Result<void> writeDataValue(
+    T& connection, const NodeId& id, const DataValue& value
+) noexcept {
     return writeAttribute(connection, id, AttributeId::Value, value);
 }
 

--- a/include/open62541pp/services/Attribute.h
+++ b/include/open62541pp/services/Attribute.h
@@ -229,7 +229,7 @@ auto writeAttributeAsync(
         connection,
         request,
         [](UA_WriteResponse& response) {
-            return detail::getSingleResult(response).andThen(detail::asResult);
+            return detail::getSingleResult(response).andThen(detail::toResult);
         },
         std::forward<CompletionToken>(token)
     );

--- a/include/open62541pp/services/Attribute_highlevel.h
+++ b/include/open62541pp/services/Attribute_highlevel.h
@@ -15,7 +15,7 @@ namespace opcua::services {
  * @ingroup Read
  */
 template <typename T>
-inline Result<NodeId> readNodeId(T& connection, const NodeId& id) {
+inline Result<NodeId> readNodeId(T& connection, const NodeId& id) noexcept {
     return detail::readAttributeImpl<AttributeId::NodeId>(connection, id);
 }
 
@@ -41,7 +41,7 @@ inline auto readNodeIdAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Result<NodeClass> readNodeClass(T& connection, const NodeId& id) {
+inline Result<NodeClass> readNodeClass(T& connection, const NodeId& id) noexcept {
     return detail::readAttributeImpl<AttributeId::NodeClass>(connection, id);
 }
 
@@ -67,7 +67,7 @@ inline auto readNodeClassAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Result<QualifiedName> readBrowseName(T& connection, const NodeId& id) {
+inline Result<QualifiedName> readBrowseName(T& connection, const NodeId& id) noexcept {
     return detail::readAttributeImpl<AttributeId::BrowseName>(connection, id);
 }
 
@@ -96,7 +96,7 @@ inline auto readBrowseNameAsync(
 template <typename T>
 inline Result<void> writeBrowseName(
     T& connection, const NodeId& id, const QualifiedName& browseName
-) {
+) noexcept {
     return detail::writeAttributeImpl<AttributeId::BrowseName>(connection, id, browseName);
 }
 
@@ -125,7 +125,7 @@ inline auto writeBrowseNameAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Result<LocalizedText> readDisplayName(T& connection, const NodeId& id) {
+inline Result<LocalizedText> readDisplayName(T& connection, const NodeId& id) noexcept {
     return detail::readAttributeImpl<AttributeId::DisplayName>(connection, id);
 }
 
@@ -154,7 +154,7 @@ inline auto readDisplayNameAsync(
 template <typename T>
 inline Result<void> writeDisplayName(
     T& connection, const NodeId& id, const LocalizedText& displayName
-) {
+) noexcept {
     return detail::writeAttributeImpl<AttributeId::DisplayName>(connection, id, displayName);
 }
 
@@ -183,7 +183,7 @@ inline auto writeDisplayNameAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Result<LocalizedText> readDescription(T& connection, const NodeId& id) {
+inline Result<LocalizedText> readDescription(T& connection, const NodeId& id) noexcept {
     return detail::readAttributeImpl<AttributeId::Description>(connection, id);
 }
 
@@ -212,7 +212,7 @@ inline auto readDescriptionAsync(
 template <typename T>
 inline Result<void> writeDescription(
     T& connection, const NodeId& id, const LocalizedText& description
-) {
+) noexcept {
     return detail::writeAttributeImpl<AttributeId::Description>(connection, id, description);
 }
 
@@ -241,7 +241,7 @@ inline auto writeDescriptionAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Result<Bitmask<WriteMask>> readWriteMask(T& connection, const NodeId& id) {
+inline Result<Bitmask<WriteMask>> readWriteMask(T& connection, const NodeId& id) noexcept {
     return detail::readAttributeImpl<AttributeId::WriteMask>(connection, id);
 }
 
@@ -268,7 +268,9 @@ inline auto readWriteMaskAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeWriteMask(T& connection, const NodeId& id, Bitmask<WriteMask> writeMask) {
+inline Result<void> writeWriteMask(
+    T& connection, const NodeId& id, Bitmask<WriteMask> writeMask
+) noexcept {
     return detail::writeAttributeImpl<AttributeId::WriteMask>(connection, id, writeMask);
 }
 
@@ -297,7 +299,7 @@ inline auto writeWriteMaskAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Result<Bitmask<WriteMask>> readUserWriteMask(T& connection, const NodeId& id) {
+inline Result<Bitmask<WriteMask>> readUserWriteMask(T& connection, const NodeId& id) noexcept {
     return detail::readAttributeImpl<AttributeId::UserWriteMask>(connection, id);
 }
 
@@ -326,7 +328,7 @@ inline auto readUserWriteMaskAsync(
 template <typename T>
 inline Result<void> writeUserWriteMask(
     T& connection, const NodeId& id, Bitmask<WriteMask> userWriteMask
-) {
+) noexcept {
     return detail::writeAttributeImpl<AttributeId::UserWriteMask>(connection, id, userWriteMask);
 }
 
@@ -355,7 +357,7 @@ inline auto writeUserWriteMaskAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Result<bool> readIsAbstract(T& connection, const NodeId& id) {
+inline Result<bool> readIsAbstract(T& connection, const NodeId& id) noexcept {
     return detail::readAttributeImpl<AttributeId::IsAbstract>(connection, id);
 }
 
@@ -382,7 +384,7 @@ inline auto readIsAbstractAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeIsAbstract(T& connection, const NodeId& id, bool isAbstract) {
+inline Result<void> writeIsAbstract(T& connection, const NodeId& id, bool isAbstract) noexcept {
     return detail::writeAttributeImpl<AttributeId::IsAbstract>(connection, id, isAbstract);
 }
 
@@ -411,7 +413,7 @@ inline auto writeIsAbstractAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Result<bool> readSymmetric(T& connection, const NodeId& id) {
+inline Result<bool> readSymmetric(T& connection, const NodeId& id) noexcept {
     return detail::readAttributeImpl<AttributeId::Symmetric>(connection, id);
 }
 
@@ -438,7 +440,7 @@ inline auto readSymmetricAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeSymmetric(T& connection, const NodeId& id, bool symmetric) {
+inline Result<void> writeSymmetric(T& connection, const NodeId& id, bool symmetric) noexcept {
     return detail::writeAttributeImpl<AttributeId::Symmetric>(connection, id, symmetric);
 }
 
@@ -467,7 +469,7 @@ inline auto writeSymmetricAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Result<LocalizedText> readInverseName(T& connection, const NodeId& id) {
+inline Result<LocalizedText> readInverseName(T& connection, const NodeId& id) noexcept {
     return detail::readAttributeImpl<AttributeId::InverseName>(connection, id);
 }
 
@@ -496,7 +498,7 @@ inline auto readInverseNameAsync(
 template <typename T>
 inline Result<void> writeInverseName(
     T& connection, const NodeId& id, const LocalizedText& inverseName
-) {
+) noexcept {
     return detail::writeAttributeImpl<AttributeId::InverseName>(connection, id, inverseName);
 }
 
@@ -525,7 +527,7 @@ inline auto writeInverseNameAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Result<bool> readContainsNoLoops(T& connection, const NodeId& id) {
+inline Result<bool> readContainsNoLoops(T& connection, const NodeId& id) noexcept {
     return detail::readAttributeImpl<AttributeId::ContainsNoLoops>(connection, id);
 }
 
@@ -554,7 +556,7 @@ inline auto readContainsNoLoopsAsync(
 template <typename T>
 inline Result<void> writeContainsNoLoops(
     T& connection, const NodeId& id, const bool& containsNoLoops
-) {
+) noexcept {
     return detail::writeAttributeImpl<AttributeId::ContainsNoLoops>(
         connection, id, containsNoLoops
     );
@@ -585,7 +587,7 @@ inline auto writeContainsNoLoopsAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Result<Bitmask<EventNotifier>> readEventNotifier(T& connection, const NodeId& id) {
+inline Result<Bitmask<EventNotifier>> readEventNotifier(T& connection, const NodeId& id) noexcept {
     return detail::readAttributeImpl<AttributeId::EventNotifier>(connection, id);
 }
 
@@ -614,7 +616,7 @@ inline auto readEventNotifierAsync(
 template <typename T>
 inline Result<void> writeEventNotifier(
     T& connection, const NodeId& id, Bitmask<EventNotifier> eventNotifier
-) {
+) noexcept {
     return detail::writeAttributeImpl<AttributeId::EventNotifier>(connection, id, eventNotifier);
 }
 
@@ -643,7 +645,7 @@ inline auto writeEventNotifierAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Result<Variant> readValue(T& connection, const NodeId& id) {
+inline Result<Variant> readValue(T& connection, const NodeId& id) noexcept {
     return detail::readAttributeImpl<AttributeId::Value>(connection, id);
 }
 
@@ -670,7 +672,7 @@ inline auto readValueAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeValue(T& connection, const NodeId& id, const Variant& value) {
+inline Result<void> writeValue(T& connection, const NodeId& id, const Variant& value) noexcept {
     return detail::writeAttributeImpl<AttributeId::Value>(connection, id, value);
 }
 
@@ -699,7 +701,7 @@ inline auto writeValueAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Result<NodeId> readDataType(T& connection, const NodeId& id) {
+inline Result<NodeId> readDataType(T& connection, const NodeId& id) noexcept {
     return detail::readAttributeImpl<AttributeId::DataType>(connection, id);
 }
 
@@ -726,7 +728,9 @@ inline auto readDataTypeAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeDataType(T& connection, const NodeId& id, const NodeId& dataType) {
+inline Result<void> writeDataType(
+    T& connection, const NodeId& id, const NodeId& dataType
+) noexcept {
     return detail::writeAttributeImpl<AttributeId::DataType>(connection, id, dataType);
 }
 
@@ -755,7 +759,7 @@ inline auto writeDataTypeAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Result<ValueRank> readValueRank(T& connection, const NodeId& id) {
+inline Result<ValueRank> readValueRank(T& connection, const NodeId& id) noexcept {
     return detail::readAttributeImpl<AttributeId::ValueRank>(connection, id);
 }
 
@@ -782,7 +786,7 @@ inline auto readValueRankAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeValueRank(T& connection, const NodeId& id, ValueRank valueRank) {
+inline Result<void> writeValueRank(T& connection, const NodeId& id, ValueRank valueRank) noexcept {
     return detail::writeAttributeImpl<AttributeId::ValueRank>(connection, id, valueRank);
 }
 
@@ -811,7 +815,7 @@ inline auto writeValueRankAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Result<std::vector<uint32_t>> readArrayDimensions(T& connection, const NodeId& id) {
+inline Result<std::vector<uint32_t>> readArrayDimensions(T& connection, const NodeId& id) noexcept {
     return detail::readAttributeImpl<AttributeId::ArrayDimensions>(connection, id);
 }
 
@@ -840,7 +844,7 @@ inline auto readArrayDimensionsAsync(
 template <typename T>
 inline Result<void> writeArrayDimensions(
     T& connection, const NodeId& id, Span<const uint32_t> arrayDimensions
-) {
+) noexcept {
     return detail::writeAttributeImpl<AttributeId::ArrayDimensions>(
         connection, id, arrayDimensions
     );
@@ -871,7 +875,7 @@ inline auto writeArrayDimensionsAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Result<Bitmask<AccessLevel>> readAccessLevel(T& connection, const NodeId& id) {
+inline Result<Bitmask<AccessLevel>> readAccessLevel(T& connection, const NodeId& id) noexcept {
     return detail::readAttributeImpl<AttributeId::AccessLevel>(connection, id);
 }
 
@@ -900,7 +904,7 @@ inline auto readAccessLevelAsync(
 template <typename T>
 inline Result<void> writeAccessLevel(
     T& connection, const NodeId& id, Bitmask<AccessLevel> accessLevel
-) {
+) noexcept {
     return detail::writeAttributeImpl<AttributeId::AccessLevel>(connection, id, accessLevel);
 }
 
@@ -929,7 +933,7 @@ inline auto writeAccessLevelAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Result<Bitmask<AccessLevel>> readUserAccessLevel(T& connection, const NodeId& id) {
+inline Result<Bitmask<AccessLevel>> readUserAccessLevel(T& connection, const NodeId& id) noexcept {
     return detail::readAttributeImpl<AttributeId::UserAccessLevel>(connection, id);
 }
 
@@ -958,7 +962,7 @@ inline auto readUserAccessLevelAsync(
 template <typename T>
 inline Result<void> writeUserAccessLevel(
     T& connection, const NodeId& id, Bitmask<AccessLevel> userAccessLevel
-) {
+) noexcept {
     return detail::writeAttributeImpl<AttributeId::UserAccessLevel>(
         connection, id, userAccessLevel
     );
@@ -989,7 +993,7 @@ inline auto writeUserAccessLevelAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Result<double> readMinimumSamplingInterval(T& connection, const NodeId& id) {
+inline Result<double> readMinimumSamplingInterval(T& connection, const NodeId& id) noexcept {
     return detail::readAttributeImpl<AttributeId::MinimumSamplingInterval>(connection, id);
 }
 
@@ -1018,7 +1022,7 @@ inline auto readMinimumSamplingIntervalAsync(
 template <typename T>
 inline Result<void> writeMinimumSamplingInterval(
     T& connection, const NodeId& id, double minimumSamplingInterval
-) {
+) noexcept {
     return detail::writeAttributeImpl<AttributeId::MinimumSamplingInterval>(
         connection, id, minimumSamplingInterval
     );
@@ -1049,7 +1053,7 @@ inline auto writeMinimumSamplingIntervalAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Result<bool> readHistorizing(T& connection, const NodeId& id) {
+inline Result<bool> readHistorizing(T& connection, const NodeId& id) noexcept {
     return detail::readAttributeImpl<AttributeId::Historizing>(connection, id);
 }
 
@@ -1076,7 +1080,7 @@ inline auto readHistorizingAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeHistorizing(T& connection, const NodeId& id, bool historizing) {
+inline Result<void> writeHistorizing(T& connection, const NodeId& id, bool historizing) noexcept {
     return detail::writeAttributeImpl<AttributeId::Historizing>(connection, id, historizing);
 }
 
@@ -1105,7 +1109,7 @@ inline auto writeHistorizingAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Result<bool> readExecutable(T& connection, const NodeId& id) {
+inline Result<bool> readExecutable(T& connection, const NodeId& id) noexcept {
     return detail::readAttributeImpl<AttributeId::Executable>(connection, id);
 }
 
@@ -1132,7 +1136,7 @@ inline auto readExecutableAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeExecutable(T& connection, const NodeId& id, bool executable) {
+inline Result<void> writeExecutable(T& connection, const NodeId& id, bool executable) noexcept {
     return detail::writeAttributeImpl<AttributeId::Executable>(connection, id, executable);
 }
 
@@ -1161,7 +1165,7 @@ inline auto writeExecutableAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Result<bool> readUserExecutable(T& connection, const NodeId& id) {
+inline Result<bool> readUserExecutable(T& connection, const NodeId& id) noexcept {
     return detail::readAttributeImpl<AttributeId::UserExecutable>(connection, id);
 }
 
@@ -1188,7 +1192,9 @@ inline auto readUserExecutableAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeUserExecutable(T& connection, const NodeId& id, bool userExecutable) {
+inline Result<void> writeUserExecutable(
+    T& connection, const NodeId& id, bool userExecutable
+) noexcept {
     return detail::writeAttributeImpl<AttributeId::UserExecutable>(connection, id, userExecutable);
 }
 

--- a/include/open62541pp/services/Attribute_highlevel.h
+++ b/include/open62541pp/services/Attribute_highlevel.h
@@ -15,7 +15,7 @@ namespace opcua::services {
  * @ingroup Read
  */
 template <typename T>
-inline NodeId readNodeId(T& connection, const NodeId& id) {
+inline Result<NodeId> readNodeId(T& connection, const NodeId& id) {
     return detail::readAttributeImpl<AttributeId::NodeId>(connection, id);
 }
 
@@ -41,7 +41,7 @@ inline auto readNodeIdAsync(
  * @ingroup Read
  */
 template <typename T>
-inline NodeClass readNodeClass(T& connection, const NodeId& id) {
+inline Result<NodeClass> readNodeClass(T& connection, const NodeId& id) {
     return detail::readAttributeImpl<AttributeId::NodeClass>(connection, id);
 }
 
@@ -67,7 +67,7 @@ inline auto readNodeClassAsync(
  * @ingroup Read
  */
 template <typename T>
-inline QualifiedName readBrowseName(T& connection, const NodeId& id) {
+inline Result<QualifiedName> readBrowseName(T& connection, const NodeId& id) {
     return detail::readAttributeImpl<AttributeId::BrowseName>(connection, id);
 }
 
@@ -94,8 +94,10 @@ inline auto readBrowseNameAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeBrowseName(T& connection, const NodeId& id, const QualifiedName& browseName) {
-    detail::writeAttributeImpl<AttributeId::BrowseName>(connection, id, browseName);
+inline Result<void> writeBrowseName(
+    T& connection, const NodeId& id, const QualifiedName& browseName
+) {
+    return detail::writeAttributeImpl<AttributeId::BrowseName>(connection, id, browseName);
 }
 
 /**
@@ -111,7 +113,7 @@ inline auto writeBrowseNameAsync(
     const QualifiedName& browseName,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
-    detail::writeAttributeAsyncImpl<AttributeId::BrowseName>(
+    return detail::writeAttributeAsyncImpl<AttributeId::BrowseName>(
         connection, id, browseName, std::forward<CompletionToken>(token)
     );
 }
@@ -123,7 +125,7 @@ inline auto writeBrowseNameAsync(
  * @ingroup Read
  */
 template <typename T>
-inline LocalizedText readDisplayName(T& connection, const NodeId& id) {
+inline Result<LocalizedText> readDisplayName(T& connection, const NodeId& id) {
     return detail::readAttributeImpl<AttributeId::DisplayName>(connection, id);
 }
 
@@ -150,8 +152,10 @@ inline auto readDisplayNameAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeDisplayName(T& connection, const NodeId& id, const LocalizedText& displayName) {
-    detail::writeAttributeImpl<AttributeId::DisplayName>(connection, id, displayName);
+inline Result<void> writeDisplayName(
+    T& connection, const NodeId& id, const LocalizedText& displayName
+) {
+    return detail::writeAttributeImpl<AttributeId::DisplayName>(connection, id, displayName);
 }
 
 /**
@@ -167,7 +171,7 @@ inline auto writeDisplayNameAsync(
     const LocalizedText& displayName,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
-    detail::writeAttributeAsyncImpl<AttributeId::DisplayName>(
+    return detail::writeAttributeAsyncImpl<AttributeId::DisplayName>(
         connection, id, displayName, std::forward<CompletionToken>(token)
     );
 }
@@ -179,7 +183,7 @@ inline auto writeDisplayNameAsync(
  * @ingroup Read
  */
 template <typename T>
-inline LocalizedText readDescription(T& connection, const NodeId& id) {
+inline Result<LocalizedText> readDescription(T& connection, const NodeId& id) {
     return detail::readAttributeImpl<AttributeId::Description>(connection, id);
 }
 
@@ -206,8 +210,10 @@ inline auto readDescriptionAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeDescription(T& connection, const NodeId& id, const LocalizedText& description) {
-    detail::writeAttributeImpl<AttributeId::Description>(connection, id, description);
+inline Result<void> writeDescription(
+    T& connection, const NodeId& id, const LocalizedText& description
+) {
+    return detail::writeAttributeImpl<AttributeId::Description>(connection, id, description);
 }
 
 /**
@@ -223,7 +229,7 @@ inline auto writeDescriptionAsync(
     const LocalizedText& description,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
-    detail::writeAttributeAsyncImpl<AttributeId::Description>(
+    return detail::writeAttributeAsyncImpl<AttributeId::Description>(
         connection, id, description, std::forward<CompletionToken>(token)
     );
 }
@@ -235,7 +241,7 @@ inline auto writeDescriptionAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Bitmask<WriteMask> readWriteMask(T& connection, const NodeId& id) {
+inline Result<Bitmask<WriteMask>> readWriteMask(T& connection, const NodeId& id) {
     return detail::readAttributeImpl<AttributeId::WriteMask>(connection, id);
 }
 
@@ -262,8 +268,8 @@ inline auto readWriteMaskAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeWriteMask(T& connection, const NodeId& id, Bitmask<WriteMask> writeMask) {
-    detail::writeAttributeImpl<AttributeId::WriteMask>(connection, id, writeMask);
+inline Result<void> writeWriteMask(T& connection, const NodeId& id, Bitmask<WriteMask> writeMask) {
+    return detail::writeAttributeImpl<AttributeId::WriteMask>(connection, id, writeMask);
 }
 
 /**
@@ -279,7 +285,7 @@ inline auto writeWriteMaskAsync(
     Bitmask<WriteMask> writeMask,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
-    detail::writeAttributeAsyncImpl<AttributeId::WriteMask>(
+    return detail::writeAttributeAsyncImpl<AttributeId::WriteMask>(
         connection, id, writeMask, std::forward<CompletionToken>(token)
     );
 }
@@ -291,7 +297,7 @@ inline auto writeWriteMaskAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Bitmask<WriteMask> readUserWriteMask(T& connection, const NodeId& id) {
+inline Result<Bitmask<WriteMask>> readUserWriteMask(T& connection, const NodeId& id) {
     return detail::readAttributeImpl<AttributeId::UserWriteMask>(connection, id);
 }
 
@@ -318,8 +324,10 @@ inline auto readUserWriteMaskAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeUserWriteMask(T& connection, const NodeId& id, Bitmask<WriteMask> userWriteMask) {
-    detail::writeAttributeImpl<AttributeId::UserWriteMask>(connection, id, userWriteMask);
+inline Result<void> writeUserWriteMask(
+    T& connection, const NodeId& id, Bitmask<WriteMask> userWriteMask
+) {
+    return detail::writeAttributeImpl<AttributeId::UserWriteMask>(connection, id, userWriteMask);
 }
 
 /**
@@ -335,7 +343,7 @@ inline auto writeUserWriteMaskAsync(
     Bitmask<WriteMask> userWriteMask,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
-    detail::writeAttributeAsyncImpl<AttributeId::UserWriteMask>(
+    return detail::writeAttributeAsyncImpl<AttributeId::UserWriteMask>(
         connection, id, userWriteMask, std::forward<CompletionToken>(token)
     );
 }
@@ -347,7 +355,7 @@ inline auto writeUserWriteMaskAsync(
  * @ingroup Read
  */
 template <typename T>
-inline bool readIsAbstract(T& connection, const NodeId& id) {
+inline Result<bool> readIsAbstract(T& connection, const NodeId& id) {
     return detail::readAttributeImpl<AttributeId::IsAbstract>(connection, id);
 }
 
@@ -374,8 +382,8 @@ inline auto readIsAbstractAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeIsAbstract(T& connection, const NodeId& id, bool isAbstract) {
-    detail::writeAttributeImpl<AttributeId::IsAbstract>(connection, id, isAbstract);
+inline Result<void> writeIsAbstract(T& connection, const NodeId& id, bool isAbstract) {
+    return detail::writeAttributeImpl<AttributeId::IsAbstract>(connection, id, isAbstract);
 }
 
 /**
@@ -391,7 +399,7 @@ inline auto writeIsAbstractAsync(
     bool isAbstract,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
-    detail::writeAttributeAsyncImpl<AttributeId::IsAbstract>(
+    return detail::writeAttributeAsyncImpl<AttributeId::IsAbstract>(
         connection, id, isAbstract, std::forward<CompletionToken>(token)
     );
 }
@@ -403,7 +411,7 @@ inline auto writeIsAbstractAsync(
  * @ingroup Read
  */
 template <typename T>
-inline bool readSymmetric(T& connection, const NodeId& id) {
+inline Result<bool> readSymmetric(T& connection, const NodeId& id) {
     return detail::readAttributeImpl<AttributeId::Symmetric>(connection, id);
 }
 
@@ -430,8 +438,8 @@ inline auto readSymmetricAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeSymmetric(T& connection, const NodeId& id, bool symmetric) {
-    detail::writeAttributeImpl<AttributeId::Symmetric>(connection, id, symmetric);
+inline Result<void> writeSymmetric(T& connection, const NodeId& id, bool symmetric) {
+    return detail::writeAttributeImpl<AttributeId::Symmetric>(connection, id, symmetric);
 }
 
 /**
@@ -447,7 +455,7 @@ inline auto writeSymmetricAsync(
     bool symmetric,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
-    detail::writeAttributeAsyncImpl<AttributeId::Symmetric>(
+    return detail::writeAttributeAsyncImpl<AttributeId::Symmetric>(
         connection, id, symmetric, std::forward<CompletionToken>(token)
     );
 }
@@ -459,7 +467,7 @@ inline auto writeSymmetricAsync(
  * @ingroup Read
  */
 template <typename T>
-inline LocalizedText readInverseName(T& connection, const NodeId& id) {
+inline Result<LocalizedText> readInverseName(T& connection, const NodeId& id) {
     return detail::readAttributeImpl<AttributeId::InverseName>(connection, id);
 }
 
@@ -486,8 +494,10 @@ inline auto readInverseNameAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeInverseName(T& connection, const NodeId& id, const LocalizedText& inverseName) {
-    detail::writeAttributeImpl<AttributeId::InverseName>(connection, id, inverseName);
+inline Result<void> writeInverseName(
+    T& connection, const NodeId& id, const LocalizedText& inverseName
+) {
+    return detail::writeAttributeImpl<AttributeId::InverseName>(connection, id, inverseName);
 }
 
 /**
@@ -503,7 +513,7 @@ inline auto writeInverseNameAsync(
     const LocalizedText& inverseName,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
-    detail::writeAttributeAsyncImpl<AttributeId::InverseName>(
+    return detail::writeAttributeAsyncImpl<AttributeId::InverseName>(
         connection, id, inverseName, std::forward<CompletionToken>(token)
     );
 }
@@ -515,7 +525,7 @@ inline auto writeInverseNameAsync(
  * @ingroup Read
  */
 template <typename T>
-inline bool readContainsNoLoops(T& connection, const NodeId& id) {
+inline Result<bool> readContainsNoLoops(T& connection, const NodeId& id) {
     return detail::readAttributeImpl<AttributeId::ContainsNoLoops>(connection, id);
 }
 
@@ -542,8 +552,12 @@ inline auto readContainsNoLoopsAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeContainsNoLoops(T& connection, const NodeId& id, const bool& containsNoLoops) {
-    detail::writeAttributeImpl<AttributeId::ContainsNoLoops>(connection, id, containsNoLoops);
+inline Result<void> writeContainsNoLoops(
+    T& connection, const NodeId& id, const bool& containsNoLoops
+) {
+    return detail::writeAttributeImpl<AttributeId::ContainsNoLoops>(
+        connection, id, containsNoLoops
+    );
 }
 
 /**
@@ -559,7 +573,7 @@ inline auto writeContainsNoLoopsAsync(
     const bool& containsNoLoops,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
-    detail::writeAttributeAsyncImpl<AttributeId::ContainsNoLoops>(
+    return detail::writeAttributeAsyncImpl<AttributeId::ContainsNoLoops>(
         connection, id, containsNoLoops, std::forward<CompletionToken>(token)
     );
 }
@@ -571,7 +585,7 @@ inline auto writeContainsNoLoopsAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Bitmask<EventNotifier> readEventNotifier(T& connection, const NodeId& id) {
+inline Result<Bitmask<EventNotifier>> readEventNotifier(T& connection, const NodeId& id) {
     return detail::readAttributeImpl<AttributeId::EventNotifier>(connection, id);
 }
 
@@ -598,10 +612,10 @@ inline auto readEventNotifierAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeEventNotifier(
+inline Result<void> writeEventNotifier(
     T& connection, const NodeId& id, Bitmask<EventNotifier> eventNotifier
 ) {
-    detail::writeAttributeImpl<AttributeId::EventNotifier>(connection, id, eventNotifier);
+    return detail::writeAttributeImpl<AttributeId::EventNotifier>(connection, id, eventNotifier);
 }
 
 /**
@@ -617,7 +631,7 @@ inline auto writeEventNotifierAsync(
     Bitmask<EventNotifier> eventNotifier,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
-    detail::writeAttributeAsyncImpl<AttributeId::EventNotifier>(
+    return detail::writeAttributeAsyncImpl<AttributeId::EventNotifier>(
         connection, id, eventNotifier, std::forward<CompletionToken>(token)
     );
 }
@@ -629,7 +643,7 @@ inline auto writeEventNotifierAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Variant readValue(T& connection, const NodeId& id) {
+inline Result<Variant> readValue(T& connection, const NodeId& id) {
     return detail::readAttributeImpl<AttributeId::Value>(connection, id);
 }
 
@@ -656,8 +670,8 @@ inline auto readValueAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeValue(T& connection, const NodeId& id, const Variant& value) {
-    detail::writeAttributeImpl<AttributeId::Value>(connection, id, value);
+inline Result<void> writeValue(T& connection, const NodeId& id, const Variant& value) {
+    return detail::writeAttributeImpl<AttributeId::Value>(connection, id, value);
 }
 
 /**
@@ -673,7 +687,7 @@ inline auto writeValueAsync(
     const Variant& value,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
-    detail::writeAttributeAsyncImpl<AttributeId::Value>(
+    return detail::writeAttributeAsyncImpl<AttributeId::Value>(
         connection, id, value, std::forward<CompletionToken>(token)
     );
 }
@@ -685,7 +699,7 @@ inline auto writeValueAsync(
  * @ingroup Read
  */
 template <typename T>
-inline NodeId readDataType(T& connection, const NodeId& id) {
+inline Result<NodeId> readDataType(T& connection, const NodeId& id) {
     return detail::readAttributeImpl<AttributeId::DataType>(connection, id);
 }
 
@@ -712,8 +726,8 @@ inline auto readDataTypeAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeDataType(T& connection, const NodeId& id, const NodeId& dataType) {
-    detail::writeAttributeImpl<AttributeId::DataType>(connection, id, dataType);
+inline Result<void> writeDataType(T& connection, const NodeId& id, const NodeId& dataType) {
+    return detail::writeAttributeImpl<AttributeId::DataType>(connection, id, dataType);
 }
 
 /**
@@ -729,7 +743,7 @@ inline auto writeDataTypeAsync(
     const NodeId& dataType,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
-    detail::writeAttributeAsyncImpl<AttributeId::DataType>(
+    return detail::writeAttributeAsyncImpl<AttributeId::DataType>(
         connection, id, dataType, std::forward<CompletionToken>(token)
     );
 }
@@ -741,7 +755,7 @@ inline auto writeDataTypeAsync(
  * @ingroup Read
  */
 template <typename T>
-inline ValueRank readValueRank(T& connection, const NodeId& id) {
+inline Result<ValueRank> readValueRank(T& connection, const NodeId& id) {
     return detail::readAttributeImpl<AttributeId::ValueRank>(connection, id);
 }
 
@@ -768,8 +782,8 @@ inline auto readValueRankAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeValueRank(T& connection, const NodeId& id, ValueRank valueRank) {
-    detail::writeAttributeImpl<AttributeId::ValueRank>(connection, id, valueRank);
+inline Result<void> writeValueRank(T& connection, const NodeId& id, ValueRank valueRank) {
+    return detail::writeAttributeImpl<AttributeId::ValueRank>(connection, id, valueRank);
 }
 
 /**
@@ -785,7 +799,7 @@ inline auto writeValueRankAsync(
     ValueRank valueRank,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
-    detail::writeAttributeAsyncImpl<AttributeId::ValueRank>(
+    return detail::writeAttributeAsyncImpl<AttributeId::ValueRank>(
         connection, id, valueRank, std::forward<CompletionToken>(token)
     );
 }
@@ -797,7 +811,7 @@ inline auto writeValueRankAsync(
  * @ingroup Read
  */
 template <typename T>
-inline std::vector<uint32_t> readArrayDimensions(T& connection, const NodeId& id) {
+inline Result<std::vector<uint32_t>> readArrayDimensions(T& connection, const NodeId& id) {
     return detail::readAttributeImpl<AttributeId::ArrayDimensions>(connection, id);
 }
 
@@ -824,10 +838,12 @@ inline auto readArrayDimensionsAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeArrayDimensions(
+inline Result<void> writeArrayDimensions(
     T& connection, const NodeId& id, Span<const uint32_t> arrayDimensions
 ) {
-    detail::writeAttributeImpl<AttributeId::ArrayDimensions>(connection, id, arrayDimensions);
+    return detail::writeAttributeImpl<AttributeId::ArrayDimensions>(
+        connection, id, arrayDimensions
+    );
 }
 
 /**
@@ -843,7 +859,7 @@ inline auto writeArrayDimensionsAsync(
     Span<const uint32_t> arrayDimensions,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
-    detail::writeAttributeAsyncImpl<AttributeId::ArrayDimensions>(
+    return detail::writeAttributeAsyncImpl<AttributeId::ArrayDimensions>(
         connection, id, arrayDimensions, std::forward<CompletionToken>(token)
     );
 }
@@ -855,7 +871,7 @@ inline auto writeArrayDimensionsAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Bitmask<AccessLevel> readAccessLevel(T& connection, const NodeId& id) {
+inline Result<Bitmask<AccessLevel>> readAccessLevel(T& connection, const NodeId& id) {
     return detail::readAttributeImpl<AttributeId::AccessLevel>(connection, id);
 }
 
@@ -882,8 +898,10 @@ inline auto readAccessLevelAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeAccessLevel(T& connection, const NodeId& id, Bitmask<AccessLevel> accessLevel) {
-    detail::writeAttributeImpl<AttributeId::AccessLevel>(connection, id, accessLevel);
+inline Result<void> writeAccessLevel(
+    T& connection, const NodeId& id, Bitmask<AccessLevel> accessLevel
+) {
+    return detail::writeAttributeImpl<AttributeId::AccessLevel>(connection, id, accessLevel);
 }
 
 /**
@@ -899,7 +917,7 @@ inline auto writeAccessLevelAsync(
     Bitmask<AccessLevel> accessLevel,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
-    detail::writeAttributeAsyncImpl<AttributeId::AccessLevel>(
+    return detail::writeAttributeAsyncImpl<AttributeId::AccessLevel>(
         connection, id, accessLevel, std::forward<CompletionToken>(token)
     );
 }
@@ -911,7 +929,7 @@ inline auto writeAccessLevelAsync(
  * @ingroup Read
  */
 template <typename T>
-inline Bitmask<AccessLevel> readUserAccessLevel(T& connection, const NodeId& id) {
+inline Result<Bitmask<AccessLevel>> readUserAccessLevel(T& connection, const NodeId& id) {
     return detail::readAttributeImpl<AttributeId::UserAccessLevel>(connection, id);
 }
 
@@ -938,10 +956,12 @@ inline auto readUserAccessLevelAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeUserAccessLevel(
+inline Result<void> writeUserAccessLevel(
     T& connection, const NodeId& id, Bitmask<AccessLevel> userAccessLevel
 ) {
-    detail::writeAttributeImpl<AttributeId::UserAccessLevel>(connection, id, userAccessLevel);
+    return detail::writeAttributeImpl<AttributeId::UserAccessLevel>(
+        connection, id, userAccessLevel
+    );
 }
 
 /**
@@ -957,7 +977,7 @@ inline auto writeUserAccessLevelAsync(
     Bitmask<AccessLevel> userAccessLevel,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
-    detail::writeAttributeAsyncImpl<AttributeId::UserAccessLevel>(
+    return detail::writeAttributeAsyncImpl<AttributeId::UserAccessLevel>(
         connection, id, userAccessLevel, std::forward<CompletionToken>(token)
     );
 }
@@ -969,7 +989,7 @@ inline auto writeUserAccessLevelAsync(
  * @ingroup Read
  */
 template <typename T>
-inline double readMinimumSamplingInterval(T& connection, const NodeId& id) {
+inline Result<double> readMinimumSamplingInterval(T& connection, const NodeId& id) {
     return detail::readAttributeImpl<AttributeId::MinimumSamplingInterval>(connection, id);
 }
 
@@ -996,10 +1016,10 @@ inline auto readMinimumSamplingIntervalAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeMinimumSamplingInterval(
+inline Result<void> writeMinimumSamplingInterval(
     T& connection, const NodeId& id, double minimumSamplingInterval
 ) {
-    detail::writeAttributeImpl<AttributeId::MinimumSamplingInterval>(
+    return detail::writeAttributeImpl<AttributeId::MinimumSamplingInterval>(
         connection, id, minimumSamplingInterval
     );
 }
@@ -1017,7 +1037,7 @@ inline auto writeMinimumSamplingIntervalAsync(
     double minimumSamplingInterval,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
-    detail::writeAttributeAsyncImpl<AttributeId::MinimumSamplingInterval>(
+    return detail::writeAttributeAsyncImpl<AttributeId::MinimumSamplingInterval>(
         connection, id, minimumSamplingInterval, std::forward<CompletionToken>(token)
     );
 }
@@ -1029,7 +1049,7 @@ inline auto writeMinimumSamplingIntervalAsync(
  * @ingroup Read
  */
 template <typename T>
-inline bool readHistorizing(T& connection, const NodeId& id) {
+inline Result<bool> readHistorizing(T& connection, const NodeId& id) {
     return detail::readAttributeImpl<AttributeId::Historizing>(connection, id);
 }
 
@@ -1056,8 +1076,8 @@ inline auto readHistorizingAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeHistorizing(T& connection, const NodeId& id, bool historizing) {
-    detail::writeAttributeImpl<AttributeId::Historizing>(connection, id, historizing);
+inline Result<void> writeHistorizing(T& connection, const NodeId& id, bool historizing) {
+    return detail::writeAttributeImpl<AttributeId::Historizing>(connection, id, historizing);
 }
 
 /**
@@ -1073,7 +1093,7 @@ inline auto writeHistorizingAsync(
     bool historizing,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
-    detail::writeAttributeAsyncImpl<AttributeId::Historizing>(
+    return detail::writeAttributeAsyncImpl<AttributeId::Historizing>(
         connection, id, historizing, std::forward<CompletionToken>(token)
     );
 }
@@ -1085,7 +1105,7 @@ inline auto writeHistorizingAsync(
  * @ingroup Read
  */
 template <typename T>
-inline bool readExecutable(T& connection, const NodeId& id) {
+inline Result<bool> readExecutable(T& connection, const NodeId& id) {
     return detail::readAttributeImpl<AttributeId::Executable>(connection, id);
 }
 
@@ -1112,8 +1132,8 @@ inline auto readExecutableAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeExecutable(T& connection, const NodeId& id, bool executable) {
-    detail::writeAttributeImpl<AttributeId::Executable>(connection, id, executable);
+inline Result<void> writeExecutable(T& connection, const NodeId& id, bool executable) {
+    return detail::writeAttributeImpl<AttributeId::Executable>(connection, id, executable);
 }
 
 /**
@@ -1129,7 +1149,7 @@ inline auto writeExecutableAsync(
     bool executable,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
-    detail::writeAttributeAsyncImpl<AttributeId::Executable>(
+    return detail::writeAttributeAsyncImpl<AttributeId::Executable>(
         connection, id, executable, std::forward<CompletionToken>(token)
     );
 }
@@ -1141,7 +1161,7 @@ inline auto writeExecutableAsync(
  * @ingroup Read
  */
 template <typename T>
-inline bool readUserExecutable(T& connection, const NodeId& id) {
+inline Result<bool> readUserExecutable(T& connection, const NodeId& id) {
     return detail::readAttributeImpl<AttributeId::UserExecutable>(connection, id);
 }
 
@@ -1168,8 +1188,8 @@ inline auto readUserExecutableAsync(
  * @ingroup Write
  */
 template <typename T>
-inline void writeUserExecutable(T& connection, const NodeId& id, bool userExecutable) {
-    detail::writeAttributeImpl<AttributeId::UserExecutable>(connection, id, userExecutable);
+inline Result<void> writeUserExecutable(T& connection, const NodeId& id, bool userExecutable) {
+    return detail::writeAttributeImpl<AttributeId::UserExecutable>(connection, id, userExecutable);
 }
 
 /**
@@ -1185,7 +1205,7 @@ inline auto writeUserExecutableAsync(
     bool userExecutable,
     CompletionToken&& token = DefaultCompletionToken()
 ) {
-    detail::writeAttributeAsyncImpl<AttributeId::UserExecutable>(
+    return detail::writeAttributeAsyncImpl<AttributeId::UserExecutable>(
         connection, id, userExecutable, std::forward<CompletionToken>(token)
     );
 }

--- a/include/open62541pp/services/Method.h
+++ b/include/open62541pp/services/Method.h
@@ -37,7 +37,7 @@ namespace opcua::services {
  * @param connection Instance of type Client
  * @param request Call request
  */
-CallResponse call(Client& connection, const CallRequest& request);
+CallResponse call(Client& connection, const CallRequest& request) noexcept;
 
 /**
  * Asynchronously call server methods.
@@ -74,7 +74,7 @@ Result<std::vector<Variant>> call(
     const NodeId& objectId,
     const NodeId& methodId,
     Span<const Variant> inputArguments
-);
+) noexcept;
 
 /**
  * Asynchronously call a server method and return outputs.

--- a/include/open62541pp/services/Method.h
+++ b/include/open62541pp/services/Method.h
@@ -5,6 +5,7 @@
 
 #include "open62541pp/Client.h"
 #include "open62541pp/Config.h"
+#include "open62541pp/Result.h"
 #include "open62541pp/Span.h"
 #include "open62541pp/async.h"
 #include "open62541pp/services/detail/ClientService.h"
@@ -41,7 +42,7 @@ CallResponse call(Client& connection, const CallRequest& request);
 /**
  * Asynchronously call server methods.
  * @copydetails call
- * @param token @completiontoken{void(Result<CallResponse>&)}
+ * @param token @completiontoken{void(CallResponse&)}
  */
 template <typename CompletionToken = DefaultCompletionToken>
 auto callAsync(
@@ -50,10 +51,7 @@ auto callAsync(
     CompletionToken&& token = DefaultCompletionToken()
 ) {
     return detail::sendRequest<UA_CallRequest, UA_CallResponse>(
-        connection,
-        request,
-        detail::WrapResponse<CallResponse>{},
-        std::forward<CompletionToken>(token)
+        connection, request, detail::Wrap<CallResponse>{}, std::forward<CompletionToken>(token)
     );
 }
 
@@ -71,7 +69,7 @@ auto callAsync(
  * @exception BadStatus (BadTooManyArguments) If too many input arguments provided
  */
 template <typename T>
-std::vector<Variant> call(
+Result<std::vector<Variant>> call(
     T& connection,
     const NodeId& objectId,
     const NodeId& methodId,
@@ -104,7 +102,7 @@ auto callAsync(
         connection,
         request,
         [](UA_CallResponse& response) {
-            return detail::getOutputArguments(detail::getSingleResult(response));
+            return detail::getSingleResult(response).andThen(detail::getOutputArguments);
         },
         std::forward<CompletionToken>(token)
     );

--- a/include/open62541pp/services/MonitoredItem.h
+++ b/include/open62541pp/services/MonitoredItem.h
@@ -5,6 +5,7 @@
 
 #include "open62541pp/Common.h"  // TimestampsToReturn, MonitoringMode
 #include "open62541pp/Config.h"
+#include "open62541pp/Result.h"
 #include "open62541pp/Span.h"
 #include "open62541pp/types/ExtensionObject.h"
 
@@ -124,7 +125,7 @@ using EventNotificationCallback =
  * @param deleteCallback Invoked when the monitored item is deleted
  */
 template <typename T>
-[[nodiscard]] uint32_t createMonitoredItemDataChange(
+[[nodiscard]] Result<uint32_t> createMonitoredItemDataChange(
     T& connection,
     uint32_t subscriptionId,
     const ReadValueId& itemToMonitor,
@@ -146,7 +147,7 @@ template <typename T>
  * @param parameters Monitoring parameters, may be revised by server
  * @param dataChangeCallback Invoked when the monitored item is changed
  */
-[[nodiscard]] uint32_t createMonitoredItemDataChange(
+[[nodiscard]] Result<uint32_t> createMonitoredItemDataChange(
     Server& connection,
     const ReadValueId& itemToMonitor,
     MonitoringMode monitoringMode,
@@ -168,7 +169,7 @@ template <typename T>
  * @param eventCallback Invoked when an event is published
  * @param deleteCallback Invoked when the monitored item is deleted
  */
-[[nodiscard]] uint32_t createMonitoredItemEvent(
+[[nodiscard]] Result<uint32_t> createMonitoredItemEvent(
     Client& connection,
     uint32_t subscriptionId,
     const ReadValueId& itemToMonitor,
@@ -195,7 +196,7 @@ template <typename T>
  * @param monitoredItemId Identifier of the monitored item
  * @param parameters Monitoring parameters, may be revised by server
  */
-void modifyMonitoredItem(
+Result<void> modifyMonitoredItem(
     Client& connection,
     uint32_t subscriptionId,
     uint32_t monitoredItemId,
@@ -218,7 +219,7 @@ void modifyMonitoredItem(
  * @param monitoredItemId Identifier of the monitored item
  * @param monitoringMode Monitoring mode
  */
-void setMonitoringMode(
+Result<void> setMonitoringMode(
     Client& connection,
     uint32_t subscriptionId,
     uint32_t monitoredItemId,
@@ -245,7 +246,7 @@ void setMonitoringMode(
  * @param linksToAdd List of monitoring item identifiers to be added as triggering links
  * @param linksToRemove List of monitoring item identifiers to be removed as triggering links
  */
-void setTriggering(
+Result<void> setTriggering(
     Client& connection,
     uint32_t subscriptionId,
     uint32_t triggeringItemId,
@@ -270,7 +271,7 @@ void setTriggering(
  * @param monitoredItemId Identifier of the monitored item
  */
 template <typename T>
-void deleteMonitoredItem(T& connection, uint32_t subscriptionId, uint32_t monitoredItemId);
+Result<void> deleteMonitoredItem(T& connection, uint32_t subscriptionId, uint32_t monitoredItemId);
 
 /**
  * Delete a local monitored item.
@@ -278,7 +279,7 @@ void deleteMonitoredItem(T& connection, uint32_t subscriptionId, uint32_t monito
  * @param connection Instance of type Server
  * @param monitoredItemId Identifier of the monitored item
  */
-void deleteMonitoredItem(Server& connection, uint32_t monitoredItemId);
+Result<void> deleteMonitoredItem(Server& connection, uint32_t monitoredItemId);
 
 /**
  * @}

--- a/include/open62541pp/services/MonitoredItem.h
+++ b/include/open62541pp/services/MonitoredItem.h
@@ -201,7 +201,7 @@ Result<void> modifyMonitoredItem(
     uint32_t subscriptionId,
     uint32_t monitoredItemId,
     MonitoringParametersEx& parameters
-);
+) noexcept;
 
 /**
  * @}
@@ -224,7 +224,7 @@ Result<void> setMonitoringMode(
     uint32_t subscriptionId,
     uint32_t monitoredItemId,
     MonitoringMode monitoringMode
-);
+) noexcept;
 
 /**
  * @}
@@ -252,7 +252,7 @@ Result<void> setTriggering(
     uint32_t triggeringItemId,
     Span<const uint32_t> linksToAdd,
     Span<const uint32_t> linksToRemove
-);
+) noexcept;
 
 /**
  * @}

--- a/include/open62541pp/services/NodeManagement.h
+++ b/include/open62541pp/services/NodeManagement.h
@@ -202,7 +202,7 @@ auto addReferenceAsync(
         connection,
         request,
         [](UA_AddReferencesResponse& response) {
-            return detail::getSingleResult(response).andThen(detail::asResult);
+            return detail::getSingleResult(response).andThen(detail::toResult);
         },
         std::forward<CompletionToken>(token)
     );
@@ -273,7 +273,7 @@ auto deleteNodeAsync(
         connection,
         request,
         [](UA_DeleteNodesResponse& response) {
-            return detail::getSingleResult(response).andThen(detail::asResult);
+            return detail::getSingleResult(response).andThen(detail::toResult);
         },
         std::forward<CompletionToken>(token)
     );
@@ -362,7 +362,7 @@ auto deleteReferenceAsync(
         connection,
         request,
         [](UA_DeleteReferencesResponse& response) {
-            return detail::getSingleResult(response).andThen(detail::asResult);
+            return detail::getSingleResult(response).andThen(detail::toResult);
         },
         std::forward<CompletionToken>(token)
     );

--- a/include/open62541pp/services/NodeManagement.h
+++ b/include/open62541pp/services/NodeManagement.h
@@ -41,7 +41,7 @@ namespace opcua::services {
  * @param connection Instance of type Client
  * @param request Add nodes request
  */
-AddNodesResponse addNodes(Client& connection, const AddNodesRequest& request);
+AddNodesResponse addNodes(Client& connection, const AddNodesRequest& request) noexcept;
 
 /**
  * Asynchronously add one or more nodes (client only).
@@ -81,7 +81,7 @@ Result<NodeId> addNode(
     const ExtensionObject& nodeAttributes,
     const NodeId& typeDefinition,
     const NodeId& referenceType
-);
+) noexcept;
 
 /**
  * Asynchronously add a node.
@@ -135,7 +135,9 @@ auto addNodeAsync(
  * @param connection Instance of type Client
  * @param request Add references request
  */
-AddReferencesResponse addReferences(Client& connection, const AddReferencesRequest& request);
+AddReferencesResponse addReferences(
+    Client& connection, const AddReferencesRequest& request
+) noexcept;
 
 /**
  * Asynchronously add one or more references (client only).
@@ -171,7 +173,7 @@ Result<void> addReference(
     const NodeId& targetId,
     const NodeId& referenceType,
     bool forward = true
-);
+) noexcept;
 
 /**
  * Asynchronously add reference.
@@ -219,7 +221,7 @@ auto addReferenceAsync(
  * @param connection Instance of type Client
  * @param request Delete nodes request
  */
-DeleteNodesResponse deleteNodes(Client& connection, const DeleteNodesRequest& request);
+DeleteNodesResponse deleteNodes(Client& connection, const DeleteNodesRequest& request) noexcept;
 
 /**
  * Asynchronously delete one or more nodes (client only).
@@ -247,7 +249,7 @@ auto deleteNodesAsync(
  * @param deleteReferences Delete references in target nodes that reference the node to delete
  */
 template <typename T>
-Result<void> deleteNode(T& connection, const NodeId& id, bool deleteReferences = true);
+Result<void> deleteNode(T& connection, const NodeId& id, bool deleteReferences = true) noexcept;
 
 /**
  * Asynchronously delete node.
@@ -292,7 +294,7 @@ auto deleteNodeAsync(
  */
 DeleteReferencesResponse deleteReferences(
     Client& connection, const DeleteReferencesRequest& request
-);
+) noexcept;
 
 /**
  * Asynchronously delete one or more references (client only).
@@ -330,7 +332,7 @@ Result<void> deleteReference(
     const NodeId& referenceType,
     bool isForward,
     bool deleteBidirectional
-);
+) noexcept;
 
 /**
  * Asynchronously delete reference.
@@ -397,7 +399,7 @@ inline Result<NodeId> addObject(
     const ObjectAttributes& attributes = {},
     const NodeId& objectType = ObjectTypeId::BaseObjectType,
     const NodeId& referenceType = ReferenceTypeId::HasComponent
-) {
+) noexcept {
     return addNode(
         connection,
         NodeClass::Object,
@@ -457,7 +459,7 @@ inline Result<NodeId> addFolder(
     std::string_view browseName,
     const ObjectAttributes& attributes = {},
     const NodeId& referenceType = ReferenceTypeId::HasComponent
-) {
+) noexcept {
     return addObject(
         connection, parentId, id, browseName, attributes, ObjectTypeId::FolderType, referenceType
     );
@@ -510,7 +512,7 @@ inline Result<NodeId> addVariable(
     const VariableAttributes& attributes = {},
     const NodeId& variableType = VariableTypeId::BaseDataVariableType,
     const NodeId& referenceType = ReferenceTypeId::HasComponent
-) {
+) noexcept {
     return addNode(
         connection,
         NodeClass::Variable,
@@ -568,7 +570,7 @@ inline Result<NodeId> addProperty(
     const NodeId& id,
     std::string_view browseName,
     const VariableAttributes& attributes = {}
-) {
+) noexcept {
     return addVariable(
         connection,
         parentId,
@@ -639,7 +641,7 @@ Result<NodeId> addMethod(
     Span<const Argument> outputArguments,
     const MethodAttributes& attributes = {},
     const NodeId& referenceType = ReferenceTypeId::HasComponent
-);
+) noexcept;
 
 /**
  * Asynchronously add method.
@@ -691,7 +693,7 @@ inline Result<NodeId> addObjectType(
     std::string_view browseName,
     const ObjectTypeAttributes& attributes = {},
     const NodeId& referenceType = ReferenceTypeId::HasSubtype
-) {
+) noexcept {
     return addNode(
         connection,
         NodeClass::ObjectType,
@@ -752,7 +754,7 @@ inline Result<NodeId> addVariableType(
     const VariableTypeAttributes& attributes = {},
     const NodeId& variableType = VariableTypeId::BaseDataVariableType,
     const NodeId& referenceType = ReferenceTypeId::HasSubtype
-) {
+) noexcept {
     return addNode(
         connection,
         NodeClass::VariableType,
@@ -812,7 +814,7 @@ inline Result<NodeId> addReferenceType(
     std::string_view browseName,
     const ReferenceTypeAttributes& attributes = {},
     const NodeId& referenceType = ReferenceTypeId::HasSubtype
-) {
+) noexcept {
     return addNode(
         connection,
         NodeClass::ReferenceType,
@@ -871,7 +873,7 @@ inline Result<NodeId> addDataType(
     std::string_view browseName,
     const DataTypeAttributes& attributes = {},
     const NodeId& referenceType = ReferenceTypeId::HasSubtype
-) {
+) noexcept {
     return addNode(
         connection,
         NodeClass::DataType,
@@ -930,7 +932,7 @@ inline Result<NodeId> addView(
     std::string_view browseName,
     const ViewAttributes& attributes = {},
     const NodeId& referenceType = ReferenceTypeId::Organizes
-) {
+) noexcept {
     return addNode(
         connection,
         NodeClass::View,
@@ -985,7 +987,7 @@ inline auto addViewAsync(
  * @see https://reference.opcfoundation.org/Core/Part3/v105/docs/6.4.4
  */
 template <typename T>
-inline Result<void> addModellingRule(T& connection, const NodeId& id, ModellingRule rule) {
+inline Result<void> addModellingRule(T& connection, const NodeId& id, ModellingRule rule) noexcept {
     return addReference(
         connection, id, {0, static_cast<uint32_t>(rule)}, ReferenceTypeId::HasModellingRule, true
     );

--- a/include/open62541pp/services/Subscription.h
+++ b/include/open62541pp/services/Subscription.h
@@ -4,6 +4,7 @@
 #include <functional>
 
 #include "open62541pp/Config.h"
+#include "open62541pp/Result.h"
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
 
@@ -70,7 +71,7 @@ using DeleteSubscriptionCallback = std::function<void(uint32_t subId)>;
  * @param deleteCallback Invoked when the subscription is deleted
  * @return Server-assigned identifier of the subscription
  */
-[[nodiscard]] uint32_t createSubscription(
+[[nodiscard]] Result<uint32_t> createSubscription(
     Client& connection,
     SubscriptionParameters& parameters,
     bool publishingEnabled = true,
@@ -92,7 +93,7 @@ using DeleteSubscriptionCallback = std::function<void(uint32_t subId)>;
  * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
  * @param parameters Subscription parameters, may be revised by server
  */
-void modifySubscription(
+Result<void> modifySubscription(
     Client& connection, uint32_t subscriptionId, SubscriptionParameters& parameters
 );
 
@@ -112,7 +113,7 @@ void modifySubscription(
  * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
  * @param publishing Enable/disable publishing
  */
-void setPublishingMode(Client& connection, uint32_t subscriptionId, bool publishing);
+Result<void> setPublishingMode(Client& connection, uint32_t subscriptionId, bool publishing);
 
 /**
  * @}
@@ -127,7 +128,7 @@ void setPublishingMode(Client& connection, uint32_t subscriptionId, bool publish
  * @param connection Instance of type Client
  * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
  */
-void deleteSubscription(Client& connection, uint32_t subscriptionId);
+Result<void> deleteSubscription(Client& connection, uint32_t subscriptionId);
 
 /**
  * @}

--- a/include/open62541pp/services/Subscription.h
+++ b/include/open62541pp/services/Subscription.h
@@ -95,7 +95,7 @@ using DeleteSubscriptionCallback = std::function<void(uint32_t subId)>;
  */
 Result<void> modifySubscription(
     Client& connection, uint32_t subscriptionId, SubscriptionParameters& parameters
-);
+) noexcept;
 
 /**
  * @}
@@ -113,7 +113,9 @@ Result<void> modifySubscription(
  * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
  * @param publishing Enable/disable publishing
  */
-Result<void> setPublishingMode(Client& connection, uint32_t subscriptionId, bool publishing);
+Result<void> setPublishingMode(
+    Client& connection, uint32_t subscriptionId, bool publishing
+) noexcept;
 
 /**
  * @}
@@ -128,7 +130,7 @@ Result<void> setPublishingMode(Client& connection, uint32_t subscriptionId, bool
  * @param connection Instance of type Client
  * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
  */
-Result<void> deleteSubscription(Client& connection, uint32_t subscriptionId);
+Result<void> deleteSubscription(Client& connection, uint32_t subscriptionId) noexcept;
 
 /**
  * @}

--- a/include/open62541pp/services/View.h
+++ b/include/open62541pp/services/View.h
@@ -367,14 +367,14 @@ Result<std::vector<ReferenceDescription>> browseAll(
         );
     };
     Result<BrowseResult> result = browse(connection, bd, maxReferences);
-    if (result.code().isBad()) {
+    if (!result) {
         return BadResult(result.code());
     }
     append(result->getReferences());
     while (!result.value().getContinuationPoint().empty()) {
         const bool release = (refs.size() >= maxReferences);
         result = browseNext(connection, release, result->getContinuationPoint());
-        if (result.code().isBad()) {
+        if (!result) {
             return BadResult(result.code());
         }
         append(result->getReferences());

--- a/include/open62541pp/services/View.h
+++ b/include/open62541pp/services/View.h
@@ -44,7 +44,7 @@ namespace opcua::services {
  * @param connection Instance of type Client
  * @param request Browse request
  */
-BrowseResponse browse(Client& connection, const BrowseRequest& request);
+BrowseResponse browse(Client& connection, const BrowseRequest& request) noexcept;
 
 /**
  * Asynchronously discover the references of one or more nodes (client only).
@@ -70,7 +70,9 @@ auto browseAsync(
  * @param maxReferences The maximum number of references to return (0 if no limit)
  */
 template <typename T>
-Result<BrowseResult> browse(T& connection, const BrowseDescription& bd, uint32_t maxReferences = 0);
+Result<BrowseResult> browse(
+    T& connection, const BrowseDescription& bd, uint32_t maxReferences = 0
+) noexcept;
 
 /**
  * Asynchronously discover the references of a specified node.
@@ -109,7 +111,7 @@ auto browseAsync(
  * @param connection Instance of type Client
  * @param request Browse request
  */
-BrowseNextResponse browseNext(Client& connection, const BrowseNextRequest& request);
+BrowseNextResponse browseNext(Client& connection, const BrowseNextRequest& request) noexcept;
 
 /**
  * Asynchronously request the next sets of @ref browse / @ref browseNext responses (client only).
@@ -141,7 +143,7 @@ auto browseNextAsync(
 template <typename T>
 Result<BrowseResult> browseNext(
     T& connection, bool releaseContinuationPoint, const ByteString& continuationPoint
-);
+) noexcept;
 
 /**
  * Asynchronously request the next set of a @ref browse or @ref browseNext response.
@@ -181,7 +183,7 @@ auto browseNextAsync(
  */
 TranslateBrowsePathsToNodeIdsResponse translateBrowsePathsToNodeIds(
     Client& connection, const TranslateBrowsePathsToNodeIdsRequest& request
-);
+) noexcept;
 
 /**
  * Asynchronously translate browse paths to NodeIds (client only).
@@ -211,7 +213,9 @@ auto translateBrowsePathsToNodeIdsAsync(
  * @param browsePath Browse path (starting node & relative path)
  */
 template <typename T>
-Result<BrowsePathResult> translateBrowsePathToNodeIds(T& connection, const BrowsePath& browsePath);
+Result<BrowsePathResult> translateBrowsePathToNodeIds(
+    T& connection, const BrowsePath& browsePath
+) noexcept;
 
 /**
  * Asynchronously translate a browse path to NodeIds.
@@ -287,7 +291,9 @@ inline auto browseSimplifiedBrowsePathAsync(
  * @param connection Instance of type Client
  * @param request Request
  */
-RegisterNodesResponse registerNodes(Client& connection, const RegisterNodesRequest& request);
+RegisterNodesResponse registerNodes(
+    Client& connection, const RegisterNodesRequest& request
+) noexcept;
 
 /**
  * Asynchronously register nodes for efficient access operations (client only).
@@ -322,7 +328,9 @@ auto registerNodesAsync(
  * @param connection Instance of type Client
  * @param request Request
  */
-UnregisterNodesResponse unregisterNodes(Client& connection, const UnregisterNodesRequest& request);
+UnregisterNodesResponse unregisterNodes(
+    Client& connection, const UnregisterNodesRequest& request
+) noexcept;
 
 /**
  * Asynchronously unregister nodes (client only).

--- a/include/open62541pp/services/detail/ClientService.h
+++ b/include/open62541pp/services/detail/ClientService.h
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <functional>  // invoke
+#include <memory>
 #include <tuple>
 #include <type_traits>
 #include <utility>  // forward
@@ -127,7 +128,11 @@ auto sendRequest(
                 userdata,
                 nullptr
             );
-            throwIfBad(status);
+            if (opcua::detail::isBad(status)) {
+                Response response{};
+                response.responseHeader.serviceResult = status;
+                callback(client.handle(), userdata, {}, &response);
+            }
         },
         std::forward<TransformResponse>(transformResponse),
         std::forward<CompletionToken>(token)

--- a/include/open62541pp/services/detail/ClientService.h
+++ b/include/open62541pp/services/detail/ClientService.h
@@ -145,7 +145,7 @@ static auto sendRequest(
     const Request& request,
     TransformResponse&& transformResponse,
     SyncOperation /*unused*/
-) {
+) noexcept(std::is_nothrow_invocable_v<TransformResponse, Response&>) {
     Response response{};
     const auto responseDeleter = opcua::detail::ScopeExit([&] {
         opcua::detail::clear(response, getDataType<Response>());

--- a/include/open62541pp/services/detail/ClientService.h
+++ b/include/open62541pp/services/detail/ClientService.h
@@ -9,14 +9,12 @@
 
 #include "open62541pp/Client.h"
 #include "open62541pp/ErrorHandling.h"
-#include "open62541pp/Result.h"
-#include "open62541pp/TypeRegistry.h"
+#include "open62541pp/TypeRegistry.h"  // getDataType
 #include "open62541pp/async.h"
 #include "open62541pp/detail/ClientContext.h"
 #include "open62541pp/detail/ExceptionCatcher.h"
 #include "open62541pp/detail/ScopeExit.h"
 #include "open62541pp/detail/open62541/client.h"
-#include "open62541pp/detail/result_util.h"
 
 namespace opcua::services::detail {
 
@@ -41,23 +39,21 @@ struct AsyncServiceAdapter {
     ) {
         static_assert(std::is_invocable_v<TransformResponse, Response&>);
         using TransformResult = std::invoke_result_t<TransformResponse, Response&>;
+        static_assert(std::is_invocable_v<CompletionHandler, TransformResult&>);
         using Context = std::tuple<ExceptionCatcher&, TransformResponse, CompletionHandler>;
 
         auto callback = [](UA_Client*, void* userdata, uint32_t /* reqId */, void* responsePtr) {
             assert(userdata != nullptr);
             std::unique_ptr<Context> context{static_cast<Context*>(userdata)};
             auto& catcher = std::get<ExceptionCatcher&>(*context);
-            auto& handler = std::get<CompletionHandler>(*context);
-
-            auto result = [&]() -> opcua::Result<TransformResult> {
+            catcher.invoke([&] {
                 if (responsePtr == nullptr) {
-                    return opcua::BadResult(UA_STATUSCODE_BADUNEXPECTEDERROR);
+                    throw BadStatus(UA_STATUSCODE_BADUNEXPECTEDERROR);
                 }
                 Response& response = *static_cast<Response*>(responsePtr);
-                return opcua::detail::tryInvoke(std::get<TransformResponse>(*context), response);
-            }();
-
-            catcher.invoke(handler, result);
+                auto result = std::invoke(std::get<TransformResponse>(*context), response);
+                std::invoke(std::get<CompletionHandler>(*context), result);
+            });
         };
 
         return CallbackAndContext<Context>{

--- a/include/open62541pp/services/detail/RequestHandling.h
+++ b/include/open62541pp/services/detail/RequestHandling.h
@@ -17,21 +17,31 @@
 namespace opcua::services::detail {
 
 template <typename T>
-inline ExtensionObject wrapNodeAttributes(const T& attributes) {
+inline ExtensionObject wrapNodeAttributes(const T& attributes) noexcept {
     // NOLINTNEXTLINE, won't be modified
     return ExtensionObject::fromDecoded(const_cast<T&>(attributes));
 }
 
 template <typename T>
-inline auto* getNativePointer(T& wrapper) noexcept {
+inline auto* getPointer(T& value) noexcept {
     // NOLINTNEXTLINE, request object won't be modified
-    return asNative(const_cast<std::remove_const_t<T>*>(&wrapper));
+    return const_cast<std::remove_const_t<T>*>(&value);
+}
+
+template <typename T>
+inline auto* getPointer(Span<T> array) noexcept {
+    // NOLINTNEXTLINE, request object won't be modified
+    return const_cast<std::remove_const_t<T>*>(array.data());
+}
+
+template <typename T>
+inline auto* getNativePointer(T& wrapper) noexcept {
+    return asNative(getPointer(wrapper));
 }
 
 template <typename T>
 inline auto* getNativePointer(Span<T> array) noexcept {
-    // NOLINTNEXTLINE, request object won't be modified
-    return asNative(const_cast<std::remove_const_t<T>*>(array.data()));
+    return asNative(getPointer(array));
 }
 
 inline UA_ReadValueId createReadValueId(const NodeId& id, AttributeId attributeId) noexcept {
@@ -119,7 +129,7 @@ inline UA_BrowseNextRequest createBrowseNextRequest(
 
 inline UA_TranslateBrowsePathsToNodeIdsRequest createTranslateBrowsePathsToNodeIdsRequest(
     const BrowsePath& browsePath
-) {
+) noexcept {
     UA_TranslateBrowsePathsToNodeIdsRequest request{};
     request.browsePathsSize = 1;
     request.browsePaths = getNativePointer(browsePath);
@@ -144,7 +154,7 @@ inline BrowsePath createBrowsePath(const NodeId& origin, Span<const QualifiedNam
 template <typename SubscriptionParameters>
 inline UA_CreateSubscriptionRequest createCreateSubscriptionRequest(
     const SubscriptionParameters& parameters, bool publishingEnabled
-) {
+) noexcept {
     UA_CreateSubscriptionRequest request{};
     request.requestedPublishingInterval = parameters.publishingInterval;
     request.requestedLifetimeCount = parameters.lifetimeCount;
@@ -158,7 +168,7 @@ inline UA_CreateSubscriptionRequest createCreateSubscriptionRequest(
 template <typename SubscriptionParameters>
 inline UA_ModifySubscriptionRequest createModifySubscriptionRequest(
     uint32_t subscriptionId, const SubscriptionParameters& parameters
-) {
+) noexcept {
     UA_ModifySubscriptionRequest request{};
     request.subscriptionId = subscriptionId;
     request.requestedPublishingInterval = parameters.publishingInterval;
@@ -171,18 +181,18 @@ inline UA_ModifySubscriptionRequest createModifySubscriptionRequest(
 
 inline UA_SetPublishingModeRequest createSetPublishingModeRequest(
     Span<const uint32_t> subscriptionIds, bool publishing
-) {
+) noexcept {
     UA_SetPublishingModeRequest request{};
     request.publishingEnabled = publishing;
     request.subscriptionIdsSize = subscriptionIds.size();
-    request.subscriptionIds = const_cast<uint32_t*>(subscriptionIds.data());  // NOLINT
+    request.subscriptionIds = getPointer(subscriptionIds);
     return request;
 }
 
 template <typename MonitoringParameters>
 inline void copyMonitoringParametersToNative(
     const MonitoringParameters& parameters, UA_MonitoringParameters& native
-) {
+) noexcept {
     native.samplingInterval = parameters.samplingInterval;
     native.filter = parameters.filter;
     native.queueSize = parameters.queueSize;
@@ -194,7 +204,7 @@ inline UA_MonitoredItemCreateRequest createMonitoredItemCreateRequest(
     const ReadValueId& itemToMonitor,
     MonitoringMode monitoringMode,
     MonitoringParameters& parameters
-) {
+) noexcept {
     UA_MonitoredItemCreateRequest request{};
     request.itemToMonitor = itemToMonitor;
     request.monitoringMode = static_cast<UA_MonitoringMode>(monitoringMode);
@@ -205,7 +215,7 @@ inline UA_MonitoredItemCreateRequest createMonitoredItemCreateRequest(
 template <typename MonitoringParameters>
 inline UA_MonitoredItemModifyRequest createMonitoredItemModifyRequest(
     uint32_t monitoredItemId, MonitoringParameters& parameters
-) {
+) noexcept {
     UA_MonitoredItemModifyRequest item{};
     item.monitoredItemId = monitoredItemId;
     copyMonitoringParametersToNative(parameters, item.requestedParameters);
@@ -215,7 +225,7 @@ inline UA_MonitoredItemModifyRequest createMonitoredItemModifyRequest(
 template <typename MonitoringParameters>
 inline UA_ModifyMonitoredItemsRequest createModifyMonitoredItemsRequest(
     uint32_t subscriptionId, MonitoringParameters& parameters, UA_MonitoredItemModifyRequest& item
-) {
+) noexcept {
     UA_ModifyMonitoredItemsRequest request{};
     request.subscriptionId = subscriptionId;
     request.timestampsToReturn = static_cast<UA_TimestampsToReturn>(parameters.timestamps);
@@ -226,12 +236,12 @@ inline UA_ModifyMonitoredItemsRequest createModifyMonitoredItemsRequest(
 
 inline UA_SetMonitoringModeRequest createSetMonitoringModeRequest(
     uint32_t subscriptionId, Span<const uint32_t> monitoredItemIds, MonitoringMode monitoringMode
-) {
+) noexcept {
     UA_SetMonitoringModeRequest request{};
     request.subscriptionId = subscriptionId;
     request.monitoringMode = static_cast<UA_MonitoringMode>(monitoringMode);
     request.monitoredItemIdsSize = monitoredItemIds.size();
-    request.monitoredItemIds = const_cast<uint32_t*>(monitoredItemIds.data());  // NOLINT
+    request.monitoredItemIds = getPointer(monitoredItemIds);
     return request;
 }
 
@@ -240,14 +250,14 @@ inline UA_SetTriggeringRequest createSetTriggeringRequest(
     uint32_t triggeringItemId,
     Span<const uint32_t> linksToAdd,
     Span<const uint32_t> linksToRemove
-) {
+) noexcept {
     UA_SetTriggeringRequest request{};
     request.subscriptionId = subscriptionId;
     request.triggeringItemId = triggeringItemId;
     request.linksToAddSize = linksToAdd.size();
-    request.linksToAdd = const_cast<uint32_t*>(linksToAdd.data());  // NOLINT
+    request.linksToAdd = getPointer(linksToAdd);
     request.linksToRemoveSize = linksToRemove.size();
-    request.linksToRemove = const_cast<uint32_t*>(linksToRemove.data());  // NOLINT
+    request.linksToRemove = getPointer(linksToRemove);
     return request;
 }
 

--- a/include/open62541pp/services/detail/ResponseHandling.h
+++ b/include/open62541pp/services/detail/ResponseHandling.h
@@ -6,11 +6,11 @@
 #include <utility>  // exchange
 #include <vector>
 
-#include "open62541pp/ErrorHandling.h"
 #include "open62541pp/Result.h"
 #include "open62541pp/Span.h"
 #include "open62541pp/Wrapper.h"  // asWrapper, isWrapper
 #include "open62541pp/detail/open62541/common.h"
+#include "open62541pp/detail/result_util.h"
 #include "open62541pp/types/Builtin.h"  // StatusCode
 #include "open62541pp/types/DataValue.h"
 #include "open62541pp/types/Variant.h"
@@ -83,14 +83,12 @@ inline Result<std::vector<Variant>> getOutputArguments(UA_CallMethodResult& resu
             return BadResult(code);
         }
     }
-    try {
+    return opcua::detail::tryInvoke([&] {
         return std::vector<Variant>{
             std::make_move_iterator(result.outputArguments),
             std::make_move_iterator(result.outputArguments + result.outputArgumentsSize)  // NOLINT
         };
-    } catch (...) {
-        return BadResult(opcua::detail::getStatusCode(std::current_exception()));
-    }
+    });
 }
 
 template <typename SubscriptionParameters, typename Response>

--- a/include/open62541pp/services/detail/ResponseHandling.h
+++ b/include/open62541pp/services/detail/ResponseHandling.h
@@ -60,7 +60,7 @@ auto getSingleResult(Response& response) noexcept -> Result<decltype(std::ref(*r
     return std::ref(*response.results);
 }
 
-inline Result<void> asResult(UA_StatusCode code) noexcept {
+inline Result<void> toResult(UA_StatusCode code) noexcept {
     if (opcua::detail::isBad(code)) {
         return BadResult(code);
     }

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -353,6 +353,7 @@ bool Client::isConnected() noexcept {
 
 std::vector<std::string> Client::getNamespaceArray() {
     return services::readValue(*this, {0, UA_NS0ID_SERVER_NAMESPACEARRAY})
+        .value()
         .getArrayCopy<std::string>();
 }
 
@@ -363,7 +364,7 @@ Subscription<Client> Client::createSubscription() {
 }
 
 Subscription<Client> Client::createSubscription(SubscriptionParameters& parameters) {
-    const uint32_t subscriptionId = services::createSubscription(*this, parameters, true);
+    const uint32_t subscriptionId = services::createSubscription(*this, parameters, true).value();
     return {*this, subscriptionId};
 }
 

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -278,6 +278,7 @@ std::vector<Session> Server::getSessions() {
 
 std::vector<std::string> Server::getNamespaceArray() {
     return services::readValue(*this, {0, UA_NS0ID_SERVER_NAMESPACEARRAY})
+        .value()
         .getArrayCopy<std::string>();
 }
 
@@ -349,10 +350,10 @@ static UA_StatusCode valueSourceRead(
     assert(nodeContext != nullptr && value != nullptr);
     auto& callback = static_cast<detail::NodeContext*>(nodeContext)->dataSource.read;
     if (callback) {
-        return detail::tryInvoke(
-                   callback, asWrapper<DataValue>(*value), asRange(range), includeSourceTimestamp
-        )
-            .code();
+        auto result = detail::tryInvoke(
+            callback, asWrapper<DataValue>(*value), asRange(range), includeSourceTimestamp
+        );
+        return result.code();
     }
     return UA_STATUSCODE_BADINTERNALERROR;
 }
@@ -369,7 +370,8 @@ static UA_StatusCode valueSourceWrite(
     assert(nodeContext != nullptr && value != nullptr);
     auto& callback = static_cast<detail::NodeContext*>(nodeContext)->dataSource.write;
     if (callback) {
-        return detail::tryInvoke(callback, asWrapper<DataValue>(*value), asRange(range)).code();
+        auto result = detail::tryInvoke(callback, asWrapper<DataValue>(*value), asRange(range));
+        return result.code();
     }
     return UA_STATUSCODE_BADINTERNALERROR;
 }

--- a/src/services/Attribute.cpp
+++ b/src/services/Attribute.cpp
@@ -35,7 +35,7 @@ Result<void> writeAttribute<Server>(
     Server& connection, const NodeId& id, AttributeId attributeId, const DataValue& value
 ) noexcept {
     const auto item = detail::createWriteValue(id, attributeId, value);
-    return detail::asResult(UA_Server_write(connection.handle(), &item));
+    return detail::toResult(UA_Server_write(connection.handle(), &item));
 }
 
 template <>

--- a/src/services/Attribute.cpp
+++ b/src/services/Attribute.cpp
@@ -5,14 +5,14 @@
 
 namespace opcua::services {
 
-ReadResponse read(Client& connection, const ReadRequest& request) {
+ReadResponse read(Client& connection, const ReadRequest& request) noexcept {
     return readAsync(connection, request, detail::SyncOperation{});
 }
 
 template <>
 Result<DataValue> readAttribute<Server>(
     Server& connection, const NodeId& id, AttributeId attributeId, TimestampsToReturn timestamps
-) {
+) noexcept {
     const auto item = detail::createReadValueId(id, attributeId);
     return DataValue(
         UA_Server_read(connection.handle(), &item, static_cast<UA_TimestampsToReturn>(timestamps))
@@ -22,18 +22,18 @@ Result<DataValue> readAttribute<Server>(
 template <>
 Result<DataValue> readAttribute<Client>(
     Client& connection, const NodeId& id, AttributeId attributeId, TimestampsToReturn timestamps
-) {
+) noexcept {
     return readAttributeAsync(connection, id, attributeId, timestamps, detail::SyncOperation{});
 }
 
-WriteResponse write(Client& connection, const WriteRequest& request) {
+WriteResponse write(Client& connection, const WriteRequest& request) noexcept {
     return writeAsync(connection, request, detail::SyncOperation{});
 }
 
 template <>
 Result<void> writeAttribute<Server>(
     Server& connection, const NodeId& id, AttributeId attributeId, const DataValue& value
-) {
+) noexcept {
     const auto item = detail::createWriteValue(id, attributeId, value);
     return detail::asResult(UA_Server_write(connection.handle(), &item));
 }
@@ -41,7 +41,7 @@ Result<void> writeAttribute<Server>(
 template <>
 Result<void> writeAttribute<Client>(
     Client& connection, const NodeId& id, AttributeId attributeId, const DataValue& value
-) {
+) noexcept {
     return writeAttributeAsync(connection, id, attributeId, value, detail::SyncOperation{});
 }
 

--- a/src/services/Method.cpp
+++ b/src/services/Method.cpp
@@ -13,7 +13,7 @@ CallResponse call(Client& connection, const CallRequest& request) {
 }
 
 template <>
-std::vector<Variant> call(
+Result<std::vector<Variant>> call(
     Server& connection,
     const NodeId& objectId,
     const NodeId& methodId,
@@ -25,7 +25,7 @@ std::vector<Variant> call(
 }
 
 template <>
-std::vector<Variant> call(
+Result<std::vector<Variant>> call(
     Client& connection,
     const NodeId& objectId,
     const NodeId& methodId,

--- a/src/services/Method.cpp
+++ b/src/services/Method.cpp
@@ -8,7 +8,7 @@
 
 namespace opcua::services {
 
-CallResponse call(Client& connection, const CallRequest& request) {
+CallResponse call(Client& connection, const CallRequest& request) noexcept {
     return callAsync(connection, request, detail::SyncOperation{});
 }
 
@@ -18,7 +18,7 @@ Result<std::vector<Variant>> call(
     const NodeId& objectId,
     const NodeId& methodId,
     Span<const Variant> inputArguments
-) {
+) noexcept {
     UA_CallMethodRequest item = detail::createCallMethodRequest(objectId, methodId, inputArguments);
     CallMethodResult result = UA_Server_call(connection.handle(), &item);
     return detail::getOutputArguments(result);
@@ -30,7 +30,7 @@ Result<std::vector<Variant>> call(
     const NodeId& objectId,
     const NodeId& methodId,
     Span<const Variant> inputArguments
-) {
+) noexcept {
     return callAsync(connection, objectId, methodId, inputArguments, detail::SyncOperation{});
 }
 

--- a/src/services/MonitoredItem.cpp
+++ b/src/services/MonitoredItem.cpp
@@ -156,7 +156,7 @@ Result<void> modifyMonitoredItem(
     uint32_t subscriptionId,
     uint32_t monitoredItemId,
     MonitoringParametersEx& parameters
-) {
+) noexcept {
     auto item = detail::createMonitoredItemModifyRequest(monitoredItemId, parameters);
     auto request = detail::createModifyMonitoredItemsRequest(subscriptionId, parameters, item);
     using Response =
@@ -177,7 +177,7 @@ Result<void> setMonitoringMode(
     uint32_t subscriptionId,
     uint32_t monitoredItemId,
     MonitoringMode monitoringMode
-) {
+) noexcept {
     return detail::sendRequest<UA_SetMonitoringModeRequest, UA_SetMonitoringModeResponse>(
         connection,
         detail::createSetMonitoringModeRequest(
@@ -196,7 +196,7 @@ Result<void> setTriggering(
     uint32_t triggeringItemId,
     Span<const uint32_t> linksToAdd,
     Span<const uint32_t> linksToRemove
-) {
+) noexcept {
     return detail::sendRequest<UA_SetTriggeringRequest, UA_SetTriggeringResponse>(
         connection,
         detail::createSetTriggeringRequest(

--- a/src/services/MonitoredItem.cpp
+++ b/src/services/MonitoredItem.cpp
@@ -184,7 +184,7 @@ Result<void> setMonitoringMode(
             subscriptionId, {&monitoredItemId, 1}, monitoringMode
         ),
         [](UA_SetMonitoringModeResponse& response) -> Result<void> {
-            return detail::getSingleResult(response).andThen(detail::asResult);
+            return detail::getSingleResult(response).andThen(detail::toResult);
         },
         detail::SyncOperation{}
     );
@@ -226,7 +226,7 @@ template <>
 Result<void> deleteMonitoredItem<Client>(
     Client& connection, uint32_t subscriptionId, uint32_t monitoredItemId
 ) {
-    return detail::asResult(
+    return detail::toResult(
         UA_Client_MonitoredItems_deleteSingle(connection.handle(), subscriptionId, monitoredItemId)
     );
 }
@@ -235,7 +235,7 @@ template <>
 Result<void> deleteMonitoredItem<Server>(
     Server& connection, [[maybe_unused]] uint32_t subscriptionId, uint32_t monitoredItemId
 ) {
-    const auto result = detail::asResult(
+    const auto result = detail::toResult(
         UA_Server_deleteMonitoredItem(connection.handle(), monitoredItemId)
     );
     opcua::detail::getContext(connection).monitoredItems.erase({0U, monitoredItemId});

--- a/src/services/NodeManagement.cpp
+++ b/src/services/NodeManagement.cpp
@@ -186,7 +186,7 @@ Result<void> addReference<Server>(
     const NodeId& referenceType,
     bool forward
 ) noexcept {
-    return detail::asResult(UA_Server_addReference(
+    return detail::toResult(UA_Server_addReference(
         connection.handle(),
         sourceId,
         referenceType,
@@ -212,7 +212,7 @@ template <>
 Result<void> deleteNode<Server>(
     Server& connection, const NodeId& id, bool deleteReferences
 ) noexcept {
-    return detail::asResult(UA_Server_deleteNode(connection.handle(), id, deleteReferences));
+    return detail::toResult(UA_Server_deleteNode(connection.handle(), id, deleteReferences));
 }
 
 template <>
@@ -231,7 +231,7 @@ Result<void> deleteReference<Server>(
     bool isForward,
     bool deleteBidirectional
 ) noexcept {
-    return detail::asResult(UA_Server_deleteReference(
+    return detail::toResult(UA_Server_deleteReference(
         connection.handle(),
         sourceId,
         referenceType,

--- a/src/services/Subscription.cpp
+++ b/src/services/Subscription.cpp
@@ -66,14 +66,14 @@ Result<void> setPublishingMode(
         connection,
         detail::createSetPublishingModeRequest({&subscriptionId, 1}, publishing),
         [](UA_SetPublishingModeResponse& response) {
-            return detail::getSingleResult(response).andThen(detail::asResult);
+            return detail::getSingleResult(response).andThen(detail::toResult);
         },
         detail::SyncOperation{}
     );
 }
 
 Result<void> deleteSubscription(Client& connection, uint32_t subscriptionId) noexcept {
-    return detail::asResult(
+    return detail::toResult(
         UA_Client_Subscriptions_deleteSingle(connection.handle(), subscriptionId)
     );
 }

--- a/src/services/Subscription.cpp
+++ b/src/services/Subscription.cpp
@@ -48,7 +48,7 @@ Result<uint32_t> createSubscription(
 
 Result<void> modifySubscription(
     Client& connection, uint32_t subscriptionId, SubscriptionParameters& parameters
-) {
+) noexcept {
     const ModifySubscriptionResponse response = UA_Client_Subscriptions_modify(
         connection.handle(), detail::createModifySubscriptionRequest(subscriptionId, parameters)
     );
@@ -59,7 +59,9 @@ Result<void> modifySubscription(
     return {};
 }
 
-Result<void> setPublishingMode(Client& connection, uint32_t subscriptionId, bool publishing) {
+Result<void> setPublishingMode(
+    Client& connection, uint32_t subscriptionId, bool publishing
+) noexcept {
     return detail::sendRequest<UA_SetPublishingModeRequest, UA_SetPublishingModeResponse>(
         connection,
         detail::createSetPublishingModeRequest({&subscriptionId, 1}, publishing),
@@ -70,7 +72,7 @@ Result<void> setPublishingMode(Client& connection, uint32_t subscriptionId, bool
     );
 }
 
-Result<void> deleteSubscription(Client& connection, uint32_t subscriptionId) {
+Result<void> deleteSubscription(Client& connection, uint32_t subscriptionId) noexcept {
     return detail::asResult(
         UA_Client_Subscriptions_deleteSingle(connection.handle(), subscriptionId)
     );

--- a/src/services/Subscription.cpp
+++ b/src/services/Subscription.cpp
@@ -15,10 +15,11 @@
 #include "open62541pp/services/detail/RequestHandling.h"
 #include "open62541pp/services/detail/ResponseHandling.h"
 #include "open62541pp/services/detail/SubscriptionContext.h"
+#include "open62541pp/types/Composed.h"
 
 namespace opcua::services {
 
-uint32_t createSubscription(
+Result<uint32_t> createSubscription(
     Client& connection,
     SubscriptionParameters& parameters,
     bool publishingEnabled,
@@ -28,49 +29,51 @@ uint32_t createSubscription(
     context->catcher = &opcua::detail::getContext(connection).exceptionCatcher;
     context->deleteCallback = std::move(deleteCallback);
 
-    using Response =
-        TypeWrapper<UA_CreateSubscriptionResponse, UA_TYPES_CREATESUBSCRIPTIONRESPONSE>;
-    const Response response = UA_Client_Subscriptions_create(
+    const CreateSubscriptionResponse response = UA_Client_Subscriptions_create(
         connection.handle(),
         detail::createCreateSubscriptionRequest(parameters, publishingEnabled),
         context.get(),
         nullptr,  // statusChangeCallback
         context->deleteCallbackNative
     );
-    throwIfBad(response->responseHeader.serviceResult);
+    if (StatusCode serviceResult = detail::getServiceResult(response); serviceResult.isBad()) {
+        return BadResult(serviceResult);
+    }
     detail::reviseSubscriptionParameters(parameters, asNative(response));
 
-    const auto subscriptionId = response->subscriptionId;
+    const auto subscriptionId = response.getSubscriptionId();
     opcua::detail::getContext(connection).subscriptions.insert(subscriptionId, std::move(context));
     return subscriptionId;
 }
 
-void modifySubscription(
+Result<void> modifySubscription(
     Client& connection, uint32_t subscriptionId, SubscriptionParameters& parameters
 ) {
-    using Response =
-        TypeWrapper<UA_ModifySubscriptionResponse, UA_TYPES_MODIFYSUBSCRIPTIONRESPONSE>;
-    const Response response = UA_Client_Subscriptions_modify(
+    const ModifySubscriptionResponse response = UA_Client_Subscriptions_modify(
         connection.handle(), detail::createModifySubscriptionRequest(subscriptionId, parameters)
     );
-    throwIfBad(response->responseHeader.serviceResult);
+    if (StatusCode serviceResult = detail::getServiceResult(response); serviceResult.isBad()) {
+        return BadResult(serviceResult);
+    }
     detail::reviseSubscriptionParameters(parameters, asNative(response));
+    return {};
 }
 
-void setPublishingMode(Client& connection, uint32_t subscriptionId, bool publishing) {
-    detail::sendRequest<UA_SetPublishingModeRequest, UA_SetPublishingModeResponse>(
+Result<void> setPublishingMode(Client& connection, uint32_t subscriptionId, bool publishing) {
+    return detail::sendRequest<UA_SetPublishingModeRequest, UA_SetPublishingModeResponse>(
         connection,
         detail::createSetPublishingModeRequest({&subscriptionId, 1}, publishing),
         [](UA_SetPublishingModeResponse& response) {
-            throwIfBad(detail::getSingleResult(response));
+            return detail::getSingleResult(response).andThen(detail::asResult);
         },
         detail::SyncOperation{}
     );
 }
 
-void deleteSubscription(Client& connection, uint32_t subscriptionId) {
-    const auto status = UA_Client_Subscriptions_deleteSingle(connection.handle(), subscriptionId);
-    throwIfBad(status);
+Result<void> deleteSubscription(Client& connection, uint32_t subscriptionId) {
+    return detail::asResult(
+        UA_Client_Subscriptions_deleteSingle(connection.handle(), subscriptionId)
+    );
 }
 
 }  // namespace opcua::services

--- a/src/services/View.cpp
+++ b/src/services/View.cpp
@@ -14,32 +14,32 @@
 
 namespace opcua::services {
 
-BrowseResponse browse(Client& connection, const BrowseRequest& request) {
+BrowseResponse browse(Client& connection, const BrowseRequest& request) noexcept {
     return browseAsync(connection, request, detail::SyncOperation{});
 }
 
 template <>
 Result<BrowseResult> browse<Server>(
     Server& connection, const BrowseDescription& bd, uint32_t maxReferences
-) {
+) noexcept {
     return {UA_Server_browse(connection.handle(), maxReferences, bd.handle())};
 }
 
 template <>
 Result<BrowseResult> browse<Client>(
     Client& connection, const BrowseDescription& bd, uint32_t maxReferences
-) {
+) noexcept {
     return browseAsync(connection, bd, maxReferences, detail::SyncOperation{});
 }
 
-BrowseNextResponse browseNext(Client& connection, const BrowseNextRequest& request) {
+BrowseNextResponse browseNext(Client& connection, const BrowseNextRequest& request) noexcept {
     return browseNextAsync(connection, request, detail::SyncOperation{});
 }
 
 template <>
 Result<BrowseResult> browseNext<Server>(
     Server& connection, bool releaseContinuationPoint, const ByteString& continuationPoint
-) {
+) noexcept {
     return {UA_Server_browseNext(
         connection.handle(), releaseContinuationPoint, continuationPoint.handle()
     )};
@@ -48,7 +48,7 @@ Result<BrowseResult> browseNext<Server>(
 template <>
 Result<BrowseResult> browseNext<Client>(
     Client& connection, bool releaseContinuationPoint, const ByteString& continuationPoint
-) {
+) noexcept {
     return browseNextAsync(
         connection, releaseContinuationPoint, continuationPoint, detail::SyncOperation{}
     );
@@ -56,29 +56,33 @@ Result<BrowseResult> browseNext<Client>(
 
 TranslateBrowsePathsToNodeIdsResponse translateBrowsePathsToNodeIds(
     Client& connection, const TranslateBrowsePathsToNodeIdsRequest& request
-) {
+) noexcept {
     return translateBrowsePathsToNodeIdsAsync(connection, request, detail::SyncOperation{});
 }
 
 template <>
 Result<BrowsePathResult> translateBrowsePathToNodeIds<Server>(
     Server& connection, const BrowsePath& browsePath
-) {
+) noexcept {
     return {UA_Server_translateBrowsePathToNodeIds(connection.handle(), browsePath.handle())};
 }
 
 template <>
 Result<BrowsePathResult> translateBrowsePathToNodeIds<Client>(
     Client& connection, const BrowsePath& browsePath
-) {
+) noexcept {
     return translateBrowsePathToNodeIdsAsync(connection, browsePath, detail::SyncOperation{});
 }
 
-RegisterNodesResponse registerNodes(Client& connection, const RegisterNodesRequest& request) {
+RegisterNodesResponse registerNodes(
+    Client& connection, const RegisterNodesRequest& request
+) noexcept {
     return registerNodesAsync(connection, request, detail::SyncOperation{});
 }
 
-UnregisterNodesResponse unregisterNodes(Client& connection, const UnregisterNodesRequest& request) {
+UnregisterNodesResponse unregisterNodes(
+    Client& connection, const UnregisterNodesRequest& request
+) noexcept {
     return unregisterNodesAsync(connection, request, detail::SyncOperation{});
 }
 

--- a/tests/ClientService.cpp
+++ b/tests/ClientService.cpp
@@ -138,6 +138,20 @@ TEST_CASE("sendRequest") {
             });
             CHECK_THROWS_AS_MESSAGE(client.runIterate(), std::runtime_error, "Error");
         }
+
+        SUBCASE("Disconnected") {
+            client.disconnect();
+            sendReadRequest(
+                services::detail::WrapResponse<ReadResponse>{},
+                [&](Result<ReadResponse> result) {
+                    CHECK(result.code().isGood());
+                    CHECK(
+                        result.value().getResponseHeader().getServiceResult() ==
+                        UA_STATUSCODE_BADSERVERNOTCONNECTED
+                    );
+                }
+            );
+        }
     }
 
     SUBCASE("Sync") {
@@ -156,6 +170,16 @@ TEST_CASE("sendRequest") {
                 ),
                 std::runtime_error,
                 "Error"
+            );
+        }
+
+        SUBCASE("Disconnected") {
+            client.disconnect();
+            const auto response = sendReadRequest(
+                services::detail::WrapResponse<ReadResponse>{}, services::detail::SyncOperation{}
+            );
+            CHECK(
+                response.getResponseHeader().getServiceResult() == UA_STATUSCODE_BADCONNECTIONCLOSED
             );
         }
     }

--- a/tests/ClientService.cpp
+++ b/tests/ClientService.cpp
@@ -137,10 +137,8 @@ TEST_CASE("sendRequest") {
         SUBCASE("Disconnected") {
             client.disconnect();
             sendReadRequest(services::detail::Wrap<ReadResponse>{}, [&](ReadResponse& response) {
-                CHECK(
-                    response.getResponseHeader().getServiceResult().get() ==
-                    UA_STATUSCODE_BADSERVERNOTCONNECTED
-                );
+                // UA_STATUSCODE_BADSERVERNOTCONNECTED since v1.1
+                CHECK(response.getResponseHeader().getServiceResult().isBad());
             });
         }
 #endif
@@ -170,10 +168,8 @@ TEST_CASE("sendRequest") {
             const auto response = sendReadRequest(
                 services::detail::Wrap<ReadResponse>{}, services::detail::SyncOperation{}
             );
-            CHECK(
-                response.getResponseHeader().getServiceResult().get() ==
-                UA_STATUSCODE_BADCONNECTIONCLOSED
-            );
+            // UA_STATUSCODE_BADCONNECTIONCLOSED or UA_STATUSCODE_BADINTERNALERROR (v1.0)
+            CHECK(response.getResponseHeader().getServiceResult().isBad());
         }
     }
 }

--- a/tests/ClientService.cpp
+++ b/tests/ClientService.cpp
@@ -3,6 +3,7 @@
 #include <doctest/doctest.h>
 
 #include "open62541pp/Client.h"
+#include "open62541pp/Config.h"
 #include "open62541pp/Server.h"
 #include "open62541pp/detail/open62541/common.h"
 #include "open62541pp/services/detail/ClientService.h"
@@ -132,15 +133,17 @@ TEST_CASE("sendRequest") {
             CHECK_THROWS_AS_MESSAGE(client.runIterate(), std::runtime_error, "Error");
         }
 
+#if UAPP_OPEN62541_VER_GE(1, 1)
         SUBCASE("Disconnected") {
             client.disconnect();
             sendReadRequest(services::detail::Wrap<ReadResponse>{}, [&](ReadResponse& response) {
                 CHECK(
-                    response.getResponseHeader().getServiceResult() ==
+                    response.getResponseHeader().getServiceResult().get() ==
                     UA_STATUSCODE_BADSERVERNOTCONNECTED
                 );
             });
         }
+#endif
     }
 
     SUBCASE("Sync") {
@@ -168,7 +171,8 @@ TEST_CASE("sendRequest") {
                 services::detail::Wrap<ReadResponse>{}, services::detail::SyncOperation{}
             );
             CHECK(
-                response.getResponseHeader().getServiceResult() == UA_STATUSCODE_BADCONNECTIONCLOSED
+                response.getResponseHeader().getServiceResult().get() ==
+                UA_STATUSCODE_BADCONNECTIONCLOSED
             );
         }
     }

--- a/tests/Event.cpp
+++ b/tests/Event.cpp
@@ -19,11 +19,11 @@ TEST_CASE("Event") {
 
         const auto id = event->id();
         CHECK_FALSE(id.isNull());
-        CHECK_NOTHROW(services::readNodeId(server, id));
+        CHECK(services::readNodeId(server, id));
 
         // delete event
         event = nullptr;
-        CHECK_THROWS_WITH(services::readNodeId(server, id), "BadNodeIdUnknown");
+        CHECK(services::readNodeId(server, id).code() == UA_STATUSCODE_BADNODEIDUNKNOWN);
     }
 
     SUBCASE("Create and trigger event") {

--- a/tests/Node.cpp
+++ b/tests/Node.cpp
@@ -16,12 +16,10 @@ TEST_CASE_TEMPLATE("Node", T, Server, Client) {
     auto& connection = setup.getInstance<T>();
 
     const NodeId varId{1, 1};
-    services::addVariable(setup.server, {0, UA_NS0ID_OBJECTSFOLDER}, varId, "variable")
-        .code()
-        .throwIfBad();
+    services::addVariable(setup.server, {0, UA_NS0ID_OBJECTSFOLDER}, varId, "variable").value();
     // set all bits to 1 -> allow all
-    services::writeAccessLevel(setup.server, varId, 0xFF).code().throwIfBad();
-    services::writeWriteMask(setup.server, varId, 0xFFFFFFFF).code().throwIfBad();
+    services::writeAccessLevel(setup.server, varId, 0xFF).value();
+    services::writeWriteMask(setup.server, varId, 0xFFFFFFFF).value();
 
     auto rootNode = connection.getRootNode();
     auto objNode = connection.getObjectsNode();

--- a/tests/Node.cpp
+++ b/tests/Node.cpp
@@ -16,9 +16,12 @@ TEST_CASE_TEMPLATE("Node", T, Server, Client) {
     auto& connection = setup.getInstance<T>();
 
     const NodeId varId{1, 1};
-    services::addVariable(setup.server, {0, UA_NS0ID_OBJECTSFOLDER}, varId, "variable");
-    services::writeAccessLevel(setup.server, varId, 0xFF);
-    services::writeWriteMask(setup.server, varId, 0xFFFFFFFF);  // set all bits to 1 -> allow all
+    services::addVariable(setup.server, {0, UA_NS0ID_OBJECTSFOLDER}, varId, "variable")
+        .code()
+        .throwIfBad();
+    // set all bits to 1 -> allow all
+    services::writeAccessLevel(setup.server, varId, 0xFF).code().throwIfBad();
+    services::writeWriteMask(setup.server, varId, 0xFFFFFFFF).code().throwIfBad();
 
     auto rootNode = connection.getRootNode();
     auto objNode = connection.getObjectsNode();

--- a/tests/Services.cpp
+++ b/tests/Services.cpp
@@ -194,7 +194,7 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
                 );
             }
         };
-        CHECK(addReference().code().isGood());
+        CHECK(addReference());
         CHECK(addReference().code() == UA_STATUSCODE_BADDUPLICATEREFERENCENOTALLOWED);
 
         auto deleteReference = [&] {
@@ -210,7 +210,7 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
                 );
             }
         };
-        CHECK(deleteReference().code().isGood());
+        CHECK(deleteReference());
     }
 
     SUBCASE("Delete node") {
@@ -225,7 +225,7 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
                 return services::deleteNode(connection, {1, 1000});
             }
         };
-        CHECK(deleteNode().code().isGood());
+        CHECK(deleteNode());
         CHECK(deleteNode().code() == UA_STATUSCODE_BADNODEIDUNKNOWN);
     }
 
@@ -309,7 +309,7 @@ TEST_CASE("Attribute service set (highlevel)") {
 
         // write new attributes
         const auto eventNotifier = EventNotifier::HistoryRead | EventNotifier::HistoryWrite;
-        CHECK(services::writeEventNotifier(server, id, eventNotifier).code().isGood());
+        CHECK(services::writeEventNotifier(server, id, eventNotifier));
 
         // read new attributes
         CHECK(services::readEventNotifier(server, id).value().allOf(eventNotifier));
@@ -320,16 +320,16 @@ TEST_CASE("Attribute service set (highlevel)") {
         services::addVariable(server, objectsId, id, "testAttributes").value();
 
         // write new attributes
-        CHECK(services::writeDisplayName(server, id, {"en-US", "newDisplayName"}).code().isGood());
-        CHECK(services::writeDescription(server, id, {"de-DE", "newDescription"}).code().isGood());
-        CHECK(services::writeWriteMask(server, id, WriteMask::Executable).code().isGood());
-        CHECK(services::writeDataType(server, id, NodeId{0, 2}).code().isGood());
-        CHECK(services::writeValueRank(server, id, ValueRank::TwoDimensions).code().isGood());
-        CHECK(services::writeArrayDimensions(server, id, {3, 2}).code().isGood());
+        CHECK(services::writeDisplayName(server, id, {"en-US", "newDisplayName"}));
+        CHECK(services::writeDescription(server, id, {"de-DE", "newDescription"}));
+        CHECK(services::writeWriteMask(server, id, WriteMask::Executable));
+        CHECK(services::writeDataType(server, id, NodeId{0, 2}));
+        CHECK(services::writeValueRank(server, id, ValueRank::TwoDimensions));
+        CHECK(services::writeArrayDimensions(server, id, {3, 2}));
         const auto newAccessLevel = AccessLevel::CurrentRead | AccessLevel::CurrentWrite;
-        CHECK(services::writeAccessLevel(server, id, newAccessLevel).code().isGood());
-        CHECK(services::writeMinimumSamplingInterval(server, id, 10.0).code().isGood());
-        CHECK(services::writeHistorizing(server, id, true).code().isGood());
+        CHECK(services::writeAccessLevel(server, id, newAccessLevel));
+        CHECK(services::writeMinimumSamplingInterval(server, id, 10.0));
+        CHECK(services::writeHistorizing(server, id, true));
 
         // read new attributes
         CHECK(
@@ -357,7 +357,7 @@ TEST_CASE("Attribute service set (highlevel)") {
         services::addMethod(server, objectsId, id, "testMethod", nullptr, {}, {}).value();
 
         // write new attributes
-        CHECK(services::writeExecutable(server, id, true).code().isGood());
+        CHECK(services::writeExecutable(server, id, true));
 
         // read new attributes
         CHECK(services::readExecutable(server, id));
@@ -374,9 +374,9 @@ TEST_CASE("Attribute service set (highlevel)") {
         CHECK(services::readInverseName(server, id).value() == LocalizedText("", "References"));
 
         // write new attributes
-        CHECK(services::writeIsAbstract(server, id, false).code().isGood());
-        CHECK(services::writeSymmetric(server, id, false).code().isGood());
-        CHECK(services::writeInverseName(server, id, LocalizedText("", "New")).code().isGood());
+        CHECK(services::writeIsAbstract(server, id, false));
+        CHECK(services::writeSymmetric(server, id, false));
+        CHECK(services::writeInverseName(server, id, LocalizedText("", "New")));
 
         // read new attributes
         CHECK(services::readIsAbstract(server, id).value() == false);
@@ -397,36 +397,36 @@ TEST_CASE("Attribute service set (highlevel)") {
             };
             for (auto valueRank : valueRanks) {
                 CAPTURE(valueRank);
-                CHECK(services::writeValueRank(server, id, valueRank).code().isGood());
-                CHECK(services::writeArrayDimensions(server, id, {}).code().isGood());
-                CHECK(services::writeArrayDimensions(server, id, {1}).code().isBad());
-                CHECK(services::writeArrayDimensions(server, id, {1, 2}).code().isBad());
-                CHECK(services::writeArrayDimensions(server, id, {1, 2, 3}).code().isBad());
+                CHECK(services::writeValueRank(server, id, valueRank));
+                CHECK(services::writeArrayDimensions(server, id, {}));
+                CHECK_FALSE(services::writeArrayDimensions(server, id, {1}));
+                CHECK_FALSE(services::writeArrayDimensions(server, id, {1, 2}));
+                CHECK_FALSE(services::writeArrayDimensions(server, id, {1, 2, 3}));
             }
         }
 
         SUBCASE("OneDimension") {
-            CHECK(services::writeValueRank(server, id, ValueRank::OneDimension).code().isGood());
-            CHECK(services::writeArrayDimensions(server, id, {1}).code().isGood());
-            CHECK(services::writeArrayDimensions(server, id, {}).code().isBad());
-            CHECK(services::writeArrayDimensions(server, id, {1, 2}).code().isBad());
-            CHECK(services::writeArrayDimensions(server, id, {1, 2, 3}).code().isBad());
+            CHECK(services::writeValueRank(server, id, ValueRank::OneDimension));
+            CHECK(services::writeArrayDimensions(server, id, {1}));
+            CHECK_FALSE(services::writeArrayDimensions(server, id, {}));
+            CHECK_FALSE(services::writeArrayDimensions(server, id, {1, 2}));
+            CHECK_FALSE(services::writeArrayDimensions(server, id, {1, 2, 3}));
         }
 
         SUBCASE("TwoDimensions") {
-            CHECK(services::writeValueRank(server, id, ValueRank::TwoDimensions).code().isGood());
-            CHECK(services::writeArrayDimensions(server, id, {1, 2}).code().isGood());
-            CHECK(services::writeArrayDimensions(server, id, {}).code().isBad());
-            CHECK(services::writeArrayDimensions(server, id, {1}).code().isBad());
-            CHECK(services::writeArrayDimensions(server, id, {1, 2, 3}).code().isBad());
+            CHECK(services::writeValueRank(server, id, ValueRank::TwoDimensions));
+            CHECK(services::writeArrayDimensions(server, id, {1, 2}));
+            CHECK_FALSE(services::writeArrayDimensions(server, id, {}));
+            CHECK_FALSE(services::writeArrayDimensions(server, id, {1}));
+            CHECK_FALSE(services::writeArrayDimensions(server, id, {1, 2, 3}));
         }
 
         SUBCASE("ThreeDimensions") {
-            CHECK(services::writeValueRank(server, id, ValueRank::ThreeDimensions).code().isGood());
-            CHECK(services::writeArrayDimensions(server, id, {1, 2, 3}).code().isGood());
-            CHECK(services::writeArrayDimensions(server, id, {}).code().isBad());
-            CHECK(services::writeArrayDimensions(server, id, {1}).code().isBad());
-            CHECK(services::writeArrayDimensions(server, id, {1, 2}).code().isBad());
+            CHECK(services::writeValueRank(server, id, ValueRank::ThreeDimensions));
+            CHECK(services::writeArrayDimensions(server, id, {1, 2, 3}));
+            CHECK_FALSE(services::writeArrayDimensions(server, id, {}));
+            CHECK_FALSE(services::writeArrayDimensions(server, id, {1}));
+            CHECK_FALSE(services::writeArrayDimensions(server, id, {1, 2}));
         }
     }
 
@@ -436,7 +436,7 @@ TEST_CASE("Attribute service set (highlevel)") {
 
         Variant variantWrite;
         variantWrite.setScalarCopy(11.11);
-        CHECK(services::writeValue(server, id, variantWrite).code().isGood());
+        services::writeValue(server, id, variantWrite).value();
 
         Variant variantRead = services::readValue(server, id).value();
         CHECK(variantRead.getScalar<double>() == 11.11);
@@ -449,7 +449,7 @@ TEST_CASE("Attribute service set (highlevel)") {
         Variant variant;
         variant.setScalarCopy<int>(11);
         DataValue valueWrite(variant, {}, DateTime::now(), {}, uint16_t{1}, UA_STATUSCODE_GOOD);
-        CHECK(services::writeDataValue(server, id, valueWrite).code().isGood());
+        services::writeDataValue(server, id, valueWrite).value();
 
         DataValue valueRead = services::readDataValue(server, id).value();
 
@@ -492,11 +492,10 @@ TEST_CASE_TEMPLATE("Attribute service set write/read", T, Server, Client, Async<
             connection, id, AttributeId::Value, DataValue::fromScalar(value)
         );
         client.runIterate();
-        future.get().code().throwIfBad();
+        future.get().value();
     } else {
         services::writeAttribute(connection, id, AttributeId::Value, DataValue::fromScalar(value))
-            .code()
-            .throwIfBad();
+            .value();
     }
 
     // read
@@ -813,7 +812,7 @@ TEST_CASE("Subscription service set (client)") {
         const auto subId = services::createSubscription(client, parameters).value();
 
         parameters.priority = 1;
-        CHECK(services::modifySubscription(client, subId, parameters).code().isGood());
+        CHECK(services::modifySubscription(client, subId, parameters));
         CHECK(
             services::modifySubscription(client, subId + 1, parameters).code() ==
             UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID
@@ -822,12 +821,12 @@ TEST_CASE("Subscription service set (client)") {
 
     SUBCASE("setPublishingMode") {
         const auto subId = services::createSubscription(client, parameters).value();
-        CHECK(services::setPublishingMode(client, subId, false).code().isGood());
+        CHECK(services::setPublishingMode(client, subId, false));
     }
 
     SUBCASE("deleteSubscription") {
         const auto subId = services::createSubscription(client, parameters).value();
-        CHECK(services::deleteSubscription(client, subId).code().isGood());
+        CHECK(services::deleteSubscription(client, subId));
         CHECK(
             services::deleteSubscription(client, subId + 1).code() ==
             UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID
@@ -840,7 +839,7 @@ TEST_CASE("Subscription service set (client)") {
                                deleted = true;
                            }).value();
 
-        CHECK(services::deleteSubscription(client, subId).code().isGood());
+        CHECK(services::deleteSubscription(client, subId));
         CHECK(deleted == true);
     }
 }
@@ -889,7 +888,7 @@ TEST_CASE("MonitoredItem service set (client)") {
         );
         CAPTURE(monId);
 
-        CHECK(services::writeValue(server, id, Variant::fromScalar(11.11)).code().isGood());
+        CHECK(services::writeValue(server, id, Variant::fromScalar(11.11)));
         client.runIterate();
         CHECK(notificationCount > 0);
         CHECK(changedValue.getValue().getScalar<double>() == 11.11);
@@ -948,9 +947,7 @@ TEST_CASE("MonitoredItem service set (client)") {
 
         services::MonitoringParametersEx modifiedParameters{};
         modifiedParameters.samplingInterval = 1000.0;
-        CHECK(
-            services::modifyMonitoredItem(client, subId, monId, modifiedParameters).code().isGood()
-        );
+        CHECK(services::modifyMonitoredItem(client, subId, monId, modifiedParameters));
         CHECK(modifiedParameters.samplingInterval == 1000.0);  // should not be revised
     }
 
@@ -966,9 +963,7 @@ TEST_CASE("MonitoredItem service set (client)") {
             )
                 .value();
         CAPTURE(monId);
-        CHECK(services::setMonitoringMode(client, subId, monId, MonitoringMode::Disabled)
-                  .code()
-                  .isGood());
+        CHECK(services::setMonitoringMode(client, subId, monId, MonitoringMode::Disabled));
     }
 
 #if UAPP_OPEN62541_VER_GE(1, 2)
@@ -1009,7 +1004,7 @@ TEST_CASE("MonitoredItem service set (client)") {
             {monId},  // links to add
             {}  // links to remove
         );
-        CHECK(result.code().isGood());
+        CHECK(result);
 
         client.runIterate();
         CHECK(notificationCount > 0);
@@ -1034,7 +1029,7 @@ TEST_CASE("MonitoredItem service set (client)") {
                 [&](uint32_t, uint32_t) { deleted = true; }
             ).value();
 
-        CHECK(services::deleteMonitoredItem(client, subId, monId).code().isGood());
+        CHECK(services::deleteMonitoredItem(client, subId, monId));
         client.runIterate();
         CHECK(deleted == true);
     }
@@ -1060,7 +1055,7 @@ TEST_CASE("MonitoredItem service set (server)") {
             ).value();
         CAPTURE(monId);
         std::this_thread::sleep_for(100ms);
-        services::writeValue(server, id, Variant::fromScalar(11.11)).code().throwIfBad();
+        services::writeValue(server, id, Variant::fromScalar(11.11)).value();
         server.runIterate();
         CHECK(notificationCount > 0);
     }
@@ -1081,7 +1076,7 @@ TEST_CASE("MonitoredItem service set (server)") {
             )
                 .value();
         CAPTURE(monId);
-        CHECK(services::deleteMonitoredItem(server, monId).code().isGood());
+        CHECK(services::deleteMonitoredItem(server, monId));
     }
 }
 #endif

--- a/tests/Services.cpp
+++ b/tests/Services.cpp
@@ -13,7 +13,6 @@
 #include "open62541pp/types/ExtensionObject.h"
 
 #include "helper/ServerClientSetup.h"
-#include "helper/discard.h"
 #include "helper/stringify.h"
 
 using namespace opcua;

--- a/tests/Services.cpp
+++ b/tests/Services.cpp
@@ -29,158 +29,158 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
     const NodeId newId{1, 1000};
 
     SUBCASE("addObject") {
-        NodeId id;
+        Result<NodeId> result;
         if constexpr (isAsync<T>) {
             auto future = services::addObjectAsync(connection, objectsId, newId, "object");
             setup.client.runIterate();
-            id = future.get().value();
+            result = future.get();
         } else {
-            id = services::addObject(connection, objectsId, newId, "object");
+            result = services::addObject(connection, objectsId, newId, "object");
         }
-        CHECK_EQ(id, newId);
-        CHECK_EQ(services::readNodeClass(server, newId), NodeClass::Object);
+        CHECK_EQ(result.value(), newId);
+        CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::Object);
     }
 
     SUBCASE("addFolder") {
-        NodeId id;
+        Result<NodeId> result;
         if constexpr (isAsync<T>) {
             auto future = services::addFolderAsync(connection, objectsId, newId, "folder");
             setup.client.runIterate();
-            id = future.get().value();
+            result = future.get();
         } else {
-            id = services::addFolder(connection, objectsId, newId, "folder");
+            result = services::addFolder(connection, objectsId, newId, "folder");
         }
-        CHECK_EQ(id, newId);
-        CHECK_EQ(services::readNodeClass(server, newId), NodeClass::Object);
+        CHECK_EQ(result.value(), newId);
+        CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::Object);
     }
 
     SUBCASE("addVariable") {
-        NodeId id;
+        Result<NodeId> result;
         if constexpr (isAsync<T>) {
             auto future = services::addVariableAsync(connection, objectsId, newId, "variable");
             setup.client.runIterate();
-            id = future.get().value();
+            result = future.get();
         } else {
-            id = services::addVariable(connection, objectsId, newId, "variable");
+            result = services::addVariable(connection, objectsId, newId, "variable");
         }
-        CHECK_EQ(id, newId);
-        CHECK_EQ(services::readNodeClass(server, newId), NodeClass::Variable);
+        CHECK_EQ(result.value(), newId);
+        CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::Variable);
     }
 
     SUBCASE("addProperty") {
-        NodeId id;
+        Result<NodeId> result;
         if constexpr (isAsync<T>) {
             auto future = services::addPropertyAsync(connection, objectsId, newId, "property");
             setup.client.runIterate();
-            id = future.get().value();
+            result = future.get();
         } else {
-            id = services::addProperty(connection, objectsId, newId, "property");
+            result = services::addProperty(connection, objectsId, newId, "property");
         }
-        CHECK_EQ(id, newId);
-        CHECK_EQ(services::readNodeClass(server, newId), NodeClass::Variable);
+        CHECK_EQ(result.value(), newId);
+        CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::Variable);
     }
 
 #ifdef UA_ENABLE_METHODCALLS
     SUBCASE("addMethod") {
-        NodeId id;
+        Result<NodeId> result;
         if constexpr (isAsync<T>) {
             auto future = services::addMethodAsync(
                 connection, objectsId, newId, "method", {}, {}, {}
             );
             setup.client.runIterate();
-            id = future.get().value();
+            result = future.get();
         } else {
-            id = services::addMethod(connection, objectsId, newId, "method", {}, {}, {});
+            result = services::addMethod(connection, objectsId, newId, "method", {}, {}, {});
         }
-        CHECK_EQ(id, newId);
-        CHECK_EQ(services::readNodeClass(server, newId), NodeClass::Method);
+        CHECK_EQ(result.value(), newId);
+        CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::Method);
     }
 #endif
 
     SUBCASE("addObjectType") {
-        NodeId id;
+        Result<NodeId> result;
         if constexpr (isAsync<T>) {
             auto future = services::addObjectTypeAsync(
                 connection, {0, UA_NS0ID_BASEOBJECTTYPE}, newId, "objecttype"
             );
             setup.client.runIterate();
-            id = future.get().value();
+            result = future.get();
         } else {
-            id = services::addObjectType(
+            result = services::addObjectType(
                 connection, {0, UA_NS0ID_BASEOBJECTTYPE}, newId, "objecttype"
             );
         }
-        CHECK_EQ(id, newId);
-        CHECK_EQ(services::readNodeClass(server, newId), NodeClass::ObjectType);
+        CHECK_EQ(result.value(), newId);
+        CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::ObjectType);
     }
 
     SUBCASE("addVariableType") {
-        NodeId id;
+        Result<NodeId> result;
         if constexpr (isAsync<T>) {
             auto future = services::addVariableTypeAsync(
                 connection, {0, UA_NS0ID_BASEVARIABLETYPE}, newId, "variabletype"
             );
             setup.client.runIterate();
-            id = future.get().value();
+            result = future.get();
         } else {
-            id = services::addVariableType(
+            result = services::addVariableType(
                 connection, {0, UA_NS0ID_BASEVARIABLETYPE}, newId, "variabletype"
             );
         }
-        CHECK_EQ(id, newId);
-        CHECK_EQ(services::readNodeClass(server, newId), NodeClass::VariableType);
+        CHECK_EQ(result.value(), newId);
+        CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::VariableType);
     }
 
     SUBCASE("addReferenceType") {
-        NodeId id;
+        Result<NodeId> result;
         if constexpr (isAsync<T>) {
             auto future = services::addReferenceTypeAsync(
                 connection, {0, UA_NS0ID_ORGANIZES}, newId, "referencetype"
             );
             setup.client.runIterate();
-            id = future.get().value();
+            result = future.get();
         } else {
-            id = services::addReferenceType(
+            result = services::addReferenceType(
                 connection, {0, UA_NS0ID_ORGANIZES}, newId, "referencetype"
             );
         }
-        CHECK_EQ(id, newId);
-        CHECK_EQ(services::readNodeClass(server, newId), NodeClass::ReferenceType);
+        CHECK_EQ(result.value(), newId);
+        CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::ReferenceType);
     }
 
     SUBCASE("addDataType") {
-        NodeId id;
+        Result<NodeId> result;
         if constexpr (isAsync<T>) {
             auto future = services::addDataTypeAsync(
                 connection, {0, UA_NS0ID_STRUCTURE}, newId, "datatype"
             );
             setup.client.runIterate();
-            id = future.get().value();
+            result = future.get();
         } else {
-            id = services::addDataType(connection, {0, UA_NS0ID_STRUCTURE}, newId, "datatype");
+            result = services::addDataType(connection, {0, UA_NS0ID_STRUCTURE}, newId, "datatype");
         }
-        CHECK_EQ(id, newId);
-        CHECK_EQ(services::readNodeClass(server, newId), NodeClass::DataType);
+        CHECK_EQ(result.value(), newId);
+        CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::DataType);
     }
 
     SUBCASE("addView") {
-        NodeId id;
+        Result<NodeId> result;
         if constexpr (isAsync<T>) {
             auto future = services::addViewAsync(
                 connection, {0, UA_NS0ID_VIEWSFOLDER}, newId, "view"
             );
             setup.client.runIterate();
-            id = future.get().value();
+            result = future.get();
         } else {
-            id = services::addView(connection, {0, UA_NS0ID_VIEWSFOLDER}, newId, "view");
+            result = services::addView(connection, {0, UA_NS0ID_VIEWSFOLDER}, newId, "view");
         }
-        CHECK_EQ(id, newId);
-        CHECK_EQ(services::readNodeClass(server, newId), NodeClass::View);
+        CHECK_EQ(result.value(), newId);
+        CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::View);
     }
 
     SUBCASE("Add/delete reference") {
-        services::addFolder(connection, objectsId, {1, 1000}, "folder");
-        services::addObject(connection, objectsId, {1, 1001}, "object");
+        services::addFolder(connection, objectsId, {1, 1000}, "folder").value();
+        services::addObject(connection, objectsId, {1, 1001}, "object").value();
 
         auto addReference = [&] {
             if constexpr (isAsync<T>) {
@@ -188,15 +188,15 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
                     connection, {1, 1000}, {1, 1001}, ReferenceTypeId::Organizes
                 );
                 setup.client.runIterate();
-                future.get().code().throwIfBad();
+                return future.get();
             } else {
-                services::addReference(
+                return services::addReference(
                     connection, {1, 1000}, {1, 1001}, ReferenceTypeId::Organizes
                 );
             }
         };
-        CHECK_NOTHROW(addReference());
-        CHECK_THROWS_WITH(addReference(), "BadDuplicateReferenceNotAllowed");
+        CHECK(addReference().code().isGood());
+        CHECK(addReference().code() == UA_STATUSCODE_BADDUPLICATEREFERENCENOTALLOWED);
 
         auto deleteReference = [&] {
             if constexpr (isAsync<T>) {
@@ -204,36 +204,35 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
                     connection, {1, 1000}, {1, 1001}, ReferenceTypeId::Organizes, true, true
                 );
                 setup.client.runIterate();
-                future.get().code().throwIfBad();
+                return future.get();
             } else {
-                services::deleteReference(
+                return services::deleteReference(
                     connection, {1, 1000}, {1, 1001}, ReferenceTypeId::Organizes, true, true
                 );
             }
         };
-        CHECK_NOTHROW(deleteReference());
-        CHECK_NOTHROW(deleteReference());
+        CHECK(deleteReference().code().isGood());
     }
 
     SUBCASE("Delete node") {
-        services::addObject(connection, objectsId, {1, 1000}, "object");
+        services::addObject(connection, objectsId, {1, 1000}, "object").value();
 
         auto deleteNode = [&] {
             if constexpr (isAsync<T>) {
                 auto future = services::deleteNodeAsync(connection, {1, 1000});
                 setup.client.runIterate();
-                future.get().code().throwIfBad();
+                return future.get();
             } else {
-                services::deleteNode(connection, {1, 1000});
+                return services::deleteNode(connection, {1, 1000});
             }
         };
-        CHECK_NOTHROW(deleteNode());
-        CHECK_THROWS_WITH(deleteNode(), "BadNodeIdUnknown");
+        CHECK(deleteNode().code().isGood());
+        CHECK(deleteNode().code() == UA_STATUSCODE_BADNODEIDUNKNOWN);
     }
 
     SUBCASE("Random node id") {
         // https://www.open62541.org/doc/1.3/server.html#node-addition-and-deletion
-        const auto id = services::addObject(connection, objectsId, {1, 0}, "random");
+        const auto id = services::addObject(connection, objectsId, {1, 0}, "random").value();
         CHECK(id != NodeId(1, 0));
         CHECK(id.getNamespaceIndex() == 1);
     }
@@ -245,25 +244,25 @@ TEST_CASE("Attribute service set (highlevel)") {
 
     SUBCASE("Read default variable node attributes") {
         const NodeId id{1, "testAttributes"};
-        services::addVariable(server, objectsId, id, "testAttributes");
+        services::addVariable(server, objectsId, id, "testAttributes").value();
 
-        CHECK(services::readNodeId(server, id) == id);
-        CHECK(services::readNodeClass(server, id) == NodeClass::Variable);
-        CHECK(services::readBrowseName(server, id) == QualifiedName(1, "testAttributes"));
+        CHECK(services::readNodeId(server, id).value() == id);
+        CHECK(services::readNodeClass(server, id).value() == NodeClass::Variable);
+        CHECK(services::readBrowseName(server, id).value() == QualifiedName(1, "testAttributes"));
         // CHECK(services::readDisplayName(server, id), LocalizedText("", "testAttributes"));
-        CHECK(services::readDescription(server, id).getText().empty());
-        CHECK(services::readDescription(server, id).getLocale().empty());
-        CHECK(services::readWriteMask(server, id) == 0);
+        CHECK(services::readDescription(server, id).value().getText().empty());
+        CHECK(services::readDescription(server, id).value().getLocale().empty());
+        CHECK(services::readWriteMask(server, id).value() == 0);
         const uint32_t adminUserWriteMask = 0xFFFFFFFF;  // all bits set
-        CHECK(services::readUserWriteMask(server, id) == adminUserWriteMask);
-        CHECK(services::readDataType(server, id) == NodeId(0, UA_NS0ID_BASEDATATYPE));
-        CHECK(services::readValueRank(server, id) == ValueRank::Any);
-        CHECK(services::readArrayDimensions(server, id).empty());
-        CHECK(services::readAccessLevel(server, id) == AccessLevel::CurrentRead);
+        CHECK(services::readUserWriteMask(server, id).value() == adminUserWriteMask);
+        CHECK(services::readDataType(server, id).value() == NodeId(0, UA_NS0ID_BASEDATATYPE));
+        CHECK(services::readValueRank(server, id).value() == ValueRank::Any);
+        CHECK(services::readArrayDimensions(server, id).value().empty());
+        CHECK(services::readAccessLevel(server, id).value() == AccessLevel::CurrentRead);
         const uint8_t adminUserAccessLevel = 0xFF;  // all bits set
-        CHECK(services::readUserAccessLevel(server, id) == adminUserAccessLevel);
-        CHECK(services::readMinimumSamplingInterval(server, id) == 0.0);
-        CHECK(services::readHistorizing(server, id) == false);
+        CHECK(services::readUserAccessLevel(server, id).value() == adminUserAccessLevel);
+        CHECK(services::readMinimumSamplingInterval(server, id).value() == 0.0);
+        CHECK(services::readHistorizing(server, id).value() == false);
     }
 
     SUBCASE("Read initial variable node attributes") {
@@ -286,72 +285,80 @@ TEST_CASE("Attribute service set (highlevel)") {
             attr,
             VariableTypeId::BaseDataVariableType,
             ReferenceTypeId::HasComponent
-        );
+        )
+            .value();
 
-        CHECK(services::readDisplayName(server, id) == attr.getDisplayName());
-        CHECK(services::readDescription(server, id) == attr.getDescription());
-        CHECK(services::readWriteMask(server, id) == attr.getWriteMask());
-        CHECK(services::readDataType(server, id) == attr.getDataType());
-        CHECK(services::readValueRank(server, id) == attr.getValueRank());
+        CHECK(services::readDisplayName(server, id).value() == attr.getDisplayName());
+        CHECK(services::readDescription(server, id).value() == attr.getDescription());
+        CHECK(services::readWriteMask(server, id).value() == attr.getWriteMask());
+        CHECK(services::readDataType(server, id).value() == attr.getDataType());
+        CHECK(services::readValueRank(server, id).value() == attr.getValueRank());
         CHECK(
-            services::readArrayDimensions(server, id) ==
+            services::readArrayDimensions(server, id).value() ==
             std::vector<uint32_t>(attr.getArrayDimensions())
         );
-        CHECK(services::readAccessLevel(server, id) == attr.getAccessLevel());
+        CHECK(services::readAccessLevel(server, id).value() == attr.getAccessLevel());
         CHECK(
-            services::readMinimumSamplingInterval(server, id) == attr.getMinimumSamplingInterval()
+            services::readMinimumSamplingInterval(server, id).value() ==
+            attr.getMinimumSamplingInterval()
         );
     }
 
     SUBCASE("Read/write object node attributes") {
         const NodeId id{1, "testAttributes"};
-        services::addObject(server, objectsId, id, "testAttributes");
+        services::addObject(server, objectsId, id, "testAttributes").value();
 
         // write new attributes
         const auto eventNotifier = EventNotifier::HistoryRead | EventNotifier::HistoryWrite;
-        CHECK_NOTHROW(services::writeEventNotifier(server, id, eventNotifier));
+        CHECK(services::writeEventNotifier(server, id, eventNotifier).code().isGood());
 
         // read new attributes
-        CHECK(services::readEventNotifier(server, id).allOf(eventNotifier));
+        CHECK(services::readEventNotifier(server, id).value().allOf(eventNotifier));
     }
 
     SUBCASE("Read/write variable node attributes") {
         const NodeId id{1, "testAttributes"};
-        services::addVariable(server, objectsId, id, "testAttributes");
+        services::addVariable(server, objectsId, id, "testAttributes").value();
 
         // write new attributes
-        CHECK_NOTHROW(services::writeDisplayName(server, id, {"en-US", "newDisplayName"}));
-        CHECK_NOTHROW(services::writeDescription(server, id, {"de-DE", "newDescription"}));
-        CHECK_NOTHROW(services::writeWriteMask(server, id, WriteMask::Executable));
-        CHECK_NOTHROW(services::writeDataType(server, id, NodeId{0, 2}));
-        CHECK_NOTHROW(services::writeValueRank(server, id, ValueRank::TwoDimensions));
-        CHECK_NOTHROW(services::writeArrayDimensions(server, id, {3, 2}));
+        CHECK(services::writeDisplayName(server, id, {"en-US", "newDisplayName"}).code().isGood());
+        CHECK(services::writeDescription(server, id, {"de-DE", "newDescription"}).code().isGood());
+        CHECK(services::writeWriteMask(server, id, WriteMask::Executable).code().isGood());
+        CHECK(services::writeDataType(server, id, NodeId{0, 2}).code().isGood());
+        CHECK(services::writeValueRank(server, id, ValueRank::TwoDimensions).code().isGood());
+        CHECK(services::writeArrayDimensions(server, id, {3, 2}).code().isGood());
         const auto newAccessLevel = AccessLevel::CurrentRead | AccessLevel::CurrentWrite;
-        CHECK_NOTHROW(services::writeAccessLevel(server, id, newAccessLevel));
-        CHECK_NOTHROW(services::writeMinimumSamplingInterval(server, id, 10.0));
-        CHECK_NOTHROW(services::writeHistorizing(server, id, true));
+        CHECK(services::writeAccessLevel(server, id, newAccessLevel).code().isGood());
+        CHECK(services::writeMinimumSamplingInterval(server, id, 10.0).code().isGood());
+        CHECK(services::writeHistorizing(server, id, true).code().isGood());
 
         // read new attributes
-        CHECK(services::readDisplayName(server, id) == LocalizedText("en-US", "newDisplayName"));
-        CHECK(services::readDescription(server, id) == LocalizedText("de-DE", "newDescription"));
-        CHECK(services::readWriteMask(server, id) == UA_WRITEMASK_EXECUTABLE);
-        CHECK(services::readDataType(server, id) == NodeId(0, 2));
-        CHECK(services::readValueRank(server, id) == ValueRank::TwoDimensions);
-        CHECK(services::readArrayDimensions(server, id).size() == 2);
-        CHECK(services::readArrayDimensions(server, id).at(0) == 3);
-        CHECK(services::readArrayDimensions(server, id).at(1) == 2);
-        CHECK(services::readAccessLevel(server, id) == newAccessLevel);
-        CHECK(services::readMinimumSamplingInterval(server, id) == 10.0);
-        CHECK(services::readHistorizing(server, id) == true);
+        CHECK(
+            services::readDisplayName(server, id).value() ==
+            LocalizedText("en-US", "newDisplayName")
+        );
+        CHECK(
+            services::readDescription(server, id).value() ==
+            LocalizedText("de-DE", "newDescription")
+        );
+        CHECK(services::readWriteMask(server, id).value() == UA_WRITEMASK_EXECUTABLE);
+        CHECK(services::readDataType(server, id).value() == NodeId(0, 2));
+        CHECK(services::readValueRank(server, id).value() == ValueRank::TwoDimensions);
+        CHECK(services::readArrayDimensions(server, id).value().size() == 2);
+        CHECK(services::readArrayDimensions(server, id).value().at(0) == 3);
+        CHECK(services::readArrayDimensions(server, id).value().at(1) == 2);
+        CHECK(services::readAccessLevel(server, id).value() == newAccessLevel);
+        CHECK(services::readMinimumSamplingInterval(server, id).value() == 10.0);
+        CHECK(services::readHistorizing(server, id).value() == true);
     }
 
 #ifdef UA_ENABLE_METHODCALLS
     SUBCASE("Read/write method node attributes") {
         const NodeId id{1, "testMethod"};
-        services::addMethod(server, objectsId, id, "testMethod", nullptr, {}, {});
+        services::addMethod(server, objectsId, id, "testMethod", nullptr, {}, {}).value();
 
         // write new attributes
-        CHECK_NOTHROW(services::writeExecutable(server, id, true));
+        CHECK(services::writeExecutable(server, id, true).code().isGood());
 
         // read new attributes
         CHECK(services::readExecutable(server, id));
@@ -363,24 +370,24 @@ TEST_CASE("Attribute service set (highlevel)") {
         const NodeId id{0, UA_NS0ID_REFERENCES};
 
         // read default attributes
-        CHECK(services::readIsAbstract(server, id) == true);
-        CHECK(services::readSymmetric(server, id) == true);
-        CHECK(services::readInverseName(server, id) == LocalizedText("", "References"));
+        CHECK(services::readIsAbstract(server, id).value() == true);
+        CHECK(services::readSymmetric(server, id).value() == true);
+        CHECK(services::readInverseName(server, id).value() == LocalizedText("", "References"));
 
         // write new attributes
-        CHECK_NOTHROW(services::writeIsAbstract(server, id, false));
-        CHECK_NOTHROW(services::writeSymmetric(server, id, false));
-        CHECK_NOTHROW(services::writeInverseName(server, id, LocalizedText("", "New")));
+        CHECK(services::writeIsAbstract(server, id, false).code().isGood());
+        CHECK(services::writeSymmetric(server, id, false).code().isGood());
+        CHECK(services::writeInverseName(server, id, LocalizedText("", "New")).code().isGood());
 
         // read new attributes
-        CHECK(services::readIsAbstract(server, id) == false);
-        CHECK(services::readSymmetric(server, id) == false);
-        CHECK(services::readInverseName(server, id) == LocalizedText("", "New"));
+        CHECK(services::readIsAbstract(server, id).value() == false);
+        CHECK(services::readSymmetric(server, id).value() == false);
+        CHECK(services::readInverseName(server, id).value() == LocalizedText("", "New"));
     }
 
     SUBCASE("Value rank and array dimension combinations") {
         const NodeId id{1, "testDimensions"};
-        services::addVariable(server, objectsId, id, "testDimensions");
+        services::addVariable(server, objectsId, id, "testDimensions").value();
 
         SUBCASE("Unspecified dimension (ValueRank <= 0)") {
             const std::vector<ValueRank> valueRanks = {
@@ -391,61 +398,61 @@ TEST_CASE("Attribute service set (highlevel)") {
             };
             for (auto valueRank : valueRanks) {
                 CAPTURE(valueRank);
-                services::writeValueRank(server, id, valueRank);
-                CHECK_NOTHROW(services::writeArrayDimensions(server, id, {}));
-                CHECK_THROWS(services::writeArrayDimensions(server, id, {1}));
-                CHECK_THROWS(services::writeArrayDimensions(server, id, {1, 2}));
-                CHECK_THROWS(services::writeArrayDimensions(server, id, {1, 2, 3}));
+                CHECK(services::writeValueRank(server, id, valueRank).code().isGood());
+                CHECK(services::writeArrayDimensions(server, id, {}).code().isGood());
+                CHECK(services::writeArrayDimensions(server, id, {1}).code().isBad());
+                CHECK(services::writeArrayDimensions(server, id, {1, 2}).code().isBad());
+                CHECK(services::writeArrayDimensions(server, id, {1, 2, 3}).code().isBad());
             }
         }
 
         SUBCASE("OneDimension") {
-            services::writeValueRank(server, id, ValueRank::OneDimension);
-            services::writeArrayDimensions(server, id, {1});
-            CHECK_THROWS(services::writeArrayDimensions(server, id, {}));
-            CHECK_THROWS(services::writeArrayDimensions(server, id, {1, 2}));
-            CHECK_THROWS(services::writeArrayDimensions(server, id, {1, 2, 3}));
+            CHECK(services::writeValueRank(server, id, ValueRank::OneDimension).code().isGood());
+            CHECK(services::writeArrayDimensions(server, id, {1}).code().isGood());
+            CHECK(services::writeArrayDimensions(server, id, {}).code().isBad());
+            CHECK(services::writeArrayDimensions(server, id, {1, 2}).code().isBad());
+            CHECK(services::writeArrayDimensions(server, id, {1, 2, 3}).code().isBad());
         }
 
         SUBCASE("TwoDimensions") {
-            services::writeValueRank(server, id, ValueRank::TwoDimensions);
-            services::writeArrayDimensions(server, id, {1, 2});
-            CHECK_THROWS(services::writeArrayDimensions(server, id, {}));
-            CHECK_THROWS(services::writeArrayDimensions(server, id, {1}));
-            CHECK_THROWS(services::writeArrayDimensions(server, id, {1, 2, 3}));
+            CHECK(services::writeValueRank(server, id, ValueRank::TwoDimensions).code().isGood());
+            CHECK(services::writeArrayDimensions(server, id, {1, 2}).code().isGood());
+            CHECK(services::writeArrayDimensions(server, id, {}).code().isBad());
+            CHECK(services::writeArrayDimensions(server, id, {1}).code().isBad());
+            CHECK(services::writeArrayDimensions(server, id, {1, 2, 3}).code().isBad());
         }
 
         SUBCASE("ThreeDimensions") {
-            services::writeValueRank(server, id, ValueRank::ThreeDimensions);
-            services::writeArrayDimensions(server, id, {1, 2, 3});
-            CHECK_THROWS(services::writeArrayDimensions(server, id, {}));
-            CHECK_THROWS(services::writeArrayDimensions(server, id, {1}));
-            CHECK_THROWS(services::writeArrayDimensions(server, id, {1, 2}));
+            CHECK(services::writeValueRank(server, id, ValueRank::ThreeDimensions).code().isGood());
+            CHECK(services::writeArrayDimensions(server, id, {1, 2, 3}).code().isGood());
+            CHECK(services::writeArrayDimensions(server, id, {}).code().isBad());
+            CHECK(services::writeArrayDimensions(server, id, {1}).code().isBad());
+            CHECK(services::writeArrayDimensions(server, id, {1, 2}).code().isBad());
         }
     }
 
     SUBCASE("Read/write value") {
         const NodeId id{1, "testValue"};
-        services::addVariable(server, objectsId, id, "testValue");
+        services::addVariable(server, objectsId, id, "testValue").value();
 
         Variant variantWrite;
         variantWrite.setScalarCopy(11.11);
-        services::writeValue(server, id, variantWrite);
+        CHECK(services::writeValue(server, id, variantWrite).code().isGood());
 
-        Variant variantRead = services::readValue(server, id);
+        Variant variantRead = services::readValue(server, id).value();
         CHECK(variantRead.getScalar<double>() == 11.11);
     }
 
     SUBCASE("Read/write data value") {
         const NodeId id{1, "testDataValue"};
-        services::addVariable(server, objectsId, id, "testDataValue");
+        services::addVariable(server, objectsId, id, "testDataValue").value();
 
         Variant variant;
         variant.setScalarCopy<int>(11);
         DataValue valueWrite(variant, {}, DateTime::now(), {}, uint16_t{1}, UA_STATUSCODE_GOOD);
-        services::writeDataValue(server, id, valueWrite);
+        CHECK(services::writeDataValue(server, id, valueWrite).code().isGood());
 
-        DataValue valueRead = services::readDataValue(server, id);
+        DataValue valueRead = services::readDataValue(server, id).value();
 
         CHECK_EQ(valueRead->hasValue, true);
         CHECK_EQ(valueRead->hasServerTimestamp, true);
@@ -474,10 +481,11 @@ TEST_CASE_TEMPLATE("Attribute service set write/read", T, Server, Client, Async<
         id,
         "variable",
         VariableAttributes{}.setAccessLevel(AccessLevel::CurrentRead | AccessLevel::CurrentWrite)
-    );
+    )
+        .value();
 
     const double value = 11.11;
-    DataValue result;
+    Result<DataValue> result;
 
     // write
     if constexpr (isAsync<T>) {
@@ -487,19 +495,21 @@ TEST_CASE_TEMPLATE("Attribute service set write/read", T, Server, Client, Async<
         client.runIterate();
         future.get().code().throwIfBad();
     } else {
-        services::writeAttribute(connection, id, AttributeId::Value, DataValue::fromScalar(value));
+        services::writeAttribute(connection, id, AttributeId::Value, DataValue::fromScalar(value))
+            .code()
+            .throwIfBad();
     }
 
     // read
     if constexpr (isAsync<T>) {
         auto future = services::readAttributeAsync(connection, id, AttributeId::Value);
         client.runIterate();
-        result = future.get().value();
+        result = future.get();
     } else {
         result = services::readAttribute(connection, id, AttributeId::Value);
     }
 
-    CHECK(result.getValue().getScalar<double>() == value);
+    CHECK(result.value().getValue().getScalar<double>() == value);
 }
 
 TEST_CASE_TEMPLATE("View service set", T, Server, Client, Async<Client>) {
@@ -511,24 +521,24 @@ TEST_CASE_TEMPLATE("View service set", T, Server, Client, Async<Client>) {
 
     // add node to query references
     const NodeId id{1, 1000};
-    services::addVariable(server, {0, UA_NS0ID_OBJECTSFOLDER}, id, "Variable");
+    services::addVariable(server, {0, UA_NS0ID_OBJECTSFOLDER}, id, "Variable").value();
 
     SUBCASE("browse") {
         const BrowseDescription bd(id, BrowseDirection::Both);
-        BrowseResult result;
+        Result<BrowseResult> result;
 
         if constexpr (isAsync<T>) {
             auto future = services::browseAsync(connection, bd);
             client.runIterate();
-            result = future.get().value();
+            result = future.get();
         } else {
             result = services::browse(connection, bd);
         }
 
-        CHECK(result.getStatusCode().isGood());
-        CHECK(result.getContinuationPoint().empty());
+        CHECK(result.value().getStatusCode().isGood());
+        CHECK(result.value().getContinuationPoint().empty());
 
-        const auto refs = result.getReferences();
+        const auto refs = result.value().getReferences();
         CHECK(refs.size() == 2);
         // 1. ComponentOf Objects
         CHECK(refs[0].getReferenceTypeId() == NodeId(0, UA_NS0ID_HASCOMPONENT));
@@ -545,39 +555,39 @@ TEST_CASE_TEMPLATE("View service set", T, Server, Client, Async<Client>) {
     SUBCASE("browseNext") {
         // https://github.com/open62541/open62541/blob/v1.3.5/tests/client/check_client_highlevel.c#L252-L318
         const BrowseDescription bd({0, UA_NS0ID_SERVER}, BrowseDirection::Both);
-        BrowseResult result;
+        Result<BrowseResult> result;
 
         // restrict browse result to max 1 reference, more with browseNext
         result = services::browse(connection, bd, 1);
-        CHECK(result.getStatusCode().isGood());
-        CHECK(result.getContinuationPoint().empty() == false);
-        CHECK(result.getReferences().size() == 1);
+        CHECK(result.value().getStatusCode().isGood());
+        CHECK(result.value().getContinuationPoint().empty() == false);
+        CHECK(result.value().getReferences().size() == 1);
 
         auto browseNext = [&](bool releaseContinuationPoint) {
             if constexpr (isAsync<T>) {
                 auto future = services::browseNextAsync(
-                    connection, releaseContinuationPoint, result.getContinuationPoint()
+                    connection, releaseContinuationPoint, result.value().getContinuationPoint()
                 );
                 client.runIterate();
-                result = future.get().value();
+                result = future.get();
             } else {
                 result = services::browseNext(
-                    connection, releaseContinuationPoint, result.getContinuationPoint()
+                    connection, releaseContinuationPoint, result.value().getContinuationPoint()
                 );
             }
         };
 
         // get next result
         browseNext(false);
-        CHECK(result.getStatusCode().isGood());
-        CHECK(result.getContinuationPoint().empty() == false);
-        CHECK(result.getReferences().size() == 1);
+        CHECK(result.value().getStatusCode().isGood());
+        CHECK(result.value().getContinuationPoint().empty() == false);
+        CHECK(result.value().getReferences().size() == 1);
 
         // release continuation point, result should be empty
         browseNext(true);
-        CHECK(result.getStatusCode().isGood());
-        CHECK(result.getContinuationPoint().empty());
-        CHECK(result.getReferences().size() == 0);
+        CHECK(result.value().getStatusCode().isGood());
+        CHECK(result.value().getContinuationPoint().empty());
+        CHECK(result.value().getReferences().size() == 0);
     }
 
     if constexpr (isServer<T>) {
@@ -590,12 +600,11 @@ TEST_CASE_TEMPLATE("View service set", T, Server, Client, Async<Client>) {
                 UA_NODECLASS_VARIABLE
             );
 
-            const auto results = services::browseRecursive(connection, bd);
-            CHECK(!results.empty());
+            const auto ids = services::browseRecursive(connection, bd).value();
+            CHECK(!ids.empty());
 
             auto contains = [&](const NodeId& element) {
-                return std::find(results.begin(), results.end(), ExpandedNodeId(element)) !=
-                       results.end();
+                return std::find(ids.begin(), ids.end(), ExpandedNodeId(element)) != ids.end();
             };
 
             CHECK(contains(VariableId::Server_ServerStatus));
@@ -606,25 +615,25 @@ TEST_CASE_TEMPLATE("View service set", T, Server, Client, Async<Client>) {
 
     SUBCASE("browseAll") {
         const BrowseDescription bd(id, BrowseDirection::Both);
-        CHECK(services::browseAll(connection, bd, 0).size() == 2);
-        CHECK(services::browseAll(connection, bd, 1).size() == 1);
+        CHECK(services::browseAll(connection, bd, 0).value().size() == 2);
+        CHECK(services::browseAll(connection, bd, 1).value().size() == 1);
     }
 
     SUBCASE("browseSimplifiedBrowsePath") {
-        BrowsePathResult result;
+        Result<BrowsePathResult> result;
         if constexpr (isAsync<T>) {
             auto future = services::browseSimplifiedBrowsePathAsync(
                 connection, {0, UA_NS0ID_ROOTFOLDER}, {{0, "Objects"}, {1, "Variable"}}
             );
             client.runIterate();
-            result = future.get().value();
+            result = future.get();
         } else {
             result = services::browseSimplifiedBrowsePath(
                 connection, {0, UA_NS0ID_ROOTFOLDER}, {{0, "Objects"}, {1, "Variable"}}
             );
         }
-        CHECK(result.getStatusCode().isGood());
-        const auto targets = result.getTargets();
+        CHECK(result.value().getStatusCode().isGood());
+        const auto targets = result.value().getTargets();
         CHECK(targets.size() == 1);
         // https://reference.opcfoundation.org/Core/Part4/v105/docs/5.8
         // value shall be equal to the maximum value of uint32 if all elements processed
@@ -633,25 +642,30 @@ TEST_CASE_TEMPLATE("View service set", T, Server, Client, Async<Client>) {
     }
 
     SUBCASE("Register/unregister nodes") {
-        RegisterNodesResponse response;
-        RegisterNodesRequest requestRegister({}, {{1, 1000}});
-        if constexpr (isAsync<T>) {
-            auto future = services::registerNodesAsync(client, requestRegister);
-            client.runIterate();
-            response = future.get().value();
-        } else {
-            response = services::registerNodes(client, requestRegister);
+        {
+            RegisterNodesResponse response;
+            RegisterNodesRequest request({}, {{1, 1000}});
+            if constexpr (isAsync<T>) {
+                auto future = services::registerNodesAsync(client, request);
+                client.runIterate();
+                response = future.get();
+            } else {
+                response = services::registerNodes(client, request);
+            }
+            CHECK(response.getRegisteredNodeIds().size() == 1);
+            CHECK(response.getRegisteredNodeIds()[0] == NodeId(1, 1000));
         }
-        CHECK(response.getRegisteredNodeIds().size() == 1);
-        CHECK(response.getRegisteredNodeIds()[0] == NodeId(1, 1000));
-
-        UnregisterNodesRequest requestUnregister({}, {{1, 1000}});
-        if constexpr (isAsync<T>) {
-            auto future = services::unregisterNodesAsync(client, requestUnregister);
-            client.runIterate();
-            CHECK_NOTHROW(future.get());
-        } else {
-            CHECK_NOTHROW(services::unregisterNodes(client, requestUnregister));
+        {
+            UnregisterNodesResponse response;
+            UnregisterNodesRequest request({}, {{1, 1000}});
+            if constexpr (isAsync<T>) {
+                auto future = services::unregisterNodesAsync(client, request);
+                client.runIterate();
+                response = future.get();
+            } else {
+                response = services::unregisterNodes(client, request);
+            }
+            CHECK(response.getResponseHeader().getServiceResult().isGood());
         }
     }
 }
@@ -686,13 +700,14 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
         {
             Argument("sum", {"en-US", "sum of both numbers"}, DataTypeId::Int32, ValueRank::Scalar),
         }
-    );
+    )
+        .value();
 
     auto call = [&](auto&&... args) {
         if constexpr (isAsync<T>) {
             auto future = services::callAsync(std::forward<decltype(args)>(args)...);
             setup.client.runIterate();
-            return future.get().value();
+            return future.get();
         } else {
             return services::call(std::forward<decltype(args)>(args)...);
         }
@@ -720,7 +735,7 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
     }
 
     SUBCASE("Check result") {
-        const std::vector<Variant> outputs = call(
+        Result<std::vector<Variant>> result = call(
             connection,
             objectsId,
             methodId,
@@ -729,55 +744,54 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
                 Variant::fromScalar(int32_t{2}),
             }
         );
-        CHECK(outputs.size() == 1);
-        CHECK(outputs[0].getScalarCopy<int32_t>() == 3);
+        CHECK(result.value().size() == 1);
+        CHECK(result.value()[0].getScalarCopy<int32_t>() == 3);
     }
 
     SUBCASE("Propagate exception") {
         throwException = true;
-        CHECK_THROWS_WITH(
-            call(
-                connection,
-                objectsId,
-                methodId,
-                Span<const Variant>{
-                    Variant::fromScalar(int32_t{1}),
-                    Variant::fromScalar(int32_t{2}),
-                }
-            ),
-            "BadUnexpectedError"
+        auto result = call(
+            connection,
+            objectsId,
+            methodId,
+            Span<const Variant>{
+                Variant::fromScalar(int32_t{1}),
+                Variant::fromScalar(int32_t{2}),
+            }
         );
+        CHECK(result.code() == UA_STATUSCODE_BADUNEXPECTEDERROR);
     }
 
     SUBCASE("Invalid input arguments") {
-        CHECK_THROWS_WITH(
-            call(
-                connection,
-                objectsId,
-                methodId,
-                Span<const Variant>{
-                    Variant::fromScalar(true),
-                    Variant::fromScalar(11.11f),
-                }
-            ),
-            "BadInvalidArgument"
+        auto result = call(
+            connection,
+            objectsId,
+            methodId,
+            Span<const Variant>{
+                Variant::fromScalar(true),
+                Variant::fromScalar(11.11f),
+            }
         );
-        CHECK_THROWS_WITH(
-            call(connection, objectsId, methodId, Span<const Variant>{}), "BadArgumentsMissing"
+        CHECK(result.code() == UA_STATUSCODE_BADINVALIDARGUMENT);
+    }
+
+    SUBCASE("Missing arguments") {
+        auto result = call(connection, objectsId, methodId, Span<const Variant>{});
+        CHECK(result.code() == UA_STATUSCODE_BADARGUMENTSMISSING);
+    }
+
+    SUBCASE("Too many arguments") {
+        auto result = call(
+            connection,
+            objectsId,
+            methodId,
+            Span<const Variant>{
+                Variant::fromScalar(int32_t{1}),
+                Variant::fromScalar(int32_t{2}),
+                Variant::fromScalar(int32_t{3}),
+            }
         );
-        CHECK_THROWS_WITH(
-            call(
-                connection,
-                objectsId,
-                methodId,
-                Span<const Variant>{
-                    Variant::fromScalar(int32_t{1}),
-                    Variant::fromScalar(int32_t{2}),
-                    Variant::fromScalar(int32_t{3}),
-                }
-            ),
-            "BadTooManyArguments"
-        );
+        CHECK(result.code() == UA_STATUSCODE_BADTOOMANYARGUMENTS);
     }
 }
 #endif
@@ -792,42 +806,42 @@ TEST_CASE("Subscription service set (client)") {
     services::SubscriptionParameters parameters{};
 
     SUBCASE("createSubscription") {
-        const auto subId = services::createSubscription(client, parameters);
+        const auto subId = services::createSubscription(client, parameters).value();
         CAPTURE(subId);
     }
 
     SUBCASE("modifySubscription") {
-        const auto subId = services::createSubscription(client, parameters);
+        const auto subId = services::createSubscription(client, parameters).value();
 
         parameters.priority = 1;
-        CHECK_NOTHROW(services::modifySubscription(client, subId, parameters));
-        CHECK_THROWS_WITH(
-            services::modifySubscription(client, subId + 1, parameters), "BadSubscriptionIdInvalid"
+        CHECK(services::modifySubscription(client, subId, parameters).code().isGood());
+        CHECK(
+            services::modifySubscription(client, subId + 1, parameters).code() ==
+            UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID
         );
     }
 
     SUBCASE("setPublishingMode") {
-        const auto subId = services::createSubscription(client, parameters);
-
-        CHECK_NOTHROW(services::setPublishingMode(client, subId, false));
+        const auto subId = services::createSubscription(client, parameters).value();
+        CHECK(services::setPublishingMode(client, subId, false).code().isGood());
     }
 
     SUBCASE("deleteSubscription") {
-        const auto subId = services::createSubscription(client, parameters);
-
-        CHECK_NOTHROW(services::deleteSubscription(client, subId));
-        CHECK_THROWS_WITH(
-            services::deleteSubscription(client, subId + 1), "BadSubscriptionIdInvalid"
+        const auto subId = services::createSubscription(client, parameters).value();
+        CHECK(services::deleteSubscription(client, subId).code().isGood());
+        CHECK(
+            services::deleteSubscription(client, subId + 1).code() ==
+            UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID
         );
     }
 
     SUBCASE("deleteSubscription with callback") {
         bool deleted = false;
         const auto subId = services::createSubscription(client, parameters, true, [&](uint32_t) {
-            deleted = true;
-        });
+                               deleted = true;
+                           }).value();
 
-        CHECK_NOTHROW(services::deleteSubscription(client, subId));
+        CHECK(services::deleteSubscription(client, subId).code().isGood());
         CHECK(deleted == true);
     }
 }
@@ -840,24 +854,24 @@ TEST_CASE("MonitoredItem service set (client)") {
 
     // add variable node to test data change notifications
     const NodeId id{1, 1000};
-    services::addVariable(server, {0, UA_NS0ID_OBJECTSFOLDER}, id, "Variable");
+    services::addVariable(server, {0, UA_NS0ID_OBJECTSFOLDER}, id, "Variable").value();
 
     services::SubscriptionParameters subscriptionParameters{};
     services::MonitoringParametersEx monitoringParameters{};
     monitoringParameters.samplingInterval = 0.0;  // fastest
 
     SUBCASE("createMonitoredItemDataChange without subscription") {
-        CHECK_THROWS(discard(services::createMonitoredItemDataChange(
+        CHECK_FALSE(services::createMonitoredItemDataChange(
             client,
             11U,  // random subId
             {id, AttributeId::Value},
             MonitoringMode::Reporting,
             monitoringParameters,
             {}
-        )));
+        ));
     }
 
-    const auto subId = services::createSubscription(client, subscriptionParameters);
+    const auto subId = services::createSubscription(client, subscriptionParameters).value();
     CAPTURE(subId);
 
     SUBCASE("createMonitoredItemDataChange") {
@@ -876,7 +890,7 @@ TEST_CASE("MonitoredItem service set (client)") {
         );
         CAPTURE(monId);
 
-        services::writeValue(server, id, Variant::fromScalar(11.11));
+        CHECK(services::writeValue(server, id, Variant::fromScalar(11.11)).code().isGood());
         client.runIterate();
         CHECK(notificationCount > 0);
         CHECK(changedValue.getValue().getScalar<double>() == 11.11);
@@ -921,33 +935,41 @@ TEST_CASE("MonitoredItem service set (client)") {
 #endif
 
     SUBCASE("modifyMonitoredItem") {
-        const auto monId = services::createMonitoredItemDataChange(
-            client,
-            subId,
-            {id, AttributeId::Value},
-            MonitoringMode::Reporting,
-            monitoringParameters,
-            {}
-        );
+        const auto monId =
+            services::createMonitoredItemDataChange(
+                client,
+                subId,
+                {id, AttributeId::Value},
+                MonitoringMode::Reporting,
+                monitoringParameters,
+                {}
+            )
+                .value();
         CAPTURE(monId);
 
         services::MonitoringParametersEx modifiedParameters{};
         modifiedParameters.samplingInterval = 1000.0;
-        CHECK_NOTHROW(services::modifyMonitoredItem(client, subId, monId, modifiedParameters));
+        CHECK(
+            services::modifyMonitoredItem(client, subId, monId, modifiedParameters).code().isGood()
+        );
         CHECK(modifiedParameters.samplingInterval == 1000.0);  // should not be revised
     }
 
     SUBCASE("setMonitoringMode") {
-        const auto monId = services::createMonitoredItemDataChange(
-            client,
-            subId,
-            {id, AttributeId::Value},
-            MonitoringMode::Reporting,
-            monitoringParameters,
-            {}
-        );
+        const auto monId =
+            services::createMonitoredItemDataChange(
+                client,
+                subId,
+                {id, AttributeId::Value},
+                MonitoringMode::Reporting,
+                monitoringParameters,
+                {}
+            )
+                .value();
         CAPTURE(monId);
-        CHECK_NOTHROW(services::setMonitoringMode(client, subId, monId, MonitoringMode::Disabled));
+        CHECK(services::setMonitoringMode(client, subId, monId, MonitoringMode::Disabled)
+                  .code()
+                  .isGood());
     }
 
 #if UAPP_OPEN62541_VER_GE(1, 2)
@@ -955,37 +977,40 @@ TEST_CASE("MonitoredItem service set (client)") {
         // use current server time as triggering item and let it trigger the variable node
         size_t notificationCountTriggering = 0;
         size_t notificationCount = 0;
-        const auto monIdTriggering = services::createMonitoredItemDataChange(
-            client,
-            subId,
-            {VariableId::Server_ServerStatus_CurrentTime, AttributeId::Value},
-            MonitoringMode::Reporting,
-            monitoringParameters,
-            [&](uint32_t, uint32_t, const DataValue&) { notificationCountTriggering++; }
-        );
+        const auto monIdTriggering =
+            services::createMonitoredItemDataChange(
+                client,
+                subId,
+                {VariableId::Server_ServerStatus_CurrentTime, AttributeId::Value},
+                MonitoringMode::Reporting,
+                monitoringParameters,
+                [&](uint32_t, uint32_t, const DataValue&) { notificationCountTriggering++; }
+            ).value();
         // set triggered item's monitoring mode to sampling
         // -> will only report if triggered by triggering item
         // https://reference.opcfoundation.org/Core/Part4/v105/docs/5.12.1.6
-        const auto monId = services::createMonitoredItemDataChange(
-            client,
-            subId,
-            {id, AttributeId::Value},
-            MonitoringMode::Sampling,
-            monitoringParameters,
-            [&](uint32_t, uint32_t, const DataValue&) { notificationCount++; }
-        );
+        const auto monId =
+            services::createMonitoredItemDataChange(
+                client,
+                subId,
+                {id, AttributeId::Value},
+                MonitoringMode::Sampling,
+                monitoringParameters,
+                [&](uint32_t, uint32_t, const DataValue&) { notificationCount++; }
+            ).value();
 
         client.runIterate();
         CHECK(notificationCountTriggering > 0);
         CHECK(notificationCount == 0);  // no triggering links yet
 
-        services::setTriggering(
+        auto result = services::setTriggering(
             client,
             subId,
             monIdTriggering,
             {monId},  // links to add
             {}  // links to remove
         );
+        CHECK(result.code().isGood());
 
         client.runIterate();
         CHECK(notificationCount > 0);
@@ -993,22 +1018,24 @@ TEST_CASE("MonitoredItem service set (client)") {
 #endif
 
     SUBCASE("deleteMonitoredItem") {
-        CHECK_THROWS_WITH(
-            services::deleteMonitoredItem(client, subId, 11U), "BadMonitoredItemIdInvalid"
+        CHECK(
+            services::deleteMonitoredItem(client, subId, 11U).code() ==
+            UA_STATUSCODE_BADMONITOREDITEMIDINVALID
         );
 
         bool deleted = false;
-        const auto monId = services::createMonitoredItemDataChange(
-            client,
-            subId,
-            {id, AttributeId::Value},
-            MonitoringMode::Reporting,
-            monitoringParameters,
-            {},
-            [&](uint32_t, uint32_t) { deleted = true; }
-        );
+        const auto monId =
+            services::createMonitoredItemDataChange(
+                client,
+                subId,
+                {id, AttributeId::Value},
+                MonitoringMode::Reporting,
+                monitoringParameters,
+                {},
+                [&](uint32_t, uint32_t) { deleted = true; }
+            ).value();
 
-        CHECK_NOTHROW(services::deleteMonitoredItem(client, subId, monId));
+        CHECK(services::deleteMonitoredItem(client, subId, monId).code().isGood());
         client.runIterate();
         CHECK(deleted == true);
     }
@@ -1017,35 +1044,45 @@ TEST_CASE("MonitoredItem service set (client)") {
 TEST_CASE("MonitoredItem service set (server)") {
     Server server;
     const NodeId id{1, 1000};
-    services::addVariable(server, {0, UA_NS0ID_OBJECTSFOLDER}, id, "Variable");
+    services::addVariable(server, {0, UA_NS0ID_OBJECTSFOLDER}, id, "Variable").value();
 
     services::MonitoringParametersEx monitoringParameters{};
     monitoringParameters.samplingInterval = 0.0;  // fastest
 
     SUBCASE("createMonitoredItemDataChange") {
         size_t notificationCount = 0;
-        const auto monId = services::createMonitoredItemDataChange(
-            server,
-            {id, AttributeId::Value},
-            MonitoringMode::Reporting,
-            monitoringParameters,
-            [&](uint32_t, uint32_t, const DataValue&) { notificationCount++; }
-        );
+        const auto monId =
+            services::createMonitoredItemDataChange(
+                server,
+                {id, AttributeId::Value},
+                MonitoringMode::Reporting,
+                monitoringParameters,
+                [&](uint32_t, uint32_t, const DataValue&) { notificationCount++; }
+            ).value();
         CAPTURE(monId);
         std::this_thread::sleep_for(100ms);
-        services::writeValue(server, id, Variant::fromScalar(11.11));
+        services::writeValue(server, id, Variant::fromScalar(11.11)).code().throwIfBad();
         server.runIterate();
         CHECK(notificationCount > 0);
     }
 
     SUBCASE("deleteMonitoredItem") {
-        CHECK_THROWS_WITH(services::deleteMonitoredItem(server, 11U), "BadMonitoredItemIdInvalid");
-
-        const auto monId = services::createMonitoredItemDataChange(
-            server, {id, AttributeId::Value}, MonitoringMode::Reporting, monitoringParameters, {}
+        CHECK(
+            services::deleteMonitoredItem(server, 11U).code() ==
+            UA_STATUSCODE_BADMONITOREDITEMIDINVALID
         );
+
+        const auto monId =
+            services::createMonitoredItemDataChange(
+                server,
+                {id, AttributeId::Value},
+                MonitoringMode::Reporting,
+                monitoringParameters,
+                {}
+            )
+                .value();
         CAPTURE(monId);
-        CHECK_NOTHROW(services::deleteMonitoredItem(server, monId));
+        CHECK(services::deleteMonitoredItem(server, monId).code().isGood());
     }
 }
 #endif

--- a/tests/async.cpp
+++ b/tests/async.cpp
@@ -6,7 +6,7 @@
 using namespace opcua;
 
 template <typename T, typename CompletionHandler>
-static auto asyncTest(Result<T> result, CompletionHandler&& completionHandler) {
+static auto asyncTest(T result, CompletionHandler&& completionHandler) {
     return asyncInitiate<T>(
         [](auto... args) { std::invoke(args...); },
         std::forward<CompletionHandler>(completionHandler),

--- a/tests/helper/discard.h
+++ b/tests/helper/discard.h
@@ -1,4 +1,0 @@
-#pragma once
-
-template <typename T>
-void discard([[maybe_unused]] T&& returnValue) {}  // NOLINT

--- a/tools/gen_attribute_highlevel.py
+++ b/tools/gen_attribute_highlevel.py
@@ -66,7 +66,7 @@ TEMPLATE_READ = """
  * @ingroup Read
  */
 template <typename T>
-inline Result<{type}> read{attr}(T& connection, const NodeId& id) {{
+inline Result<{type}> read{attr}(T& connection, const NodeId& id) noexcept {{
     return detail::readAttributeImpl<AttributeId::{attr}>(connection, id);
 }}
 
@@ -95,7 +95,7 @@ TEMPLATE_WRITE = """
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> write{attr}(T& connection, const NodeId& id, {param_type} {param_name}) {{
+inline Result<void> write{attr}(T& connection, const NodeId& id, {param_type} {param_name}) noexcept {{
     return detail::writeAttributeImpl<AttributeId::{attr}>(connection, id, {param_name});
 }}
 

--- a/tools/gen_attribute_highlevel.py
+++ b/tools/gen_attribute_highlevel.py
@@ -66,7 +66,7 @@ TEMPLATE_READ = """
  * @ingroup Read
  */
 template <typename T>
-inline {type} read{attr}(T& connection, const NodeId& id) {{
+inline Result<{type}> read{attr}(T& connection, const NodeId& id) {{
     return detail::readAttributeImpl<AttributeId::{attr}>(connection, id);
 }}
 
@@ -95,8 +95,8 @@ TEMPLATE_WRITE = """
  * @ingroup Write
  */
 template <typename T>
-inline void write{attr}(T& connection, const NodeId& id, {param_type} {param_name}) {{
-    detail::writeAttributeImpl<AttributeId::{attr}>(connection, id, {param_name});
+inline Result<void> write{attr}(T& connection, const NodeId& id, {param_type} {param_name}) {{
+    return detail::writeAttributeImpl<AttributeId::{attr}>(connection, id, {param_name});
 }}
 
 /**
@@ -112,7 +112,7 @@ inline auto write{attr}Async(
     {param_type} {param_name},
     CompletionToken&& token = DefaultCompletionToken()
 ) {{
-    detail::writeAttributeAsyncImpl<AttributeId::{attr}>(
+    return detail::writeAttributeAsyncImpl<AttributeId::{attr}>(
         connection, id, {param_name}, std::forward<CompletionToken>(token)
     );
 }}


### PR DESCRIPTION
Return `Result<T>` from all functions in the `services` namespace.
This makes the functions effectively `noexcept` and allows other error handling mechanism than exceptions.
- The sync services functions are marked `noexcept`
- The async services functions can not be marked `noexcept` yet, because heap memory is allocated for the async callback context and this might result in a `std::bad_alloc` exception