### PR TITLE
feat!: add subscription status change notification callback

### DIFF
--- a/include/open62541pp/services/Subscription.h
+++ b/include/open62541pp/services/Subscription.h
@@ -5,6 +5,7 @@
 
 #include "open62541pp/Config.h"
 #include "open62541pp/Result.h"
+#include "open62541pp/types/Composed.h"  // StatusChangeNotification
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
 
@@ -62,12 +63,21 @@ struct SubscriptionParameters {
  */
 using DeleteSubscriptionCallback = std::function<void(uint32_t subId)>;
 
+/**s
+ * Subscription status change notification callback.
+ * @param subId Subscription identifier
+ * @param notification Status change notification
+ */
+using StatusChangeNotificationCallback =
+    std::function<void(uint32_t subId, StatusChangeNotification& notification)>;
+
 /**
  * Create a subscription.
  * @copydetails SubscriptionParameters
  * @param connection Instance of type Client
  * @param parameters Subscription parameters, may be revised by server
  * @param publishingEnabled Enable/disable publishing of the subscription
+ * @param statusChangeCallback Invoked when the status of a subscription is changed
  * @param deleteCallback Invoked when the subscription is deleted
  * @return Server-assigned identifier of the subscription
  */
@@ -75,6 +85,7 @@ using DeleteSubscriptionCallback = std::function<void(uint32_t subId)>;
     Client& connection,
     SubscriptionParameters& parameters,
     bool publishingEnabled = true,
+    StatusChangeNotificationCallback statusChangeCallback = {},
     DeleteSubscriptionCallback deleteCallback = {}
 );
 

--- a/include/open62541pp/types/Composed.h
+++ b/include/open62541pp/types/Composed.h
@@ -2126,9 +2126,7 @@ public:
     using TypeWrapper::TypeWrapper;
 
     DeleteMonitoredItemsRequest(
-        RequestHeader requestHeader,
-        uint32_t subscriptionId,
-        Span<const uint32_t> monitoredItemIds
+        RequestHeader requestHeader, uint32_t subscriptionId, Span<const uint32_t> monitoredItemIds
     ) {
         handle()->requestHeader = detail::toNative(std::move(requestHeader));
         handle()->subscriptionId = subscriptionId;
@@ -2297,6 +2295,19 @@ public:
     UAPP_GETTER_SPAN_WRAPPER(
         DiagnosticInfo, getDiagnosticInfos, diagnosticInfos, diagnosticInfosSize
     )
+};
+
+/**
+ * UA_StatusChangeNotification wrapper class.
+ * @see https://reference.opcfoundation.org/Core/Part4/v105/docs/7.25.4
+ */
+class StatusChangeNotification
+    : public TypeWrapper<UA_StatusChangeNotification, UA_TYPES_STATUSCHANGENOTIFICATION> {
+public:
+    using TypeWrapper::TypeWrapper;
+
+    UAPP_GETTER_WRAPPER(StatusCode, getStatus, status)
+    UAPP_GETTER_WRAPPER(DiagnosticInfo, getDiagnosticInfo, diagnosticInfo)
 };
 
 #endif

--- a/src/services/Subscription.cpp
+++ b/src/services/Subscription.cpp
@@ -23,17 +23,19 @@ Result<uint32_t> createSubscription(
     Client& connection,
     SubscriptionParameters& parameters,
     bool publishingEnabled,
+    StatusChangeNotificationCallback statusChangeCallback,
     DeleteSubscriptionCallback deleteCallback
 ) {
     auto context = std::make_unique<detail::SubscriptionContext>();
     context->catcher = &opcua::detail::getContext(connection).exceptionCatcher;
+    context->statusChangeCallback = std::move(statusChangeCallback);
     context->deleteCallback = std::move(deleteCallback);
 
     const CreateSubscriptionResponse response = UA_Client_Subscriptions_create(
         connection.handle(),
         detail::createCreateSubscriptionRequest(parameters, publishingEnabled),
         context.get(),
-        nullptr,  // statusChangeCallback
+        context->statusChangeCallbackNative,
         context->deleteCallbackNative
     );
     if (StatusCode serviceResult = detail::getServiceResult(response); serviceResult.isBad()) {

--- a/tests/Services.cpp
+++ b/tests/Services.cpp
@@ -903,9 +903,9 @@ TEST_CASE("Subscription service set (client)") {
 
     SUBCASE("deleteSubscription with callback") {
         bool deleted = false;
-        const auto subId = services::createSubscription(client, parameters, true, [&](uint32_t) {
-                               deleted = true;
-                           }).value();
+        const auto deleteCallback = [&](uint32_t) { deleted = true; };
+        const auto subId =
+            services::createSubscription(client, parameters, true, {}, deleteCallback).value();
 
         CHECK(services::deleteSubscription(client, subId));
         CHECK(deleted == true);

--- a/tests/Services.cpp
+++ b/tests/Services.cpp
@@ -864,10 +864,9 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
 TEST_CASE("Subscription service set (client)") {
-    Server server;
-    ServerRunner serverRunner(server);
-    Client client;
-    client.connect("opc.tcp://localhost:4840");
+    ServerClientSetup setup;
+    setup.client.connect(setup.endpointUrl);
+    auto& client = setup.client;
 
     services::SubscriptionParameters parameters{};
 
@@ -913,10 +912,10 @@ TEST_CASE("Subscription service set (client)") {
 }
 
 TEST_CASE("MonitoredItem service set (client)") {
-    Server server;
-    ServerRunner serverRunner(server);
-    Client client;
-    client.connect("opc.tcp://localhost:4840");
+    ServerClientSetup setup;
+    setup.client.connect(setup.endpointUrl);
+    auto& server = setup.server;
+    auto& client = setup.client;
 
     // add variable node to test data change notifications
     const NodeId id{1, 1000};


### PR DESCRIPTION
New function parameter in `services::createSubscription`:

```diff
[[nodiscard]] Result<uint32_t> createSubscription(
    Client& connection,
    SubscriptionParameters& parameters,
    bool publishingEnabled = true,
+    StatusChangeNotificationCallback statusChangeCallback = {},
    DeleteSubscriptionCallback deleteCallback = {}
);
```