### PR TITLE
feat!: remove Server overloads in MonitoredItem service set

### DIFF
--- a/include/open62541pp/services/MonitoredItem.h
+++ b/include/open62541pp/services/MonitoredItem.h
@@ -132,26 +132,6 @@ template <typename T>
 );
 
 /**
- * Create a local monitored item for data change notifications.
- * Don't use this function to monitor the `EventNotifier` attribute.
- * @copydetails MonitoringParametersEx
- *
- * @return Server-assigned identifier of the monitored item
- * @param connection Instance of type Server
- * @param itemToMonitor Item to monitor
- * @param monitoringMode Monitoring mode
- * @param parameters Monitoring parameters, may be revised by server
- * @param dataChangeCallback Invoked when the monitored item is changed
- */
-[[nodiscard]] Result<uint32_t> createMonitoredItemDataChange(
-    Server& connection,
-    const ReadValueId& itemToMonitor,
-    MonitoringMode monitoringMode,
-    MonitoringParametersEx& parameters,
-    DataChangeNotificationCallback dataChangeCallback
-);
-
-/**
  * Create and add a monitored item to a subscription for event notifications.
  * The `attributeId` of ReadValueId must be set to AttributeId::EventNotifier.
  * @copydetails MonitoringParametersEx
@@ -268,14 +248,6 @@ Result<void> setTriggering(
  */
 template <typename T>
 Result<void> deleteMonitoredItem(T& connection, uint32_t subscriptionId, uint32_t monitoredItemId);
-
-/**
- * Delete a local monitored item.
- *
- * @param connection Instance of type Server
- * @param monitoredItemId Identifier of the monitored item
- */
-Result<void> deleteMonitoredItem(Server& connection, uint32_t monitoredItemId);
 
 /**
  * @}

--- a/src/services/MonitoredItem.cpp
+++ b/src/services/MonitoredItem.cpp
@@ -113,18 +113,6 @@ Result<uint32_t> createMonitoredItemDataChange<Server>(
     return createMonitoredItem(connection, 0U, parameters, std::move(context), result);
 }
 
-Result<uint32_t> createMonitoredItemDataChange(
-    Server& connection,
-    const ReadValueId& itemToMonitor,
-    MonitoringMode monitoringMode,
-    MonitoringParametersEx& parameters,
-    DataChangeNotificationCallback dataChangeCallback
-) {
-    return createMonitoredItemDataChange(
-        connection, 0U, itemToMonitor, monitoringMode, parameters, std::move(dataChangeCallback)
-    );
-}
-
 Result<uint32_t> createMonitoredItemEvent(
     Client& connection,
     uint32_t subscriptionId,
@@ -239,10 +227,6 @@ Result<void> deleteMonitoredItem<Server>(
     );
     opcua::detail::getContext(connection).monitoredItems.erase({0U, monitoredItemId});
     return result;
-}
-
-Result<void> deleteMonitoredItem(Server& connection, uint32_t monitoredItemId) {
-    return deleteMonitoredItem(connection, 0U, monitoredItemId);
 }
 
 }  // namespace opcua::services

--- a/tests/Services.cpp
+++ b/tests/Services.cpp
@@ -1116,6 +1116,7 @@ TEST_CASE("MonitoredItem service set (server)") {
         const auto monId =
             services::createMonitoredItemDataChange(
                 server,
+                0U,
                 {id, AttributeId::Value},
                 MonitoringMode::Reporting,
                 monitoringParameters,
@@ -1130,13 +1131,14 @@ TEST_CASE("MonitoredItem service set (server)") {
 
     SUBCASE("deleteMonitoredItem") {
         CHECK(
-            services::deleteMonitoredItem(server, 11U).code() ==
+            services::deleteMonitoredItem(server, 0U, 11U).code() ==
             UA_STATUSCODE_BADMONITOREDITEMIDINVALID
         );
 
         const auto monId =
             services::createMonitoredItemDataChange(
                 server,
+                0U,
                 {id, AttributeId::Value},
                 MonitoringMode::Reporting,
                 monitoringParameters,
@@ -1144,7 +1146,7 @@ TEST_CASE("MonitoredItem service set (server)") {
             )
                 .value();
         CAPTURE(monId);
-        CHECK(services::deleteMonitoredItem(server, monId));
+        CHECK(services::deleteMonitoredItem(server, 0U, monId));
     }
 }
 #endif


### PR DESCRIPTION
Just use the symmetric functions for both `Client` and `Server` and pass `0U` as the `subscriptionId`:

```diff
- services::createMonitoredItemDataChange(server, ...)
+ services::createMonitoredItemDataChange(server, 0U, ...)

- services::deleteMonitoredItem(server, ...)
+ services::deleteMonitoredItem(server, 0U, ...)
```