### PR TITLE
feat!: deprecate XmlElement::get()

### DIFF
--- a/include/open62541pp/types/Builtin.h
+++ b/include/open62541pp/types/Builtin.h
@@ -255,6 +255,7 @@ public:
         return handle()->length == 0U;
     }
 
+    [[deprecated("use conversion function with static_cast instead")]]
     std::string_view get() const noexcept {
         return detail::toStringView(*handle());
     }

--- a/src/types/Builtin.cpp
+++ b/src/types/Builtin.cpp
@@ -89,7 +89,7 @@ void ByteString::toFile(const fs::path& filepath) const {
 /* ----------------------------------------- XmlElement ----------------------------------------- */
 
 std::ostream& operator<<(std::ostream& os, const XmlElement& xmlElement) {
-    os << xmlElement.get();
+    os << static_cast<std::string_view>(xmlElement);
     return os;
 }
 


### PR DESCRIPTION
An implicit conversion function to `std::string_view` already exists.
Use `static_cast<std::string_view>(xml)` for explicit conversions.