### PR TITLE
fix: add missing <exception> include for std::exception_ptr

### DIFF
--- a/include/open62541pp/ErrorHandling.h
+++ b/include/open62541pp/ErrorHandling.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <exception>
 #include <new>
 #include <stdexcept>
 


### PR DESCRIPTION
The code previously relied on an indirect inclusion of <exception> via <stdexcept>. This worked in C++20 and previous C++ versions due to some standard library implementations, which included <exception> transitively when including <stdexcept>. However, C++23 has stricter header inclusion rules, meaning <exception> is no longer included indirectly.

This change explicitly adds the <exception> include to ensure compatibility with C++23 and prevent compilation errors when using std::exception_ptr.