### PR TITLE
feat: raw monitoreditem service

### DIFF
--- a/include/open62541pp/services/MonitoredItem.h
+++ b/include/open62541pp/services/MonitoredItem.h
@@ -7,7 +7,10 @@
 #include "open62541pp/Config.h"
 #include "open62541pp/Result.h"
 #include "open62541pp/Span.h"
+#include "open62541pp/types/Composed.h"
+#include "open62541pp/types/DataValue.h"
 #include "open62541pp/types/ExtensionObject.h"
+#include "open62541pp/types/Variant.h"
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
 
@@ -15,9 +18,6 @@
 namespace opcua {
 class Client;
 class Server;
-class DataValue;
-class ReadValueId;
-class Variant;
 }  // namespace opcua
 
 namespace opcua::services {
@@ -105,6 +105,23 @@ using EventNotificationCallback =
     std::function<void(uint32_t subId, uint32_t monId, Span<const Variant> eventFields)>;
 
 /**
+ * Create and add monitored items to a subscription for data change notifications.
+ * Don't use this function to monitor the `EventNotifier` attribute.
+ * Create monitored items with @ref createMonitoredItemsEvent instead.
+ *
+ * @param connection Instance of type Client
+ * @param request Create monitored items request
+ * @param dataChangeCallback Invoked when the monitored item is changed
+ * @param deleteCallback Invoked when the monitored item is deleted
+ */
+CreateMonitoredItemsResponse createMonitoredItemsDataChange(
+    Client& connection,
+    const CreateMonitoredItemsRequest& request,
+    DataChangeNotificationCallback dataChangeCallback,
+    DeleteMonitoredItemCallback deleteCallback = {}
+);
+
+/**
  * Create and add a monitored item to a subscription for data change notifications.
  * Don't use this function to monitor the `EventNotifier` attribute.
  * Create a monitored item with @ref createMonitoredItemEvent instead.
@@ -128,6 +145,22 @@ template <typename T>
     MonitoringMode monitoringMode,
     MonitoringParametersEx& parameters,
     DataChangeNotificationCallback dataChangeCallback,
+    DeleteMonitoredItemCallback deleteCallback = {}
+);
+
+/**
+ * Create and add monitored items to a subscription for event notifications.
+ * The `attributeId` of ReadValueId must be set to AttributeId::EventNotifier.
+ *
+ * @param connection Instance of type Client
+ * @param request Create monitored items request
+ * @param eventCallback Invoked when an event is published
+ * @param deleteCallback Invoked when the monitored item is deleted
+ */
+CreateMonitoredItemsResponse createMonitoredItemsEvent(
+    Client& connection,
+    const CreateMonitoredItemsRequest& request,
+    EventNotificationCallback eventCallback,
     DeleteMonitoredItemCallback deleteCallback = {}
 );
 
@@ -164,6 +197,16 @@ template <typename T>
  */
 
 /**
+ * Modify monitored items of a subscription.
+ *
+ * @param connection Instance of type Client
+ * @param request Modify monitored items request
+ */
+ModifyMonitoredItemsResponse modifyMonitoredItems(
+    Client& connection, const ModifyMonitoredItemsRequest& request
+) noexcept;
+
+/**
  * Modify a monitored item of a subscription.
  * @copydetails MonitoringParametersEx
  *
@@ -188,6 +231,16 @@ Result<void> modifyMonitoredItem(
  */
 
 /**
+ * Set the monitoring mode of monitored items.
+ *
+ * @param connection Instance of type Client
+ * @param request Set monitoring mode request
+ */
+SetMonitoringModeResponse setMonitoringMode(
+    Client& connection, const SetMonitoringModeRequest& request
+) noexcept;
+
+/**
  * Set the monitoring mode of a monitored item.
  *
  * @param connection Instance of type Client
@@ -210,6 +263,18 @@ Result<void> setMonitoringMode(
  * @see https://reference.opcfoundation.org/Core/Part4/v105/docs/5.12.5
  * @{
  */
+
+/**
+ * Add and delete triggering links of monitored items.
+ * The triggering item and the items to report shall belong to the same subscription.
+ * @note Supported since open62541 v1.2
+ *
+ * @param connection Instance of type Client
+ * @param request Set triggering request
+ */
+SetTriggeringResponse setTriggering(
+    Client& connection, const SetTriggeringRequest& request
+) noexcept;
 
 /**
  * Add and delete triggering links of a monitored item.
@@ -237,6 +302,16 @@ Result<void> setTriggering(
  * @see https://reference.opcfoundation.org/Core/Part4/v105/docs/5.12.6
  * @{
  */
+
+/**
+ * Delete monitored items from subscriptions.
+ *
+ * @param connection Instance of type Client
+ * @param request Delete monitored items request
+ */
+DeleteMonitoredItemsResponse deleteMonitoredItems(
+    Client& connection, const DeleteMonitoredItemsRequest& request
+) noexcept;
 
 /**
  * Delete a monitored item from a subscription.

--- a/include/open62541pp/services/detail/ResponseHandling.h
+++ b/include/open62541pp/services/detail/ResponseHandling.h
@@ -45,7 +45,7 @@ inline const UA_ResponseHeader& getResponseHeader(const Response& response) noex
 }
 
 template <typename Response>
-inline UA_StatusCode getServiceResult(const Response& response) noexcept {
+inline StatusCode getServiceResult(const Response& response) noexcept {
     return getResponseHeader(response).serviceResult;
 }
 
@@ -108,6 +108,13 @@ inline void reviseMonitoringParameters(
     parameters.samplingInterval = result.revisedSamplingInterval;
     parameters.queueSize = result.revisedQueueSize;
     parameters.filter = asWrapper<ExtensionObject>(result.filterResult);
+}
+
+inline Result<uint32_t> getMonitoredItemId(const UA_MonitoredItemCreateResult& result) noexcept {
+    if (StatusCode code = result.statusCode; code.isBad()) {
+        return BadResult(code);
+    }
+    return result.monitoredItemId;
 }
 
 }  // namespace opcua::services::detail

--- a/src/services/MonitoredItem.cpp
+++ b/src/services/MonitoredItem.cpp
@@ -17,9 +17,6 @@
 #include "open62541pp/services/detail/ClientService.h"
 #include "open62541pp/services/detail/RequestHandling.h"
 #include "open62541pp/services/detail/ResponseHandling.h"
-#include "open62541pp/types/Composed.h"
-#include "open62541pp/types/DataValue.h"
-#include "open62541pp/types/Variant.h"
 
 namespace opcua::services {
 
@@ -27,9 +24,9 @@ template <typename T>
 inline static auto createMonitoredItemContext(
     T& connection,
     const ReadValueId& itemToMonitor,
-    DataChangeNotificationCallback dataChangeCallback,
-    EventNotificationCallback eventCallback,
-    DeleteMonitoredItemCallback deleteCallback
+    DataChangeNotificationCallback&& dataChangeCallback,
+    EventNotificationCallback&& eventCallback,
+    DeleteMonitoredItemCallback&& deleteCallback
 ) {
     auto context = std::make_unique<detail::MonitoredItemContext>();
     context->catcher = &opcua::detail::getContext(connection).exceptionCatcher;
@@ -41,24 +38,84 @@ inline static auto createMonitoredItemContext(
 }
 
 template <typename T>
-inline static Result<uint32_t> createMonitoredItem(
+inline static auto createMonitoredItemContexts(
+    T& connection,
+    const CreateMonitoredItemsRequest& request,
+    DataChangeNotificationCallback&& dataChangeCallback,
+    EventNotificationCallback&& eventCallback,
+    DeleteMonitoredItemCallback&& deleteCallback
+) {
+    std::vector<std::unique_ptr<detail::MonitoredItemContext>> contexts;
+    for (const auto& item : request.getItemsToCreate()) {
+        contexts.push_back(createMonitoredItemContext(
+            connection,
+            item.getItemToMonitor(),
+            std::move(dataChangeCallback),
+            std::move(eventCallback),
+            std::move(deleteCallback)
+        ));
+    }
+    return contexts;
+}
+
+template <typename T>
+inline static void storeMonitoredItemContext(
     T& connection,
     uint32_t subscriptionId,
-    MonitoringParametersEx& parameters,
-    std::unique_ptr<detail::MonitoredItemContext> context,
-    const UA_MonitoredItemCreateResult& result
+    const MonitoredItemCreateResult& result,
+    std::unique_ptr<detail::MonitoredItemContext>& context
 ) {
-    if (StatusCode code = result.statusCode; code.isBad()) {
-        return BadResult(code);
+    if (result.getStatusCode().isGood()) {
+        auto* contextPtr = context.get();
+        opcua::detail::getContext(connection)
+            .monitoredItems.insert(
+                {subscriptionId, result.getMonitoredItemId()}, std::move(context)
+            );
+        contextPtr->inserted = true;
     }
-    detail::reviseMonitoringParameters(parameters, result);
+}
 
-    const auto monitoredItemId = result.monitoredItemId;
-    auto* contextPtr = context.get();
-    opcua::detail::getContext(connection)
-        .monitoredItems.insert({subscriptionId, monitoredItemId}, std::move(context));
-    contextPtr->inserted = true;
-    return monitoredItemId;
+template <typename T>
+inline static void storeMonitoredItemContexts(
+    T& connection,
+    uint32_t subscriptionId,
+    const CreateMonitoredItemsResponse& response,
+    Span<std::unique_ptr<detail::MonitoredItemContext>> contexts
+) {
+    if (detail::getServiceResult(response).isGood()) {
+        const auto& results = response.getResults();
+        for (size_t i = 0; i < results.size(); ++i) {
+            storeMonitoredItemContext(connection, subscriptionId, results[i], contexts[i]);
+        }
+    }
+}
+
+CreateMonitoredItemsResponse createMonitoredItemsDataChange(
+    Client& connection,
+    const CreateMonitoredItemsRequest& request,
+    DataChangeNotificationCallback dataChangeCallback,
+    DeleteMonitoredItemCallback deleteCallback
+) {
+    auto contexts = createMonitoredItemContexts(
+        connection, request, std::move(dataChangeCallback), {}, std::move(deleteCallback)
+    );
+    std::vector<void*> contextsRaw;
+    std::vector<UA_Client_DataChangeNotificationCallback> dataChangeCallbacks;
+    std::vector<UA_Client_DeleteMonitoredItemCallback> deleteCallbacks;
+    for (const auto& context : contexts) {
+        contextsRaw.push_back(context.get());
+        dataChangeCallbacks.push_back(context->dataChangeCallbackNativeClient);
+        deleteCallbacks.push_back(context->deleteCallbackNative);
+    }
+    CreateMonitoredItemsResponse response = UA_Client_MonitoredItems_createDataChanges(
+        connection.handle(),
+        request,
+        contextsRaw.data(),
+        dataChangeCallbacks.data(),
+        deleteCallbacks.data()
+    );
+    storeMonitoredItemContexts(connection, request.getSubscriptionId(), response, contexts);
+    return response;
 }
 
 template <>
@@ -83,7 +140,9 @@ Result<uint32_t> createMonitoredItemDataChange<Client>(
         context->dataChangeCallbackNativeClient,
         context->deleteCallbackNative
     );
-    return createMonitoredItem(connection, subscriptionId, parameters, std::move(context), result);
+    detail::reviseMonitoringParameters(parameters, asNative(result));
+    storeMonitoredItemContext(connection, subscriptionId, result, context);
+    return detail::getMonitoredItemId(result);
 }
 
 template <>
@@ -106,7 +165,37 @@ Result<uint32_t> createMonitoredItemDataChange<Server>(
         context.get(),
         context->dataChangeCallbackNativeServer
     );
-    return createMonitoredItem(connection, 0U, parameters, std::move(context), result);
+    detail::reviseMonitoringParameters(parameters, asNative(result));
+    storeMonitoredItemContext(connection, 0U, result, context);
+    return detail::getMonitoredItemId(result);
+}
+
+CreateMonitoredItemsResponse createMonitoredItemsEvent(
+    Client& connection,
+    const CreateMonitoredItemsRequest& request,
+    EventNotificationCallback eventCallback,
+    DeleteMonitoredItemCallback deleteCallback
+) {
+    auto contexts = createMonitoredItemContexts(
+        connection, request, {}, std::move(eventCallback), std::move(deleteCallback)
+    );
+    std::vector<void*> contextsRaw;
+    std::vector<UA_Client_EventNotificationCallback> eventCallbacks;
+    std::vector<UA_Client_DeleteMonitoredItemCallback> deleteCallbacks;
+    for (const auto& context : contexts) {
+        contextsRaw.push_back(context.get());
+        eventCallbacks.push_back(context->eventCallbackNative);
+        deleteCallbacks.push_back(context->deleteCallbackNative);
+    }
+    CreateMonitoredItemsResponse response = UA_Client_MonitoredItems_createEvents(
+        connection.handle(),
+        request,
+        contextsRaw.data(),
+        eventCallbacks.data(),
+        deleteCallbacks.data()
+    );
+    storeMonitoredItemContexts(connection, request.getSubscriptionId(), response, contexts);
+    return response;
 }
 
 Result<uint32_t> createMonitoredItemEvent(
@@ -130,7 +219,15 @@ Result<uint32_t> createMonitoredItemEvent(
         context->eventCallbackNative,
         context->deleteCallbackNative
     );
-    return createMonitoredItem(connection, subscriptionId, parameters, std::move(context), result);
+    detail::reviseMonitoringParameters(parameters, asNative(result));
+    storeMonitoredItemContext(connection, subscriptionId, result, context);
+    return detail::getMonitoredItemId(result);
+}
+
+ModifyMonitoredItemsResponse modifyMonitoredItems(
+    Client& connection, const ModifyMonitoredItemsRequest& request
+) noexcept {
+    return UA_Client_MonitoredItems_modify(connection.handle(), request);
 }
 
 Result<void> modifyMonitoredItem(
@@ -154,6 +251,14 @@ Result<void> modifyMonitoredItem(
         });
 }
 
+SetMonitoringModeResponse setMonitoringMode(
+    Client& connection, const SetMonitoringModeRequest& request
+) noexcept {
+    return detail::sendRequest<UA_SetMonitoringModeRequest, UA_SetMonitoringModeResponse>(
+        connection, request, detail::Wrap<SetMonitoringModeResponse>{}, detail::SyncOperation{}
+    );
+}
+
 Result<void> setMonitoringMode(
     Client& connection,
     uint32_t subscriptionId,
@@ -169,6 +274,14 @@ Result<void> setMonitoringMode(
             return detail::getSingleResult(response).andThen(detail::toResult);
         },
         detail::SyncOperation{}
+    );
+}
+
+SetTriggeringResponse setTriggering(
+    Client& connection, const SetTriggeringRequest& request
+) noexcept {
+    return detail::sendRequest<UA_SetTriggeringRequest, UA_SetTriggeringResponse>(
+        connection, request, detail::Wrap<SetTriggeringResponse>{}, detail::SyncOperation{}
     );
 }
 
@@ -202,6 +315,12 @@ Result<void> setTriggering(
         },
         detail::SyncOperation{}
     );
+}
+
+DeleteMonitoredItemsResponse deleteMonitoredItems(
+    Client& connection, const DeleteMonitoredItemsRequest& request
+) noexcept {
+    return UA_Client_MonitoredItems_delete(connection.handle(), request);
 }
 
 template <>

--- a/src/services/MonitoredItem.cpp
+++ b/src/services/MonitoredItem.cpp
@@ -24,9 +24,9 @@ template <typename T>
 inline static auto createMonitoredItemContext(
     T& connection,
     const ReadValueId& itemToMonitor,
-    DataChangeNotificationCallback&& dataChangeCallback,
-    EventNotificationCallback&& eventCallback,
-    DeleteMonitoredItemCallback&& deleteCallback
+    DataChangeNotificationCallback dataChangeCallback,
+    EventNotificationCallback eventCallback,
+    DeleteMonitoredItemCallback deleteCallback
 ) {
     auto context = std::make_unique<detail::MonitoredItemContext>();
     context->catcher = &opcua::detail::getContext(connection).exceptionCatcher;
@@ -41,18 +41,14 @@ template <typename T>
 inline static auto createMonitoredItemContexts(
     T& connection,
     const CreateMonitoredItemsRequest& request,
-    DataChangeNotificationCallback&& dataChangeCallback,
-    EventNotificationCallback&& eventCallback,
-    DeleteMonitoredItemCallback&& deleteCallback
+    const DataChangeNotificationCallback& dataChangeCallback,
+    const EventNotificationCallback& eventCallback,
+    const DeleteMonitoredItemCallback& deleteCallback
 ) {
     std::vector<std::unique_ptr<detail::MonitoredItemContext>> contexts;
     for (const auto& item : request.getItemsToCreate()) {
         contexts.push_back(createMonitoredItemContext(
-            connection,
-            item.getItemToMonitor(),
-            std::move(dataChangeCallback),
-            std::move(eventCallback),
-            std::move(deleteCallback)
+            connection, item.getItemToMonitor(), dataChangeCallback, eventCallback, deleteCallback
         ));
     }
     return contexts;
@@ -97,7 +93,7 @@ CreateMonitoredItemsResponse createMonitoredItemsDataChange(
     DeleteMonitoredItemCallback deleteCallback
 ) {
     auto contexts = createMonitoredItemContexts(
-        connection, request, std::move(dataChangeCallback), {}, std::move(deleteCallback)
+        connection, request, dataChangeCallback, {}, deleteCallback
     );
     std::vector<void*> contextsRaw;
     std::vector<UA_Client_DataChangeNotificationCallback> dataChangeCallbacks;

--- a/src/services/MonitoredItem.cpp
+++ b/src/services/MonitoredItem.cpp
@@ -89,8 +89,8 @@ inline static void storeMonitoredItemContexts(
 CreateMonitoredItemsResponse createMonitoredItemsDataChange(
     Client& connection,
     const CreateMonitoredItemsRequest& request,
-    DataChangeNotificationCallback dataChangeCallback,
-    DeleteMonitoredItemCallback deleteCallback
+    DataChangeNotificationCallback dataChangeCallback,  // NOLINT
+    DeleteMonitoredItemCallback deleteCallback  // NOLINT
 ) {
     auto contexts = createMonitoredItemContexts(
         connection, request, dataChangeCallback, {}, deleteCallback
@@ -169,11 +169,11 @@ Result<uint32_t> createMonitoredItemDataChange<Server>(
 CreateMonitoredItemsResponse createMonitoredItemsEvent(
     Client& connection,
     const CreateMonitoredItemsRequest& request,
-    EventNotificationCallback eventCallback,
-    DeleteMonitoredItemCallback deleteCallback
+    EventNotificationCallback eventCallback,  // NOLINT
+    DeleteMonitoredItemCallback deleteCallback  // NOLINT
 ) {
     auto contexts = createMonitoredItemContexts(
-        connection, request, {}, std::move(eventCallback), std::move(deleteCallback)
+        connection, request, {}, eventCallback, deleteCallback
     );
     std::vector<void*> contextsRaw;
     std::vector<UA_Client_EventNotificationCallback> eventCallbacks;

--- a/src/services/Subscription.cpp
+++ b/src/services/Subscription.cpp
@@ -37,7 +37,7 @@ CreateSubscriptionResponse createSubscription(
         context->statusChangeCallbackNative,
         context->deleteCallbackNative
     );
-    if (response.getResponseHeader().getServiceResult().isGood()) {
+    if (detail::getServiceResult(response).isGood()) {
         opcua::detail::getContext(connection)
             .subscriptions.insert(response.getSubscriptionId(), std::move(context));
     }

--- a/tests/Services.cpp
+++ b/tests/Services.cpp
@@ -942,18 +942,38 @@ TEST_CASE("MonitoredItem service set (client)") {
     SUBCASE("createMonitoredItemDataChange") {
         size_t notificationCount = 0;
         DataValue changedValue;
-        const auto monId = services::createMonitoredItemDataChange(
-            client,
-            subId,
-            {id, AttributeId::Value},
-            MonitoringMode::Reporting,
-            monitoringParameters,
-            [&](uint32_t, uint32_t, const DataValue& value) {
-                notificationCount++;
-                changedValue = value;
-            }
-        );
-        CAPTURE(monId);
+        const auto callback = [&](uint32_t, uint32_t, const DataValue& value) {
+            notificationCount++;
+            changedValue = value;
+        };
+
+        SUBCASE("Raw") {
+            const CreateMonitoredItemsRequest request(
+                {},
+                subId,
+                TimestampsToReturn::Both,
+                {
+                    MonitoredItemCreateRequest({id, AttributeId::Value}, MonitoringMode::Reporting),
+                }
+            );
+            const auto response = services::createMonitoredItemsDataChange(
+                client, request, callback
+            );
+            CHECK(response.getResponseHeader().getServiceResult().isGood());
+        }
+        SUBCASE("Single") {
+            const auto monId =
+                services::createMonitoredItemDataChange(
+                    client,
+                    subId,
+                    {id, AttributeId::Value},
+                    MonitoringMode::Reporting,
+                    monitoringParameters,
+                    callback
+                )
+                    .value();
+            CAPTURE(monId);
+        }
 
         CHECK(services::writeValue(server, id, Variant::fromScalar(11.11)));
         client.runIterate();
@@ -977,17 +997,18 @@ TEST_CASE("MonitoredItem service set (client)") {
 
         size_t notificationCount = 0;
         size_t eventFieldsSize = 0;
-        const auto monId = services::createMonitoredItemEvent(
-            client,
-            subId,
-            {ObjectId::Server, AttributeId::EventNotifier},
-            MonitoringMode::Reporting,
-            monitoringParameters,
-            [&](uint32_t, uint32_t, Span<const Variant> eventFields) {
-                notificationCount++;
-                eventFieldsSize = eventFields.size();
-            }
-        );
+        const auto monId =
+            services::createMonitoredItemEvent(
+                client,
+                subId,
+                {ObjectId::Server, AttributeId::EventNotifier},
+                MonitoringMode::Reporting,
+                monitoringParameters,
+                [&](uint32_t, uint32_t, Span<const Variant> eventFields) {
+                    notificationCount++;
+                    eventFieldsSize = eventFields.size();
+                }
+            ).value();
         CAPTURE(monId);
 
         Event event(server);


### PR DESCRIPTION
New monitored item service functions using raw requests/responses:

```cpp
CreateMonitoredItemsResponse createMonitoredItemsDataChange(
    Client& connection,
    const CreateMonitoredItemsRequest& request,
    DataChangeNotificationCallback dataChangeCallback,
    DeleteMonitoredItemCallback deleteCallback = {}
);

CreateMonitoredItemsResponse createMonitoredItemsEvent(
    Client& connection,
    const CreateMonitoredItemsRequest& request,
    EventNotificationCallback eventCallback,
    DeleteMonitoredItemCallback deleteCallback = {}
);

ModifyMonitoredItemsResponse modifyMonitoredItems(
    Client& connection, const ModifyMonitoredItemsRequest& request
) noexcept;

SetMonitoringModeResponse setMonitoringMode(
    Client& connection, const SetMonitoringModeRequest& request
) noexcept;

SetTriggeringResponse setTriggering(
    Client& connection, const SetTriggeringRequest& request
) noexcept;

DeleteMonitoredItemsResponse deleteMonitoredItems(
    Client& connection, const DeleteMonitoredItemsRequest& request
) noexcept;
```