### PR TITLE
ci: use ubuntu 24.04 image and new available compilers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
             gcov: gcov-11
 
           - name: Linux GCC 12
-            os: ubuntu-22.04
+            os: ubuntu-24.04
             compiler: g++-12
             coverage: true
             gcov: gcov-12
@@ -41,6 +41,12 @@ jobs:
             compiler: g++-13
             coverage: true
             gcov: gcov-13
+
+          - name: Linux GCC 14
+            os: ubuntu-24.04
+            compiler: g++-14
+            coverage: true
+            gcov: gcov-14
 
           - name: Linux Clang 13
             os: ubuntu-22.04
@@ -60,19 +66,37 @@ jobs:
             coverage: true
             gcov: llvm-cov-15 gcov
 
+          - name: Linux Clang 16
+            os: ubuntu-24.04
+            compiler: clang++-16
+            coverage: true
+            gcov: llvm-cov-16 gcov
+
+          - name: Linux Clang 17
+            os: ubuntu-24.04
+            compiler: clang++-17
+            coverage: true
+            gcov: llvm-cov-17 gcov
+
+          - name: Linux Clang 18
+            os: ubuntu-24.04
+            compiler: clang++-18
+            coverage: true
+            gcov: llvm-cov-18 gcov
+
           - name: Linux ASan
-            os: ubuntu-22.04
-            compiler: clang++-15
+            os: ubuntu-24.04
+            compiler: clang++-18
             flags: "-DUAPP_ENABLE_SANITIZER_ADDRESS=ON"
 
           - name: Linux TSan
-            os: ubuntu-22.04
-            compiler: clang++-15
+            os: ubuntu-24.04
+            compiler: clang++-18
             flags: "-DUAPP_ENABLE_SANITIZER_THREAD=ON"
 
           - name: Linux UBSan
-            os: ubuntu-22.04
-            compiler: clang++-15
+            os: ubuntu-24.04
+            compiler: clang++-18
             flags: "-DUAPP_ENABLE_SANITIZER_UNDEFINED_BEHAVIOR=ON"
 
           - name: macOS AppleClang 14

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   doc:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   linux:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/open62541-compatibility.yml
+++ b/.github/workflows/open62541-compatibility.yml
@@ -12,7 +12,7 @@ jobs:
       (${{ matrix.build_type }},
       ${{ matrix.library_type }},
       ${{ matrix.amalgamation && 'amalgamated' || 'default' }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   cmake:
     name: CMake package (${{ matrix.build_type }}, ${{ matrix.library_type }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
- Add new available compilers to CI workflow: Clang 16, 17, 18