### PR TITLE
chore: consistent project name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 
 project(
-    open62541++
+    open62541pp
     VERSION 0.14.0
     DESCRIPTION "C++ wrapper of open62541"
     HOMEPAGE_URL "https://github.com/open62541pp/open62541pp"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to open62541++
+# Contributing to open62541pp
 
-Thank you for your interest in contributing to open62541++! There are many ways to contribute, and all of them are appreciated.
+Thank you for your interest in contributing to open62541pp! There are many ways to contribute, and all of them are appreciated.
 
 1. [Fork](https://github.com/open62541pp/open62541pp/fork) the open62541pp repository on GitHub
 2. Clone your fork of open62541pp `git clone --recursive https://github.com/<your-username>/open62541pp.git`

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [ci-compatibility]: https://github.com/open62541pp/open62541pp/actions/workflows/open62541-compatibility.yml
 
 <div align="center">
-  <h1>open62541++</h1>
+  <h1>open62541pp</h1>
 
   [![License: MPL 2.0](https://img.shields.io/badge/License-MPL%202.0-blue.svg)](https://github.com/open62541pp/open62541pp/blob/master/LICENSE)
   [![CI](https://github.com/open62541pp/open62541pp/actions/workflows/ci.yml/badge.svg)][ci]
@@ -188,7 +188,7 @@ The library can be built, integrated and installed using [CMake](https://cmake.o
 
 Please check out the open62541 build options here: https://www.open62541.org/doc/1.3/building.html#build-options
 
-open62541++ provides additional build options:
+Open62541pp provides additional build options:
 
 - `UAPP_INTERNAL_OPEN62541`: Use internal open62541 library if `ON` or search for installed open62541 library if `OFF`
 - `UAPP_BUILD_DOCUMENTATION`: Build documentation

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -68,7 +68,7 @@ add_custom_target(
     DEPENDS ${doxygen_open62541_html_dir}/index.html
 )
 
-# -------------------------------------- Doxygen open62541++ ------------------------------------- #
+# -------------------------------------- Doxygen open62541pp ------------------------------------- #
 
 set(doxygen_output_dir ${PROJECT_BINARY_DIR}/doxygen)
 set(doxygen_html_dir   ${PROJECT_BINARY_DIR}/doc_html)

--- a/doc/DoxygenLayout_open62541.xml
+++ b/doc/DoxygenLayout_open62541.xml
@@ -35,7 +35,7 @@
     </tab>
 
     <tab type="usergroup" title="Links">
-      <tab type="user" url="../index.html" title="open62541++ API"/>
+      <tab type="user" url="../index.html" title="open62541pp API"/>
       <tab type="user" url="https://github.com/open62541/open62541" title="GitHub"/>
     </tab>
   </navindex>

--- a/doc/async_model.md
+++ b/doc/async_model.md
@@ -2,11 +2,11 @@
 
 @tableofcontents
 
-Open62541++ adapts the well-proven [asynchronous model of (Boost) Asio](https://think-async.com/asio/asio-1.28.0/doc/asio/overview/model.html). A key goal of Asio's asynchronous model is to support multiple composition mechanisms. This is achieved via completion tokens.
+Open62541pp adapts the well-proven [asynchronous model of (Boost) Asio](https://think-async.com/asio/asio-1.28.0/doc/asio/overview/model.html). A key goal of Asio's asynchronous model is to support multiple composition mechanisms. This is achieved via completion tokens.
 
 ## Completion tokens
 
-Open62541++ accepts completion tokens as the final argument of asynchronous operations.
+Open62541pp accepts completion tokens as the final argument of asynchronous operations.
 
 ```cpp
 // Function signature of the completion handler: void(opcua::Result<opcua::Variant>&)

--- a/doc/overview.dox
+++ b/doc/overview.dox
@@ -1,7 +1,7 @@
 /*!
 @page overview Overview
 
-An overview of core concepts and the features included in open62541++.
+An overview of open62541pp's core concepts and the features.
 
 - @subpage async_model
 */


### PR DESCRIPTION
Use `open62541pp` as project name consistently.