### PR TITLE
feat!: remove ByteString::fromFile, ByteString::toFile

### DIFF
--- a/include/open62541pp/types/Builtin.h
+++ b/include/open62541pp/types/Builtin.h
@@ -13,18 +13,6 @@
 #include <utility>  // move
 #include <vector>
 
-// Workaround for GCC 7 with partial (or missing) C++17 support
-// https://github.com/open62541pp/open62541pp/issues/109
-#if __has_include(<filesystem>)
-#include <filesystem>
-namespace fs = std::filesystem;
-#elif __has_include(<experimental/filesystem>)
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#else
-#define UAPP_NO_STD_FILESYSTEM
-#endif
-
 #include "open62541pp/Common.h"  // NamespaceIndex
 #include "open62541pp/ErrorHandling.h"
 #include "open62541pp/Span.h"
@@ -328,11 +316,6 @@ public:
     explicit ByteString(const std::vector<uint8_t>& bytes)
         : StringWrapper(bytes.begin(), bytes.end()) {}
 
-#ifndef UAPP_NO_STD_FILESYSTEM
-    /// Read ByteString from binary file.
-    static ByteString fromFile(const fs::path& filepath);
-#endif
-
     /// Parse ByteString from Base64 encoded string.
     /// @note Supported since open62541 v1.1
     static ByteString fromBase64(std::string_view encoded);
@@ -341,11 +324,6 @@ public:
     explicit operator std::string_view() const noexcept {
         return {reinterpret_cast<const char*>(data()), size()};  // NOLINT
     }
-
-#ifndef UAPP_NO_STD_FILESYSTEM
-    /// Write ByteString to binary file.
-    void toFile(const fs::path& filepath) const;
-#endif
 
     /// Convert to Base64 encoded string.
     /// @note Supported since open62541 v1.1

--- a/src/types/Builtin.cpp
+++ b/src/types/Builtin.cpp
@@ -1,8 +1,6 @@
 #include "open62541pp/types/Builtin.h"
 
-#include <fstream>
 #include <iomanip>
-#include <iterator>  // istreambuf_iterator
 #include <ostream>
 #include <sstream>
 #include <utility>  // move

--- a/src/types/Builtin.cpp
+++ b/src/types/Builtin.cpp
@@ -58,16 +58,6 @@ ByteString ByteString::fromBase64([[maybe_unused]] std::string_view encoded) {
 #endif
 }
 
-#ifndef UAPP_NO_STD_FILESYSTEM
-ByteString ByteString::fromFile(const fs::path& filepath) {
-    std::ifstream fp(filepath, std::ios::binary);
-    const std::vector<uint8_t> bytes(
-        (std::istreambuf_iterator<char>(fp)), (std::istreambuf_iterator<char>())
-    );
-    return ByteString(bytes);
-}
-#endif
-
 // NOLINTNEXTLINE
 std::string ByteString::toBase64() const {
 #if UAPP_OPEN62541_VER_GE(1, 1)
@@ -78,13 +68,6 @@ std::string ByteString::toBase64() const {
     return {};
 #endif
 }
-
-#ifndef UAPP_NO_STD_FILESYSTEM
-void ByteString::toFile(const fs::path& filepath) const {
-    std::ofstream fp(filepath, std::ios::binary);
-    fp.write(reinterpret_cast<char*>(handle()->data), handle()->length);  // NOLINT
-}
-#endif
 
 /* ----------------------------------------- XmlElement ----------------------------------------- */
 

--- a/tests/DataType.cpp
+++ b/tests/DataType.cpp
@@ -1,3 +1,4 @@
+#include <ostream>
 #include <string_view>
 #include <utility>  // move
 

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -216,14 +216,6 @@ TEST_CASE("ByteString") {
         CHECK(bs->data[2] == 90);
     }
 
-#ifndef UAPP_NO_STD_FILESYSTEM
-    SUBCASE("toFile / fromFile") {
-        const ByteString bs({88, 89, 90});
-        CHECK_NOTHROW(bs.toFile("bytestring.bin"));
-        CHECK(ByteString::fromFile("bytestring.bin") == bs);
-    }
-#endif
-
 #if UAPP_OPEN62541_VER_GE(1, 1)
     SUBCASE("fromBase64 / to Base64") {
         CHECK(ByteString::fromBase64("dGVzdDEyMw==") == ByteString("test123"));

--- a/tests/Types.cpp
+++ b/tests/Types.cpp
@@ -1,8 +1,4 @@
-#include <array>
 #include <sstream>
-#include <string>
-#include <utility>  // move
-#include <vector>
 
 #include <doctest/doctest.h>
 


### PR DESCRIPTION
Remove `ByteString` member functions:
- `ByteString::fromFile`
- `ByteString::toFile`

Now that the `ByteString` has a STL-compatible interface (#330), it's pretty easy to implement reading from files and writing to files:

```cpp
// write
const ByteString bs("XYZ");
std::ofstream fp("bytestring.bin", std::ios::binary);
fp.write(reinterpret_cast<const char*>(bs.data()), bs.length());

// read
std::ifstream fp("bytestring.bin", std::ios::binary);
const ByteString bsRead(std::istreambuf_iterator<char>(fp)), (std::istreambuf_iterator<char>()));
```