### PR TITLE
ci: fix gcc 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
             gcov: gcov-12
 
           - name: Linux GCC 13
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             compiler: g++-13
             coverage: true
             gcov: gcov-13


### PR DESCRIPTION
GCC 13 was removed from Ubuntu 22.04 image: https://github.com/actions/runner-images/issues/9866