### PR TITLE
feat!: deprecate ByteString::get()

### DIFF
--- a/include/open62541pp/types/Builtin.h
+++ b/include/open62541pp/types/Builtin.h
@@ -337,6 +337,11 @@ public:
     /// @note Supported since open62541 v1.1
     static ByteString fromBase64(std::string_view encoded);
 
+    /// Explicit conversion to std::string_view.
+    explicit operator std::string_view() const noexcept {
+        return {reinterpret_cast<const char*>(data()), size()};  // NOLINT
+    }
+
 #ifndef UAPP_NO_STD_FILESYSTEM
     /// Write ByteString to binary file.
     void toFile(const fs::path& filepath) const;
@@ -346,25 +351,26 @@ public:
     /// @note Supported since open62541 v1.1
     std::string toBase64() const;
 
+    [[deprecated("use conversion function with static_cast instead")]]
     std::string_view get() const noexcept {
-        return detail::toStringView(*handle());
+        return {reinterpret_cast<const char*>(data()), size()};  // NOLINT
     }
 };
 
 inline bool operator==(const ByteString& lhs, std::string_view rhs) noexcept {
-    return (lhs.get() == rhs);
+    return (static_cast<std::string_view>(lhs) == rhs);
 }
 
 inline bool operator!=(const ByteString& lhs, std::string_view rhs) noexcept {
-    return (lhs.get() != rhs);
+    return (static_cast<std::string_view>(lhs) != rhs);
 }
 
 inline bool operator==(std::string_view lhs, const ByteString& rhs) noexcept {
-    return (lhs == rhs.get());
+    return (lhs == static_cast<std::string_view>(rhs));
 }
 
 inline bool operator!=(std::string_view lhs, const ByteString& rhs) noexcept {
-    return (lhs != rhs.get());
+    return (lhs != static_cast<std::string_view>(rhs));
 }
 
 /**

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -176,9 +176,9 @@ TEST_CASE_TEMPLATE("StringLike implicit conversion to string_view", T, String, X
     CHECK(view == "test123");
 }
 
-TEST_CASE_TEMPLATE("StringLike in string constructor", T, String, XmlElement) {
+TEST_CASE_TEMPLATE("StringLike explicit conversion to string_view", T, ByteString) {
     T str("test123");
-    CHECK(std::string(str) == "test123");
+    CHECK(static_cast<std::string_view>(str) == "test123");
 }
 
 TEST_CASE_TEMPLATE("StringLike equality overloads", T, String, ByteString, XmlElement) {
@@ -214,7 +214,6 @@ TEST_CASE("ByteString") {
         CHECK(bs->data[0] == 88);
         CHECK(bs->data[1] == 89);
         CHECK(bs->data[2] == 90);
-        CHECK(std::string(bs.get()) == "XYZ");
     }
 
 #ifndef UAPP_NO_STD_FILESYSTEM


### PR DESCRIPTION
An implicit conversion function to `std::string_view` already exists.
Use `static_cast<std::string_view>(str)` for explicit conversions.