### PR TITLE
feat!: deprecate Client::connect with login, use Client::setUserIdentityToken instead

### DIFF
--- a/include/open62541pp/Client.h
+++ b/include/open62541pp/Client.h
@@ -163,6 +163,7 @@ public:
      * @param endpointUrl Endpoint URL (for example `opc.tcp://localhost:4840/open62541/server/`)
      * @param login       Login credentials with username and password
      */
+    [[deprecated("use Client::setUserIdentityToken(UserNameIdentityToken) instead")]]
     void connect(std::string_view endpointUrl, const Login& login);
 
     /// Disconnect and close a connection to the server (async, without blocking).


### PR DESCRIPTION
Deprecate `Client::connect` with login in favor of the more generic approach with UserIdentityTokens:

```cpp
opcua::Client client;

// old: connect with username credentials
client.connect(endpointUrl, {"username", "password"});

// new: set UserIdentityToken and connect afterwards
client.setUserIdentityToken(opcua::UserNameIdentityToken("username", "password"));
client.connect(endpointUrl);

