### PR TITLE
feat!: deprecate Client::get*Node, Server::get*Node

### DIFF
--- a/examples/client_browse.cpp
+++ b/examples/client_browse.cpp
@@ -54,7 +54,7 @@ int main() {
     opcua::Client client;
     client.connect("opc.tcp://localhost:4840");
 
-    auto nodeRoot = client.getRootNode();
+    opcua::Node nodeRoot(client, opcua::ObjectId::RootFolder);
 
     // Browse all nodes recursively and print node tree to console
     printNodeTree(nodeRoot, 0);

--- a/examples/client_connect.cpp
+++ b/examples/client_connect.cpp
@@ -31,7 +31,7 @@ int main(int argc, char* argv[]) {
         client.connect(serverUrl);
     }
 
-    auto node = client.getNode(opcua::VariableId::Server_ServerStatus_CurrentTime);
+    opcua::Node node(client, opcua::VariableId::Server_ServerStatus_CurrentTime);
     const auto dt = node.readValueScalar<opcua::DateTime>();
     client.disconnect();
 

--- a/examples/client_minimal.cpp
+++ b/examples/client_minimal.cpp
@@ -6,7 +6,7 @@ int main() {
     opcua::Client client;
     client.connect("opc.tcp://localhost:4840");
 
-    opcua::Node node = client.getNode(opcua::VariableId::Server_ServerStatus_CurrentTime);
+    opcua::Node node(client, opcua::VariableId::Server_ServerStatus_CurrentTime);
     const auto dt = node.readValueScalar<opcua::DateTime>();
 
     std::cout << "Server date (UTC): " << dt.format("%Y-%m-%d %H:%M:%S") << std::endl;

--- a/examples/custom_datatypes/client_custom_datatypes.cpp
+++ b/examples/custom_datatypes/client_custom_datatypes.cpp
@@ -29,7 +29,7 @@ int main() {
     // Read custom variables
     opcua::Variant variant;
 
-    variant = client.getNode({1, "Point"}).readValue();
+    variant = opcua::Node(client, {1, "Point"}).readValue();
     if (variant.isType(dataTypePoint)) {
         const auto* p = static_cast<Point*>(variant.data());
         std::cout << "Point:\n";
@@ -38,7 +38,7 @@ int main() {
         std::cout << "- z = " << p->z << "\n";
     }
 
-    variant = client.getNode({1, "PointVec"}).readValue();
+    variant = opcua::Node(client, {1, "PointVec"}).readValue();
     // Variants store non-builtin data types as ExtensionObjects. If the data type is known to the
     // client/server, open62541 unwraps scalar objects transparently in the encoding layer:
     // https://www.open62541.org/doc/master/types.html#variant
@@ -56,7 +56,7 @@ int main() {
         }
     }
 
-    variant = client.getNode({1, "Measurements"}).readValue();
+    variant = opcua::Node(client, {1, "Measurements"}).readValue();
     if (variant.isType(dataTypeMeasurements)) {
         const auto* m = static_cast<Measurements*>(variant.data());
         std::cout << "Measurements:\n";
@@ -67,7 +67,7 @@ int main() {
         }
     }
 
-    variant = client.getNode({1, "Opt"}).readValue();
+    variant = opcua::Node(client, {1, "Opt"}).readValue();
     auto formatOptional = [](const auto* ptr) {
         return ptr == nullptr ? "NULL" : std::to_string(*ptr);
     };
@@ -79,7 +79,7 @@ int main() {
         std::cout << "- c = " << formatOptional(opt->c) << "\n";
     }
 
-    variant = client.getNode({1, "Uni"}).readValue();
+    variant = opcua::Node(client, {1, "Uni"}).readValue();
     if (variant.isType(dataTypeUni)) {
         const auto* uni = static_cast<Uni*>(variant.data());
         std::cout << "Uni:\n";
@@ -92,7 +92,7 @@ int main() {
         }
     }
 
-    variant = client.getNode({1, "Color"}).readValue();
+    variant = opcua::Node(client, {1, "Color"}).readValue();
     if (variant.isType<int32_t>()) {
         std::cout << "Color: " << variant.getScalar<int32_t>() << "\n";
     }

--- a/examples/custom_datatypes/server_custom_datatypes.cpp
+++ b/examples/custom_datatypes/server_custom_datatypes.cpp
@@ -22,13 +22,13 @@ int main() {
     });
 
     // Add data type nodes
-    auto nodeStructureDataType = server.getNode(opcua::DataTypeId::Structure);
-    nodeStructureDataType.addDataType(dataTypePoint.getTypeId(), "PointDataType");
-    nodeStructureDataType.addDataType(dataTypeMeasurements.getTypeId(), "MeasurementsDataType");
-    nodeStructureDataType.addDataType(dataTypeOpt.getTypeId(), "OptDataType");
-    nodeStructureDataType.addDataType(dataTypeUni.getTypeId(), "UniDataType");
-    auto nodeEnumerationDataType = server.getNode(opcua::DataTypeId::Enumeration);
-    nodeEnumerationDataType.addDataType(dataTypeColor.getTypeId(), "Color")
+    opcua::Node structureDataTypeNode(server, opcua::DataTypeId::Structure);
+    structureDataTypeNode.addDataType(dataTypePoint.getTypeId(), "PointDataType");
+    structureDataTypeNode.addDataType(dataTypeMeasurements.getTypeId(), "MeasurementsDataType");
+    structureDataTypeNode.addDataType(dataTypeOpt.getTypeId(), "OptDataType");
+    structureDataTypeNode.addDataType(dataTypeUni.getTypeId(), "UniDataType");
+    opcua::Node enumerationDataTypeNode(server, opcua::DataTypeId::Enumeration);
+    enumerationDataTypeNode.addDataType(dataTypeColor.getTypeId(), "Color")
         .addProperty(
             {0, 0},  // auto-generate node id
             "EnumValues",
@@ -45,8 +45,8 @@ int main() {
         .addModellingRule(opcua::ModellingRule::Mandatory);
 
     // Add variable type nodes (optional)
-    auto nodeBaseDataVariableType = server.getNode(opcua::VariableTypeId::BaseDataVariableType);
-    auto nodeVariableTypePoint = nodeBaseDataVariableType.addVariableType(
+    opcua::Node baseDataVariableTypeNode(server, opcua::VariableTypeId::BaseDataVariableType);
+    auto variableTypePointNode = baseDataVariableTypeNode.addVariableType(
         {1, 4243},
         "PointType",
         opcua::VariableTypeAttributes{}
@@ -54,7 +54,7 @@ int main() {
             .setValueRank(opcua::ValueRank::ScalarOrOneDimension)
             .setValueScalar(Point{1, 2, 3}, dataTypePoint)
     );
-    auto nodeVariableTypeMeasurement = nodeBaseDataVariableType.addVariableType(
+    auto variableTypeMeasurementNode = baseDataVariableTypeNode.addVariableType(
         {1, 4444},
         "MeasurementsType",
         opcua::VariableTypeAttributes{}
@@ -62,7 +62,7 @@ int main() {
             .setValueRank(opcua::ValueRank::Scalar)
             .setValueScalar(Measurements{}, dataTypeMeasurements)
     );
-    auto nodeVariableTypeOpt = nodeBaseDataVariableType.addVariableType(
+    auto variableTypeOptNode = baseDataVariableTypeNode.addVariableType(
         {1, 4645},
         "OptType",
         opcua::VariableTypeAttributes{}
@@ -70,7 +70,7 @@ int main() {
             .setValueRank(opcua::ValueRank::Scalar)
             .setValueScalar(Opt{}, dataTypeOpt)
     );
-    auto nodeVariableTypeUni = nodeBaseDataVariableType.addVariableType(
+    auto variableTypeUniNode = baseDataVariableTypeNode.addVariableType(
         {1, 4846},
         "UniType",
         opcua::VariableTypeAttributes{}
@@ -80,21 +80,21 @@ int main() {
     );
 
     // Add variable nodes with some values
-    auto nodeObjects = server.getObjectsNode();
+    opcua::Node objectsNode(server, opcua::ObjectId::ObjectsFolder);
 
     const Point point{3.0, 4.0, 5.0};
-    nodeObjects.addVariable(
+    objectsNode.addVariable(
         {1, "Point"},
         "Point",
         opcua::VariableAttributes{}
             .setDataType(dataTypePoint.getTypeId())
             .setValueRank(opcua::ValueRank::Scalar)
             .setValueScalar(point, dataTypePoint),
-        nodeVariableTypePoint.id()
+        variableTypePointNode.id()
     );
 
     const std::vector<Point> pointVec{{1.0, 2.0, 3.0}, {4.0, 5.0, 6.0}};
-    nodeObjects.addVariable(
+    objectsNode.addVariable(
         {1, "PointVec"},
         "PointVec",
         opcua::VariableAttributes{}
@@ -102,7 +102,7 @@ int main() {
             .setArrayDimensions({0})  // single dimension but unknown in size
             .setValueRank(opcua::ValueRank::OneDimension)
             .setValueArray(pointVec, dataTypePoint),
-        nodeVariableTypePoint.id()
+        variableTypePointNode.id()
     );
 
     std::vector<float> measurementsValues{19.1F, 20.2F, 19.7F};
@@ -111,42 +111,42 @@ int main() {
         measurementsValues.size(),
         measurementsValues.data(),
     };
-    nodeObjects.addVariable(
+    objectsNode.addVariable(
         {1, "Measurements"},
         "Measurements",
         opcua::VariableAttributes{}
             .setDataType(dataTypeMeasurements.getTypeId())
             .setValueRank(opcua::ValueRank::Scalar)
             .setValueScalar(measurements, dataTypeMeasurements),
-        nodeVariableTypeMeasurement.id()
+        variableTypeMeasurementNode.id()
     );
 
     float optC = 10.10F;
     const Opt opt{3, nullptr, &optC};
-    nodeObjects.addVariable(
+    objectsNode.addVariable(
         {1, "Opt"},
         "Opt",
         opcua::VariableAttributes{}
             .setDataType(dataTypeOpt.getTypeId())
             .setValueRank(opcua::ValueRank::Scalar)
             .setValueScalar(opt, dataTypeOpt),
-        nodeVariableTypeOpt.id()
+        variableTypeOptNode.id()
     );
 
     Uni uni{};
     uni.switchField = UniSwitch::OptionB;
     uni.fields.optionB = UA_STRING_STATIC("test string");  // NOLINT
-    nodeObjects.addVariable(
+    objectsNode.addVariable(
         {1, "Uni"},
         "Uni",
         opcua::VariableAttributes{}
             .setDataType(dataTypeUni.getTypeId())
             .setValueRank(opcua::ValueRank::Scalar)
             .setValueScalar(uni, dataTypeUni),
-        nodeVariableTypeUni.id()
+        variableTypeUniNode.id()
     );
 
-    nodeObjects.addVariable(
+    objectsNode.addVariable(
         {1, "Color"},
         "Color",
         opcua::VariableAttributes{}

--- a/examples/events/server_events.cpp
+++ b/examples/events/server_events.cpp
@@ -4,11 +4,12 @@ int main() {
     opcua::Server server;
 
     // Objects node can be used to subscribe to events.
-    server.getObjectsNode().writeEventNotifier(opcua::EventNotifier::SubscribeToEvents);
+    opcua::Node objectsNode(server, opcua::ObjectId::ObjectsFolder);
+    objectsNode.writeEventNotifier(opcua::EventNotifier::SubscribeToEvents);
 
     // Add a method to generate and trigger events.
     opcua::Event event(server);
-    server.getObjectsNode().addMethod(
+    objectsNode.addMethod(
         {1, 1000},
         "GenerateEvent",
         [&](opcua::Span<const opcua::Variant> input, opcua::Span<opcua::Variant>) {

--- a/examples/method/client_method.cpp
+++ b/examples/method/client_method.cpp
@@ -9,11 +9,11 @@ int main() {
     client.connect("opc.tcp://localhost:4840");
 
     // Browse method node
-    auto objNode = client.getObjectsNode();
-    auto greetMethodNode = objNode.browseChild({{1, "Greet"}});
+    opcua::Node objectsNode(client, opcua::ObjectId::ObjectsFolder);
+    opcua::Node greetMethodNode = objectsNode.browseChild({{1, "Greet"}});
 
     // Call method from parent node (Objects)
-    const auto outputs = objNode.callMethod(
+    const auto outputs = objectsNode.callMethod(
         greetMethodNode.id(), {opcua::Variant::fromScalar("World")}
     );
     std::cout << outputs.at(0).getScalar<opcua::String>() << std::endl;

--- a/examples/method/client_method_async.cpp
+++ b/examples/method/client_method_async.cpp
@@ -10,8 +10,8 @@ int main() {
     client.connect("opc.tcp://localhost:4840");
 
     // Browse method node
-    auto objNode = client.getObjectsNode();
-    auto greetMethodNode = objNode.browseChild({{1, "Greet"}});
+    opcua::Node objectsNode(client, opcua::ObjectId::ObjectsFolder);
+    opcua::Node greetMethodNode = objectsNode.browseChild({{1, "Greet"}});
 
     // Run client event loop in separate thread
     auto clientThread = std::thread([&] { client.run(); });
@@ -20,7 +20,7 @@ int main() {
     {
         auto future = opcua::services::callAsync(
             client,
-            objNode.id(),
+            objectsNode.id(),
             greetMethodNode.id(),
             {opcua::Variant::fromScalar("Future World")},
             opcua::useFuture  // default, can be omitted
@@ -38,7 +38,7 @@ int main() {
     {
         opcua::services::callAsync(
             client,
-            objNode.id(),
+            objectsNode.id(),
             greetMethodNode.id(),
             {opcua::Variant::fromScalar("Callback World")},
             [](const opcua::Result<std::vector<opcua::Variant>>& result) {

--- a/examples/method/server_method.cpp
+++ b/examples/method/server_method.cpp
@@ -5,10 +5,10 @@
 int main() {
     opcua::Server server;
 
-    auto objectNode = server.getObjectsNode();
+    opcua::Node objectsNode(server, opcua::ObjectId::ObjectsFolder);
 
     // Add a method to return "Hello " + provided name.
-    objectNode.addMethod(
+    objectsNode.addMethod(
         {1, 1000},
         "Greet",
         [](opcua::Span<const opcua::Variant> input, opcua::Span<opcua::Variant> output) {
@@ -22,7 +22,7 @@ int main() {
 
     // Add a method that takes an array of 5 integers and a scalar as input.
     // It returns a copy of the array with every entry increased by the scalar.
-    objectNode.addMethod(
+    objectsNode.addMethod(
         {1, 1001},
         "IncInt32ArrayValues",
         [](opcua::Span<const opcua::Variant> input, opcua::Span<opcua::Variant> output) {

--- a/examples/server.cpp
+++ b/examples/server.cpp
@@ -10,8 +10,8 @@ int main() {
     server.setProductUri("https://open62541pp.github.io");
 
     // Add a variable node to the Objects node
-    auto parentNode = server.getObjectsNode();
-    auto myIntegerNode = parentNode.addVariable(
+    opcua::Node parentNode(server, opcua::ObjectId::ObjectsFolder);
+    opcua::Node myIntegerNode = parentNode.addVariable(
         {1, "TheAnswer"},
         "The Answer",
         opcua::VariableAttributes{}

--- a/examples/server_accesscontrol.cpp
+++ b/examples/server_accesscontrol.cpp
@@ -35,8 +35,9 @@ public:
         const bool isAdmin = session.getSessionAttribute({0, "isAdmin"}).getScalar<bool>();
         std::cout << "Get user access level of node id " << nodeId.toString() << std::endl;
         std::cout << "Admin rights granted: " << isAdmin << std::endl;
-        return isAdmin ? AccessLevel::CurrentRead | AccessLevel::CurrentWrite
-                       : AccessLevel::CurrentRead;
+        return isAdmin
+            ? AccessLevel::CurrentRead | AccessLevel::CurrentWrite
+            : AccessLevel::CurrentRead;
     }
 };
 
@@ -55,15 +56,16 @@ int main() {
     server.setAccessControl(accessControl);
 
     // Add variable node. Try to change its value as a client with different logins.
-    server.getObjectsNode().addVariable(
-        {1, 1000},
-        "Variable",
-        VariableAttributes{}
-            .setAccessLevel(AccessLevel::CurrentRead | AccessLevel::CurrentWrite)
-            .setDataType(DataTypeId::Int32)
-            .setValueRank(ValueRank::Scalar)
-            .setValueScalar(0)
-    );
+    Node(server, ObjectId::ObjectsFolder)
+        .addVariable(
+            {1, 1000},
+            "Variable",
+            VariableAttributes{}
+                .setAccessLevel(AccessLevel::CurrentRead | AccessLevel::CurrentWrite)
+                .setDataType(DataTypeId::Int32)
+                .setValueRank(ValueRank::Scalar)
+                .setValueScalar(0)
+        );
 
     server.run();
 }

--- a/examples/server_datasource.cpp
+++ b/examples/server_datasource.cpp
@@ -9,14 +9,16 @@ int main() {
     int counter = 0;
 
     // Add variable node
-    auto nodeCounter = server.getObjectsNode().addVariable(
+    const auto counterId = opcua::services::addVariable(
+        server,
+        opcua::ObjectId::ObjectsFolder,
         {1, 1000},
         "Counter",
         opcua::VariableAttributes{}
             .setAccessLevel(UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE)
             .setDataType<int>()
             .setValueScalar(counter)
-    );
+    ).value();
 
     // Define data source with its read and write callbacks
     opcua::ValueBackendDataSource dataSource;
@@ -37,7 +39,7 @@ int main() {
     };
 
     // Define data source as variable node backend
-    server.setVariableNodeValueBackend(nodeCounter.id(), dataSource);
+    server.setVariableNodeValueBackend(counterId, dataSource);
 
     server.run();
 }

--- a/examples/server_instantiation.cpp
+++ b/examples/server_instantiation.cpp
@@ -9,7 +9,7 @@ int main() {
     //    ├─ (Variable) Age
     //    └─ (ObjectType) DogType
     //       └─ (Variable) Name
-    auto nodeBaseObjectType = server.getNode(opcua::ObjectTypeId::BaseObjectType);
+    opcua::Node nodeBaseObjectType(server, opcua::ObjectTypeId::BaseObjectType);
     auto nodeMammalType = nodeBaseObjectType.addObjectType(
         {1, 10000},
         "MammalType",
@@ -53,7 +53,8 @@ int main() {
     // └─ (Object) Bello <DogType>
     //    ├─ (Variable) Age
     //    └─ (Variable) Name
-    auto nodeBello = server.getObjectsNode().addObject(
+    opcua::Node nodeObjects(server, opcua::ObjectId::ObjectsFolder);
+    auto nodeBello = nodeObjects.addObject(
         {1, 20000},
         "Bello",
         opcua::ObjectAttributes{}

--- a/examples/server_minimal.cpp
+++ b/examples/server_minimal.cpp
@@ -4,7 +4,7 @@ int main() {
     opcua::Server server;
 
     // Add a variable node to the Objects node
-    opcua::Node parentNode = server.getObjectsNode();
+    opcua::Node parentNode(server, opcua::ObjectId::ObjectsFolder);
     opcua::Node myIntegerNode = parentNode.addVariable({1, 1000}, "TheAnswer");
     // Write some node attributes
     myIntegerNode.writeDisplayName({"en-US", "The Answer"})

--- a/examples/server_valuecallback.cpp
+++ b/examples/server_valuecallback.cpp
@@ -7,7 +7,7 @@ int main() {
 
     const opcua::NodeId currentTimeId(1, "CurrentTime");
     auto currentTimeNode =
-        server.getObjectsNode()
+        opcua::Node(server, opcua::ObjectId::ObjectsFolder)
             .addVariable(currentTimeId, "CurrentTime")
             .writeDisplayName({"en-US", "Current time"})
             .writeDescription({"en-US", "Current time"})

--- a/include/open62541pp/Client.h
+++ b/include/open62541pp/Client.h
@@ -187,11 +187,11 @@ public:
     /// Check if the client's main loop is running.
     bool isRunning() const noexcept;
 
-    Node<Client> getNode(NodeId id);
-    Node<Client> getRootNode();
-    Node<Client> getObjectsNode();
-    Node<Client> getTypesNode();
-    Node<Client> getViewsNode();
+    [[deprecated("use Node constructor")]] Node<Client> getNode(NodeId id);
+    [[deprecated("use Node constructor")]] Node<Client> getRootNode();
+    [[deprecated("use Node constructor")]] Node<Client> getObjectsNode();
+    [[deprecated("use Node constructor")]] Node<Client> getTypesNode();
+    [[deprecated("use Node constructor")]] Node<Client> getViewsNode();
 
     UA_Client* handle() noexcept;
     const UA_Client* handle() const noexcept;

--- a/include/open62541pp/Server.h
+++ b/include/open62541pp/Server.h
@@ -168,11 +168,11 @@ public:
     /// Check if the server is running.
     bool isRunning() const noexcept;
 
-    Node<Server> getNode(NodeId id);
-    Node<Server> getRootNode();
-    Node<Server> getObjectsNode();
-    Node<Server> getTypesNode();
-    Node<Server> getViewsNode();
+    [[deprecated("use Node constructor")]] Node<Server> getNode(NodeId id);
+    [[deprecated("use Node constructor")]] Node<Server> getRootNode();
+    [[deprecated("use Node constructor")]] Node<Server> getObjectsNode();
+    [[deprecated("use Node constructor")]] Node<Server> getTypesNode();
+    [[deprecated("use Node constructor")]] Node<Server> getViewsNode();
 
     UA_Server* handle() noexcept;
     const UA_Server* handle() const noexcept;

--- a/tests/Node.cpp
+++ b/tests/Node.cpp
@@ -21,10 +21,10 @@ TEST_CASE_TEMPLATE("Node", T, Server, Client) {
     services::writeAccessLevel(setup.server, varId, 0xFF).value();
     services::writeWriteMask(setup.server, varId, 0xFFFFFFFF).value();
 
-    auto rootNode = connection.getRootNode();
-    auto objNode = connection.getObjectsNode();
-    auto varNode = connection.getNode(varId);
-    auto refNode = connection.getNode(ReferenceTypeId::References);
+    opcua::Node rootNode(connection, opcua::ObjectId::RootFolder);
+    opcua::Node objNode(connection, opcua::ObjectId::ObjectsFolder);
+    opcua::Node varNode(connection, varId);
+    opcua::Node refNode(connection, ReferenceTypeId::References);
 
     SUBCASE("connection") {
         CHECK(rootNode.connection() == connection);
@@ -38,13 +38,6 @@ TEST_CASE_TEMPLATE("Node", T, Server, Client) {
     SUBCASE("exists") {
         CHECK(Node(connection, NodeId(0, UA_NS0ID_OBJECTSFOLDER)).exists());
         CHECK_FALSE(Node(connection, NodeId(0, "DoesNotExist")).exists());
-    }
-
-    SUBCASE("Node class of default nodes") {
-        CHECK(connection.getRootNode().readNodeClass() == NodeClass::Object);
-        CHECK(connection.getObjectsNode().readNodeClass() == NodeClass::Object);
-        CHECK(connection.getTypesNode().readNodeClass() == NodeClass::Object);
-        CHECK(connection.getViewsNode().readNodeClass() == NodeClass::Object);
     }
 
     SUBCASE("Add non-type nodes") {
@@ -61,12 +54,12 @@ TEST_CASE_TEMPLATE("Node", T, Server, Client) {
 
     SUBCASE("Add type nodes") {
         CHECK(
-            connection.getNode(ObjectTypeId::BaseObjectType)
+            opcua::Node(connection, ObjectTypeId::BaseObjectType)
                 .addObjectType({1, 1000}, "objecttype")
                 .readNodeClass() == NodeClass::ObjectType
         );
         CHECK(
-            connection.getNode(VariableTypeId::BaseVariableType)
+            opcua::Node(connection, VariableTypeId::BaseVariableType)
                 .addVariableType({1, 1001}, "variabletype")
                 .readNodeClass() == NodeClass::VariableType
         );

--- a/tests/Server.cpp
+++ b/tests/Server.cpp
@@ -121,15 +121,6 @@ TEST_CASE("Server configuration") {
         CHECK(server.registerNamespace("test2") == 3);
         CHECK(server.getNamespaceArray().at(3) == "test2");
     }
-
-    SUBCASE("Get default nodes") {
-        // clang-format off
-        CHECK_EQ(server.getRootNode().id(),    NodeId{0, UA_NS0ID_ROOTFOLDER});
-        CHECK_EQ(server.getObjectsNode().id(), NodeId{0, UA_NS0ID_OBJECTSFOLDER});
-        CHECK_EQ(server.getTypesNode().id(),   NodeId{0, UA_NS0ID_TYPESFOLDER});
-        CHECK_EQ(server.getViewsNode().id(),   NodeId{0, UA_NS0ID_VIEWSFOLDER});
-        // clang-format on
-    }
 }
 
 TEST_CASE("Server helper functions") {
@@ -156,7 +147,7 @@ TEST_CASE("ValueCallback") {
     Server server;
 
     NodeId id{1, 1000};
-    auto node = server.getObjectsNode().addVariable(id, "testVariable");
+    auto node = Node(server, ObjectId::ObjectsFolder).addVariable(id, "testVariable");
     node.writeValueScalar<int>(1);
 
     bool onBeforeReadCalled = false;
@@ -192,7 +183,7 @@ TEST_CASE("ValueCallback") {
 TEST_CASE("DataSource") {
     Server server;
     NodeId id{1, 1000};
-    auto node = server.getObjectsNode().addVariable(id, "testVariable");
+    auto node = Node(server, ObjectId::ObjectsFolder).addVariable(id, "testVariable");
 
     // primitive data source
     int data = 0;
@@ -220,7 +211,7 @@ TEST_CASE("DataSource") {
 TEST_CASE("DataSource with empty callbacks") {
     Server server;
     NodeId id{1, 1000};
-    auto node = server.getObjectsNode().addVariable(id, "testVariable");
+    auto node = Node(server, ObjectId::ObjectsFolder).addVariable(id, "testVariable");
 
     server.setVariableNodeValueBackend(id, ValueBackendDataSource{});
 
@@ -232,7 +223,7 @@ TEST_CASE("DataSource with empty callbacks") {
 TEST_CASE("DataSource with exception in callback") {
     Server server;
     NodeId id{1, 1000};
-    auto node = server.getObjectsNode().addVariable(id, "testVariable");
+    auto node = Node(server, ObjectId::ObjectsFolder).addVariable(id, "testVariable");
 
     SUBCASE("BadStatus exception") {
         ValueBackendDataSource dataSource;

--- a/tests/Session.cpp
+++ b/tests/Session.cpp
@@ -2,7 +2,6 @@
 
 #include "open62541pp/Client.h"
 #include "open62541pp/Config.h"
-#include "open62541pp/Node.h"
 #include "open62541pp/Server.h"
 #include "open62541pp/Session.h"
 
@@ -49,8 +48,9 @@ TEST_CASE("Session") {
         // false? bug in open62541?
 #ifndef UAPP_TSAN_ENABLED
         client.connect(localServerUrl);
-        server.getSessions().at(0).close();
-        CHECK_THROWS_WITH(client.getRootNode().readNodeClass(), "BadSessionIdInvalid");
+        auto session = server.getSessions().at(0);
+        CHECK_NOTHROW(session.close());
+        CHECK_THROWS_WITH(session.close(), "BadSessionIdInvalid");
 #endif
     }
 #endif


### PR DESCRIPTION
`Node`s should be created with its constructor and decoupled from `Client` and `Server`.

Following member functions are deprecated and will be removed in the future:
- `Client::getNode(NodeId id)`
- `Client::getRootNode()`
- `Client::getObjectsNode()`
- `Client::getTypesNode()`
- `Client::getViewsNode()`
- `Server::getNode(NodeId id)`
- `Server::getRootNode()`
- `Server::getObjectsNode()`
- `Server::getTypesNode()`
- `Server::getViewsNode()`