### PR TITLE
feat: STL-compatible interface for String, ByteString, XMLElement

### DIFF
--- a/include/open62541pp/types/Builtin.h
+++ b/include/open62541pp/types/Builtin.h
@@ -111,7 +111,7 @@ public:
     StringWrapper(InputIt first, InputIt last) {
         this->native().length = std::distance(first, last);
         if (size() > 0) {
-            this->native().data = static_cast<uint8_t*>(UA_malloc(size()));
+            this->native().data = static_cast<uint8_t*>(UA_malloc(size()));  // NOLINT
             if (data() == nullptr) {
                 throw BadStatus(UA_STATUSCODE_BADOUTOFMEMORY);
             }

--- a/include/open62541pp/types/Builtin.h
+++ b/include/open62541pp/types/Builtin.h
@@ -4,6 +4,7 @@
 #include <array>
 #include <cassert>
 #include <cstdint>
+#include <initializer_list>
 #include <iosfwd>  // forward declare ostream
 #include <iterator>  // reverse_iterator
 #include <string>
@@ -118,6 +119,9 @@ public:
             std::copy(first, last, data());
         }
     }
+
+    StringWrapper(std::initializer_list<CharT> init)
+        : StringWrapper(init.begin(), init.end()) {}
 
     size_t size() const noexcept {
         return this->native().length;

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -8,6 +8,7 @@
 
 #include "open62541pp/Config.h"
 #include "open62541pp/NodeIds.h"
+#include "open62541pp/detail/string_utils.h"  // toNativeString
 #include "open62541pp/types/Builtin.h"
 #include "open62541pp/types/Composed.h"
 #include "open62541pp/types/DataValue.h"
@@ -651,9 +652,9 @@ TEST_CASE("Variant") {
     SUBCASE("Set array of native strings") {
         Variant var;
         std::array array{
-            UA_String_fromChars("item1"),
-            UA_String_fromChars("item2"),
-            UA_String_fromChars("item3"),
+            detail::toNativeString("item1"),
+            detail::toNativeString("item2"),
+            detail::toNativeString("item3"),
         };
         var.setArray(Span{array.data(), array.size()}, UA_TYPES[UA_TYPES_STRING]);
         CHECK(var.data() == array.data());

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -67,6 +67,15 @@ TEST_CASE_TEMPLATE("StringWrapper constructors", T, StringWrapper, const StringW
         CHECK(str.data() == nullptr);
     }
 
+    SUBCASE("From empty iterator pair") {
+        std::string_view sv;
+        T str(sv.begin(), sv.end());
+        CHECK(str.size() == 0);
+        CHECK(str.length() == 0);
+        CHECK(str.empty());
+        CHECK(str.data() == nullptr);
+    }
+
     SUBCASE("From iterator pair") {
         std::string_view sv("abc");
         T str(sv.begin(), sv.end());
@@ -132,7 +141,7 @@ TEST_CASE_TEMPLATE("StringWrapper iterators", T, StringWrapper, const StringWrap
     }
 }
 
-TEST_CASE_TEMPLATE("StringLike constructor", T, String, XmlElement) {
+TEST_CASE_TEMPLATE("StringLike constructors", T, String, XmlElement) {
     SUBCASE("From const char*") {
         T str("hello");
         CHECK(str.size() == 5);


### PR DESCRIPTION
Make `String`, `ByteString` and `XMLElement` fully STL-compatible by adding following typedefs and member functions:

```cpp
using value_type             = CharT;  // char for String and XmlElement, uint8_t for ByteString
using size_type              = size_t;
using difference_type        = std::ptrdiff_t;
using pointer                = value_type*;
using const_pointer          = const value_type*;
using reference              = value_type&;
using const_reference        = const value_type&;
using iterator               = pointer;
using const_iterator         = const_pointer;
using reverse_iterator       = std::reverse_iterator<iterator>;
using const_reverse_iterator = std::reverse_iterator<const_iterator>;

size_t size() const noexcept;
size_t length() const noexcept;
bool empty() const noexcept;

pointer data() noexcept;
const_pointer data() const noexcept;

reference operator[](size_t index) noexcept;
const_reference operator[](size_t index) const noexcept;

reference front() noexcept;
const_reference front() const noexcept;

reference back() noexcept;
const_reference back() const noexcept;

iterator begin() noexcept;
const_iterator begin() const noexcept;
const_iterator cbegin() const noexcept;

iterator end() noexcept;
const_iterator end() const noexcept;
const_iterator cend() const noexcept;

reverse_iterator rbegin() noexcept;
const_reverse_iterator rbegin() const noexcept;
const_reverse_iterator crbegin() const noexcept;

reverse_iterator rend() noexcept;
const_reverse_iterator rend() const noexcept;
const_reverse_iterator crend() const noexcept;
```