### PR TITLE
refactor: `getNamespace` overloads for node id enums

### DIFF
--- a/include/open62541pp/Common.h
+++ b/include/open62541pp/Common.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string_view>
 
 #include "open62541pp/Bitmask.h"
 
@@ -9,6 +10,12 @@ namespace opcua {
 /// Namespace index.
 /// @see https://reference.opcfoundation.org/Core/Part3/v105/docs/8.2.2
 using NamespaceIndex = uint16_t;
+
+/// Namespace with index and URI.
+struct Namespace {
+    NamespaceIndex index;
+    std::string_view uri;
+};
 
 /// Type index of the ::UA_TYPES array.
 using TypeIndex = uint16_t;

--- a/include/open62541pp/NodeIds.h
+++ b/include/open62541pp/NodeIds.h
@@ -4,6 +4,10 @@
 
 #pragma once
 
+#include <cstdint>
+
+#include "open62541pp/Common.h"  // Namespace
+
 // ignore (false-positive?) warning of GCC:
 // declaration of ‘MonitoringParameters’ shadows a global declaration
 #ifndef _MSC_VER
@@ -437,6 +441,14 @@ enum class DataTypeId : int32_t {
 };
 
 /**
+ * Get namespace of DataTypeId.
+ * @ingroup NodeIds
+ */
+constexpr Namespace getNamespace(DataTypeId /* unused */) noexcept {
+    return {0, "http://opcfoundation.org/UA/"};
+}
+
+/**
  * ReferenceType node ids defined by the OPC UA specification (generated).
  * @see https://reference.opcfoundation.org/Core/Part6/v105/docs/A.3
  * @ingroup NodeIds
@@ -489,6 +501,14 @@ enum class ReferenceTypeId : int32_t {
     HasReaderGroup = 18805,
     AliasFor = 23469,
 };
+
+/**
+ * Get namespace of ReferenceTypeId.
+ * @ingroup NodeIds
+ */
+constexpr Namespace getNamespace(ReferenceTypeId /* unused */) noexcept {
+    return {0, "http://opcfoundation.org/UA/"};
+}
 
 /**
  * ObjectType node ids defined by the OPC UA specification (generated).
@@ -732,6 +752,14 @@ enum class ObjectTypeId : int32_t {
 };
 
 /**
+ * Get namespace of ObjectTypeId.
+ * @ingroup NodeIds
+ */
+constexpr Namespace getNamespace(ObjectTypeId /* unused */) noexcept {
+    return {0, "http://opcfoundation.org/UA/"};
+}
+
+/**
  * VariableType node ids defined by the OPC UA specification (generated).
  * @see https://reference.opcfoundation.org/Core/Part6/v105/docs/A.3
  * @ingroup NodeIds
@@ -797,6 +825,14 @@ enum class VariableTypeId : int32_t {
     MultiStateDictionaryEntryDiscreteType = 19084,
     PubSubDiagnosticsCounterType = 19725,
 };
+
+/**
+ * Get namespace of VariableTypeId.
+ * @ingroup NodeIds
+ */
+constexpr Namespace getNamespace(VariableTypeId /* unused */) noexcept {
+    return {0, "http://opcfoundation.org/UA/"};
+}
 
 /**
  * Object node ids defined by the OPC UA specification (generated).
@@ -2174,6 +2210,14 @@ enum class ObjectId : int32_t {
     TalkerStreams = 24231,
     ListenerStreams = 24232,
 };
+
+/**
+ * Get namespace of ObjectId.
+ * @ingroup NodeIds
+ */
+constexpr Namespace getNamespace(ObjectId /* unused */) noexcept {
+    return {0, "http://opcfoundation.org/UA/"};
+}
 
 /**
  * Variable node ids defined by the OPC UA specification (generated).
@@ -13402,6 +13446,14 @@ enum class VariableId : int32_t {
 };
 
 /**
+ * Get namespace of VariableId.
+ * @ingroup NodeIds
+ */
+constexpr Namespace getNamespace(VariableId /* unused */) noexcept {
+    return {0, "http://opcfoundation.org/UA/"};
+}
+
+/**
  * Method node ids defined by the OPC UA specification (generated).
  * @see https://reference.opcfoundation.org/Core/Part6/v105/docs/A.3
  * @ingroup NodeIds
@@ -14578,6 +14630,14 @@ enum class MethodId : int32_t {
     ServerConfiguration_CertificateGroups_DefaultHttpsGroup_GetRejectedList = 23552,
     ServerConfiguration_CertificateGroups_DefaultUserTokenGroup_GetRejectedList = 23554,
 };
+
+/**
+ * Get namespace of MethodId.
+ * @ingroup NodeIds
+ */
+constexpr Namespace getNamespace(MethodId /* unused */) noexcept {
+    return {0, "http://opcfoundation.org/UA/"};
+}
 
 // clang-format on
 

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -309,7 +309,7 @@ TEST_CASE("NodeId") {
     }
 #endif
 
-    SUBCASE("Construct from ids") {
+    SUBCASE("Construct from node id enums") {
         CHECK(NodeId(DataTypeId::Boolean) == NodeId(0, UA_NS0ID_BOOLEAN));
         CHECK(NodeId(ReferenceTypeId::References) == NodeId(0, UA_NS0ID_REFERENCES));
         CHECK(NodeId(ObjectTypeId::BaseObjectType) == NodeId(0, UA_NS0ID_BASEOBJECTTYPE));

--- a/tools/gen_nodeids.py
+++ b/tools/gen_nodeids.py
@@ -13,6 +13,10 @@ TEMPLATE_HEADER = """
 
 #pragma once
 
+#include <cstdint>
+
+#include "open62541pp/Common.h"  // Namespace
+
 // ignore (false-positive?) warning of GCC:
 // declaration of ‘MonitoringParameters’ shadows a global declaration
 #ifndef _MSC_VER
@@ -50,6 +54,14 @@ TEMPLATE_ENUM = """
 enum class {enum_name} : int32_t {{
 {body}
 }};
+
+/**
+ * Get namespace of {enum_name}.
+ * @ingroup NodeIds
+ */
+constexpr Namespace getNamespace({enum_name} /* unused */) noexcept {{
+    return {{0, "http://opcfoundation.org/UA/"}};
+}}
 """.strip()
 
 


### PR DESCRIPTION
Decouple `NodeId` from `NodeIds.h` header