### PR TITLE
fix: stack overflow in session registry when running from different translation units

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -102,6 +102,7 @@ struct ServerConnection : public ConnectionBase<Server> {
     ServerConnection& operator=(ServerConnection&&) noexcept = delete;
 
     void applySessionRegistry() {
+#if UAPP_OPEN62541_VER_GE(1, 3)
         if (config->accessControl.activateSession != &activateSession) {
             context.sessionRegistry.activateSessionUser = config->accessControl.activateSession;
             config->accessControl.activateSession = &activateSession;
@@ -110,6 +111,7 @@ struct ServerConnection : public ConnectionBase<Server> {
             context.sessionRegistry.closeSessionUser = config->accessControl.closeSession;
             config->accessControl.closeSession = &closeSession;
         }
+#endif
     }
 
     void applyDefaults() {

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -103,6 +103,11 @@ struct ServerConnection : public ConnectionBase<Server> {
 
     void applySessionRegistry() {
 #if UAPP_OPEN62541_VER_GE(1, 3)
+        // Make sure to call this function only once after access control is initialized or changed.
+        // The function pointers to activateSession / closeSession might not be unique and the
+        // the pointer comparison might fail resulting in stack overflows:
+        // - https://github.com/open62541pp/open62541pp/issues/285
+        // - https://stackoverflow.com/questions/31209693/static-library-linked-two-times
         if (config->accessControl.activateSession != &activateSession) {
             context.sessionRegistry.activateSessionUser = config->accessControl.activateSession;
             config->accessControl.activateSession = &activateSession;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -101,6 +101,17 @@ struct ServerConnection : public ConnectionBase<Server> {
     ServerConnection& operator=(const ServerConnection&) = delete;
     ServerConnection& operator=(ServerConnection&&) noexcept = delete;
 
+    void applySessionRegistry() {
+        if (config->accessControl.activateSession != &activateSession) {
+            context.sessionRegistry.activateSessionUser = config->accessControl.activateSession;
+            config->accessControl.activateSession = &activateSession;
+        }
+        if (config->accessControl.closeSession != &closeSession) {
+            context.sessionRegistry.closeSessionUser = config->accessControl.closeSession;
+            config->accessControl.closeSession = &closeSession;
+        }
+    }
+
     void applyDefaults() {
 #ifdef UA_ENABLE_SUBSCRIPTIONS
         config->publishingIntervalLimits.min = 10;  // ms
@@ -111,14 +122,6 @@ struct ServerConnection : public ConnectionBase<Server> {
 #endif
 #if UAPP_OPEN62541_VER_GE(1, 3)
         config->context = this;
-        if (config->accessControl.activateSession != &activateSession) {
-            context.sessionRegistry.activateSessionUser = config->accessControl.activateSession;
-            config->accessControl.activateSession = &activateSession;
-        }
-        if (config->accessControl.closeSession != &closeSession) {
-            context.sessionRegistry.closeSessionUser = config->accessControl.closeSession;
-            config->accessControl.closeSession = &closeSession;
-        }
 #endif
     }
 
@@ -191,6 +194,7 @@ Server::Server(uint16_t port, ByteString certificate, Logger logger)
     setConfig();
     setLogger(std::move(logger));
 #endif
+    connection_->applySessionRegistry();
     connection_->applyDefaults();
 }
 
@@ -216,6 +220,7 @@ Server::Server(
         asNative(revocationList.data()),
         revocationList.size()
     ));
+    connection_->applySessionRegistry();
     connection_->applyDefaults();
 }
 #endif
@@ -262,12 +267,12 @@ void Server::setProductUri(std::string_view uri) {
 
 void Server::setAccessControl(AccessControlBase& accessControl) {
     connection_->config.setAccessControl(accessControl);
-    connection_->applyDefaults();
+    connection_->applySessionRegistry();
 }
 
 void Server::setAccessControl(std::unique_ptr<AccessControlBase> accessControl) {
     connection_->config.setAccessControl(std::move(accessControl));
-    connection_->applyDefaults();
+    connection_->applySessionRegistry();
 }
 
 std::vector<Session> Server::getSessions() {


### PR DESCRIPTION
Avoid multiple calls to `applyDefaults` from different translation units where the session registry is applied. Instead only apply the session registry after the server config is created or the access control set.

Closes #285.