### PR TITLE
feat!: deprecate Server::createEvent

### DIFF
--- a/include/open62541pp/Server.h
+++ b/include/open62541pp/Server.h
@@ -155,6 +155,7 @@ public:
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS
     /// Create an event object to generate and trigger events.
+    [[deprecated("use Event constructor")]]
     Event createEvent(const NodeId& eventType = ObjectTypeId::BaseEventType);
 #endif
 

--- a/tests/Event.cpp
+++ b/tests/Event.cpp
@@ -42,8 +42,8 @@ TEST_CASE("Event") {
     }
 
     SUBCASE("Equality") {
-        auto event1 = server.createEvent();
-        auto event2 = server.createEvent();
+        opcua::Event event1(server);
+        opcua::Event event2(server);
         CHECK(event1 == event1);
         CHECK(event1 != event2);
     }


### PR DESCRIPTION
`Event`s should be created with its constructor and decoupled from `Server`.

Following member function is deprecated and will be removed in the future: `Server::createEvent(const NodeId& eventType)`