### PR TITLE
feat: Client::setUserIdentityToken

### DIFF
--- a/examples/client_connect.cpp
+++ b/examples/client_connect.cpp
@@ -21,15 +21,12 @@ int main(int argc, char* argv[]) {
     const auto password = parser.getValue("--password");
 
     opcua::Client client;
-
     if (username) {
-        opcua::Login login;
-        login.username = username.value();
-        login.password = password.value_or("");
-        client.connect(serverUrl, login);
-    } else {
-        client.connect(serverUrl);
+        client.setUserIdentityToken(
+            opcua::UserNameIdentityToken(username.value(), password.value_or(""))
+        );
     }
+    client.connect(serverUrl);
 
     opcua::Node node(client, opcua::VariableId::Server_ServerStatus_CurrentTime);
     const auto dt = node.readValueScalar<opcua::DateTime>();

--- a/include/open62541pp/Client.h
+++ b/include/open62541pp/Client.h
@@ -12,18 +12,17 @@
 #include "open62541pp/Span.h"
 #include "open62541pp/Subscription.h"
 #include "open62541pp/detail/open62541/client.h"
+#include "open62541pp/types/Builtin.h"
+#include "open62541pp/types/Composed.h"
+#include "open62541pp/types/NodeId.h"
 
 // forward declaration
 namespace opcua {
-class ApplicationDescription;
-class ByteString;
 class Client;
 class DataType;
-class EndpointDescription;
 struct Login;
 template <typename Connection>
 class Node;
-class NodeId;
 
 namespace detail {
 struct ClientConnection;
@@ -122,6 +121,15 @@ public:
     /// Set response timeout in milliseconds.
     void setTimeout(uint32_t milliseconds);
 
+    /// Set anonymous identity token.
+    void setUserIdentityToken(AnonymousIdentityToken token);
+    /// Set username/password identity token.
+    void setUserIdentityToken(UserNameIdentityToken token);
+    /// Set X.509 identity token.
+    void setUserIdentityToken(X509IdentityToken token);
+    /// Set issued identity token.
+    void setUserIdentityToken(IssuedIdentityToken token);
+
     /// Set message security mode.
     void setSecurityMode(MessageSecurityMode mode);
 
@@ -144,6 +152,8 @@ public:
 
     /**
      * Connect to the selected server.
+     * The session authentification method is defined by the UserIdentityToken and is set with 
+     * Client::setUserIdentityToken.
      * @param endpointUrl Endpoint URL (for example `opc.tcp://localhost:4840/open62541/server/`)
      */
     void connect(std::string_view endpointUrl);

--- a/include/open62541pp/types/Composed.h
+++ b/include/open62541pp/types/Composed.h
@@ -627,6 +627,16 @@ class UserNameIdentityToken
 public:
     using TypeWrapper::TypeWrapper;
 
+    UserNameIdentityToken(
+        std::string_view userName,
+        std::string_view password,
+        std::string_view encryptionAlgorithm = {}
+    ) {
+        handle()->userName = detail::toNative(userName);
+        handle()->password = detail::toNative(password);
+        handle()->encryptionAlgorithm = detail::toNative(encryptionAlgorithm);
+    }
+
     UAPP_GETTER_WRAPPER(String, getPolicyId, policyId)
     UAPP_GETTER_WRAPPER(String, getUserName, userName)
     UAPP_GETTER_WRAPPER(ByteString, getPassword, password)
@@ -641,6 +651,10 @@ class X509IdentityToken : public TypeWrapper<UA_X509IdentityToken, UA_TYPES_X509
 public:
     using TypeWrapper::TypeWrapper;
 
+    explicit X509IdentityToken(ByteString certificateData) {
+        handle()->certificateData = detail::toNative(std::move(certificateData));
+    }
+
     UAPP_GETTER_WRAPPER(String, getPolicyId, policyId)
     UAPP_GETTER_WRAPPER(ByteString, getCertificateData, certificateData)
 };
@@ -653,6 +667,11 @@ class IssuedIdentityToken
     : public TypeWrapper<UA_IssuedIdentityToken, UA_TYPES_ISSUEDIDENTITYTOKEN> {
 public:
     using TypeWrapper::TypeWrapper;
+
+    explicit IssuedIdentityToken(ByteString tokenData, std::string_view encryptionAlgorithm = {}) {
+        handle()->tokenData = detail::toNative(std::move(tokenData));
+        handle()->encryptionAlgorithm = detail::toNative(encryptionAlgorithm);
+    }
 
     UAPP_GETTER_WRAPPER(String, getPolicyId, policyId)
     UAPP_GETTER_WRAPPER(ByteString, getTokenData, tokenData)

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -293,18 +293,22 @@ void Client::setTimeout(uint32_t milliseconds) {
     detail::getConfig(*this).timeout = milliseconds;
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 void Client::setUserIdentityToken(AnonymousIdentityToken token) {
     connection_->config.setUserIdentityToken(std::move(token));
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 void Client::setUserIdentityToken(UserNameIdentityToken token) {
     connection_->config.setUserIdentityToken(std::move(token));
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 void Client::setUserIdentityToken(X509IdentityToken token) {
     connection_->config.setUserIdentityToken(std::move(token));
 }
 
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
 void Client::setUserIdentityToken(IssuedIdentityToken token) {
     connection_->config.setUserIdentityToken(std::move(token));
 }

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -17,9 +17,6 @@
 #include "open62541pp/detail/open62541/common.h"
 #include "open62541pp/services/Attribute.h"  // readValue
 #include "open62541pp/services/Subscription.h"
-#include "open62541pp/types/Builtin.h"
-#include "open62541pp/types/Composed.h"
-#include "open62541pp/types/NodeId.h"
 
 #include "ClientConfig.h"
 
@@ -294,6 +291,22 @@ void Client::setLogger(Logger logger) {
 
 void Client::setTimeout(uint32_t milliseconds) {
     detail::getConfig(*this).timeout = milliseconds;
+}
+
+void Client::setUserIdentityToken(AnonymousIdentityToken token) {
+    connection_->config.setUserIdentityToken(std::move(token));
+}
+
+void Client::setUserIdentityToken(UserNameIdentityToken token) {
+    connection_->config.setUserIdentityToken(std::move(token));
+}
+
+void Client::setUserIdentityToken(X509IdentityToken token) {
+    connection_->config.setUserIdentityToken(std::move(token));
+}
+
+void Client::setUserIdentityToken(IssuedIdentityToken token) {
+    connection_->config.setUserIdentityToken(std::move(token));
 }
 
 void Client::setSecurityMode(MessageSecurityMode mode) {

--- a/src/ClientConfig.h
+++ b/src/ClientConfig.h
@@ -1,10 +1,14 @@
 #pragma once
 
+#include <utility>  // forward, move
+
+#include "open62541pp/Wrapper.h"
 #include "open62541pp/detail/open62541/client.h"  // UA_ClientConfig
+#include "open62541pp/types/ExtensionObject.h"
 
 #include "CustomDataTypes.h"
-#include "plugins/PluginManager.h"
 #include "plugins/LoggerAdapter.h"
+#include "plugins/PluginManager.h"
 
 namespace opcua {
 
@@ -12,6 +16,15 @@ class ClientConfig {
 public:
     ClientConfig(UA_ClientConfig& config)
         : config_(config) {}
+
+    void setUserIdentityToken(ExtensionObject token) {
+        asWrapper<ExtensionObject>(handle()->userIdentityToken) = std::move(token);
+    }
+
+    template <typename T>
+    void setUserIdentityToken(T&& token) {
+        setUserIdentityToken(ExtensionObject::fromDecodedCopy(std::forward<T>(token)));
+    }
 
     void setLogger(Logger logger) {
         if (logger) {

--- a/tests/Client.cpp
+++ b/tests/Client.cpp
@@ -59,25 +59,25 @@ TEST_CASE("Client discovery") {
     }
 }
 
-TEST_CASE("Client anonymous login") {
+TEST_CASE("Client connect with AnonymousIdentityToken") {
     Server server;
     ServerRunner serverRunner(server);
     Client client;
 
-    SUBCASE("Connect/disconnect") {
-        CHECK_FALSE(client.isConnected());
+    SUBCASE("Connect with anonymous should succeed") {
+        client.setUserIdentityToken(AnonymousIdentityToken{});
         CHECK_NOTHROW(client.connect(localServerUrl));
         CHECK(client.isConnected());
-        CHECK_NOTHROW(client.disconnect());
     }
 
     SUBCASE("Connect with username/password should fail") {
-        CHECK_THROWS(client.connect(localServerUrl, {"username", "password"}));
+        client.setUserIdentityToken(UserNameIdentityToken("username", "password"));
+        CHECK_THROWS(client.connect(localServerUrl));
     }
 }
 
 #if UAPP_OPEN62541_VER_GE(1, 3)
-TEST_CASE("Client username/password login") {
+TEST_CASE("Client connect with UserNameIdentityToken") {
     AccessControlDefault accessControl(false, {{"username", "password"}});
     Server server;
     server.setAccessControl(accessControl);
@@ -89,9 +89,9 @@ TEST_CASE("Client username/password login") {
     }
 
     SUBCASE("Connect with username/password should succeed") {
-        CHECK_NOTHROW(client.connect(localServerUrl, {"username", "password"}));
+        client.setUserIdentityToken(UserNameIdentityToken("username", "password"));
+        CHECK_NOTHROW(client.connect(localServerUrl));
         CHECK(client.isConnected());
-        CHECK_NOTHROW(client.disconnect());
     }
 }
 #endif

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -903,18 +903,18 @@ TEST_CASE("RequestHeader") {
 }
 
 TEST_CASE("UserTokenPolicy") {
-    UserTokenPolicy userTokenPolicy(
+    UserTokenPolicy token(
         "policyId",
         UserTokenType::Username,
         "issuedTokenType",
         "issuerEndpointUrl",
         "securityPolicyUri"
     );
-    CHECK(userTokenPolicy.getPolicyId() == String("policyId"));
-    CHECK(userTokenPolicy.getTokenType() == UserTokenType::Username);
-    CHECK(userTokenPolicy.getIssuedTokenType() == String("issuedTokenType"));
-    CHECK(userTokenPolicy.getIssuerEndpointUrl() == String("issuerEndpointUrl"));
-    CHECK(userTokenPolicy.getSecurityPolicyUri() == String("securityPolicyUri"));
+    CHECK(token.getPolicyId() == String("policyId"));
+    CHECK(token.getTokenType() == UserTokenType::Username);
+    CHECK(token.getIssuedTokenType() == String("issuedTokenType"));
+    CHECK(token.getIssuerEndpointUrl() == String("issuerEndpointUrl"));
+    CHECK(token.getSecurityPolicyUri() == String("securityPolicyUri"));
 }
 
 TEST_CASE("NodeAttributes") {
@@ -960,6 +960,27 @@ TEST_CASE("NodeAttributes fluent interface") {
 TEST_CASE_TEMPLATE("NodeAttributes setDataType", T, VariableAttributes, VariableTypeAttributes) {
     CHECK(T{}.setDataType(DataTypeId::Boolean).getDataType() == NodeId(DataTypeId::Boolean));
     CHECK(T{}.template setDataType<bool>().getDataType() == NodeId(DataTypeId::Boolean));
+}
+
+TEST_CASE("UserNameIdentityToken") {
+    const UserNameIdentityToken token("userName", "password", "encryptionAlgorithm");
+    CHECK(token.getPolicyId().empty());
+    CHECK(token.getUserName() == String("userName"));
+    CHECK(token.getPassword() == ByteString("password"));
+    CHECK(token.getEncryptionAlgorithm() == String("encryptionAlgorithm"));
+}
+
+TEST_CASE("X509IdentityToken") {
+    const X509IdentityToken token(ByteString("certificateData"));
+    CHECK(token.getPolicyId().empty());
+    CHECK(token.getCertificateData() == ByteString("certificateData"));
+}
+
+TEST_CASE("IssuedIdentityToken") {
+    const IssuedIdentityToken token(ByteString("tokenData"), "encryptionAlgorithm");
+    CHECK(token.getPolicyId().empty());
+    CHECK(token.getTokenData() == ByteString("tokenData"));
+    CHECK(token.getEncryptionAlgorithm() == String("encryptionAlgorithm"));
 }
 
 TEST_CASE("AddNodesItem / AddNodesRequest") {


### PR DESCRIPTION
Add `Client::setUserIdentityToken` to define the authentification method with UserIdentityTokens before calling `Client::connect`.

```cpp
/// Set anonymous identity token.
void Client::setUserIdentityToken(AnonymousIdentityToken token);
/// Set username/password identity token.
void Client::setUserIdentityToken(UserNameIdentityToken token);
/// Set X.509 identity token.
void Client::setUserIdentityToken(X509IdentityToken token);
/// Set issued identity token.
void Client::setUserIdentityToken(IssuedIdentityToken token);
```