### PR TITLE
feat!: deprecate String::get()

### DIFF
--- a/include/open62541pp/TypeConverter.h
+++ b/include/open62541pp/TypeConverter.h
@@ -62,7 +62,7 @@ struct TypeConverter<std::string_view> {
     using NativeType = String;
 
     static void fromNative(const NativeType& src, std::string_view& dst) {
-        dst = src.get();
+        dst = static_cast<std::string_view>(src);
     }
 
     static void toNative(std::string_view src, NativeType& dst) {
@@ -76,7 +76,7 @@ struct TypeConverter<std::string> {
     using NativeType = String;
 
     static void fromNative(const NativeType& src, ValueType& dst) {
-        dst = src.get();
+        dst = std::string(src);
     }
 
     static void toNative(const ValueType& src, NativeType& dst) {

--- a/include/open62541pp/types/Builtin.h
+++ b/include/open62541pp/types/Builtin.h
@@ -106,6 +106,7 @@ public:
         return handle()->length == 0U;
     }
 
+    [[deprecated("use conversion function with static_cast instead")]]
     std::string_view get() const noexcept {
         return detail::toStringView(native());
     }
@@ -120,22 +121,22 @@ inline bool operator!=(const UA_String& lhs, const UA_String& rhs) noexcept {
 }
 
 inline bool operator==(const String& lhs, std::string_view rhs) noexcept {
-    return (lhs.get() == rhs);
+    return (static_cast<std::string_view>(lhs) == rhs);
 }
 
 inline bool operator!=(const String& lhs, std::string_view rhs) noexcept {
-    return (lhs.get() != rhs);
+    return (static_cast<std::string_view>(lhs) != rhs);
 }
 
 inline bool operator==(std::string_view lhs, const String& rhs) noexcept {
-    return (lhs == rhs.get());
+    return (lhs == static_cast<std::string_view>(rhs));
 }
 
 inline bool operator!=(std::string_view lhs, const String& rhs) noexcept {
-    return (lhs != rhs.get());
+    return (lhs != static_cast<std::string_view>(rhs));
 }
 
-std::ostream& operator<<(std::ostream& os, const String& string);
+std::ostream& operator<<(std::ostream& os, const String& str);
 
 /**
  * UA_Guid wrapper class.

--- a/src/types/Builtin.cpp
+++ b/src/types/Builtin.cpp
@@ -13,8 +13,8 @@ namespace opcua {
 
 /* ------------------------------------------- String ------------------------------------------- */
 
-std::ostream& operator<<(std::ostream& os, const String& string) {
-    os << string.get();
+std::ostream& operator<<(std::ostream& os, const String& str) {
+    os << static_cast<std::string_view>(str);
     return os;
 }
 
@@ -73,7 +73,7 @@ std::string ByteString::toBase64() const {
 #if UAPP_OPEN62541_VER_GE(1, 1)
     String output;
     UA_ByteString_toBase64(handle(), output.handle());
-    return std::string(output.get());
+    return std::string(output);
 #else
     return {};
 #endif

--- a/src/types/NodeId.cpp
+++ b/src/types/NodeId.cpp
@@ -13,7 +13,7 @@ std::string NodeId::toString() const {
         result.append("i=").append(std::to_string(getIdentifierAs<uint32_t>()));
         break;
     case NodeIdType::String:
-        result.append("s=").append(getIdentifierAs<String>().get());
+        result.append("s=").append(getIdentifierAs<String>());
         break;
     case NodeIdType::Guid:
         result.append("g=").append(getIdentifierAs<Guid>().toString());

--- a/tests/Config.cpp
+++ b/tests/Config.cpp
@@ -50,7 +50,7 @@ TEST_CASE("ServerConfig") {
 
             CHECK(ac.userTokenPolicies[1].tokenType == UA_USERTOKENTYPE_USERNAME);
             CHECK(
-                asWrapper<String>(ac.userTokenPolicies[1].securityPolicyUri).get() ==
+                asWrapper<String>(ac.userTokenPolicies[1].securityPolicyUri) ==
                 "http://opcfoundation.org/UA/SecurityPolicy#None"
             );
         }

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -60,14 +60,14 @@ TEST_CASE_TEMPLATE("StringLike", T, String, ByteString, XmlElement) {
     SUBCASE("Construct with const char*") {
         T wrapper("test");
         CHECK(wrapper.handle()->length == 4);
-        CHECK(std::string(wrapper.get()) == "test");
+        CHECK(detail::toStringView(*wrapper.handle()) == "test");
     }
 
     SUBCASE("Construct from non-null-terminated view") {
         std::string str("test123");
         std::string_view sv(str.c_str(), 4);
         T wrapper(sv);
-        CHECK(std::string(wrapper.get()) == "test");
+        CHECK(detail::toStringView(*wrapper.handle()) == "test");
     }
 
     SUBCASE("Empty") {
@@ -285,7 +285,7 @@ TEST_CASE("NodeId") {
         NodeId id(1, sv);
         CHECK(id.getIdentifierType() == NodeIdType::String);
         CHECK(id.getNamespaceIndex() == 1);
-        CHECK(id.getIdentifierAs<String>().get() == sv);
+        CHECK(id.getIdentifierAs<String>() == sv);
     }
 
     SUBCASE("Constructor with string identifier") {


### PR DESCRIPTION
An implicit conversion function to `std::string_view` already exists.
Use `static_cast<std::string_view>(str)` for explicit conversions.