### PR TITLE
feat: copyable/movable types

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,7 +7,6 @@ Checks: >
   cert*,
 
   cppcoreguidelines*,
-  -cppcoreguidelines-avoid-const-or-ref-data-members,
   -cppcoreguidelines-avoid-magic-numbers,
 
   clang-analyzer*,

--- a/examples/client_subscription.cpp
+++ b/examples/client_subscription.cpp
@@ -26,7 +26,7 @@ int main() {
             opcua::VariableId::Server_ServerStatus_CurrentTime,  // monitored node id
             opcua::AttributeId::Value,  // monitored attribute
             [&](uint32_t subId, uint32_t monId, const opcua::DataValue& value) {
-                const opcua::MonitoredItem item(client, subId, monId);
+                opcua::MonitoredItem item(client, subId, monId);
                 std::cout
                     << "Data change notification:\n"
                     << "- subscription id:   " << item.subscriptionId() << "\n"

--- a/examples/events/client_eventfilter.cpp
+++ b/examples/events/client_eventfilter.cpp
@@ -46,7 +46,7 @@ int main() {
         opcua::ObjectId::Server,
         eventFilter,
         [&](uint32_t subId, uint32_t monId, opcua::Span<const opcua::Variant> eventFields) {
-            const opcua::MonitoredItem item(client, subId, monId);
+            opcua::MonitoredItem item(client, subId, monId);
             std::cout
                 << "Event notification:\n"
                 << "- subscription id:   " << item.subscriptionId() << "\n"

--- a/include/open62541pp/Event.h
+++ b/include/open62541pp/Event.h
@@ -36,12 +36,12 @@ public:
 
     /// Get the server instance.
     Server& connection() noexcept {
-        return connection_;
+        return *connection_;
     }
 
     /// Get the server instance.
     const Server& connection() const noexcept {
-        return connection_;
+        return *connection_;
     }
 
     /// Get the NodeId of the underlying node representation.
@@ -70,7 +70,7 @@ public:
     ByteString trigger(const NodeId& originId = ObjectId::Server);
 
 private:
-    Server& connection_;
+    Server* connection_;
     NodeId id_;
 };
 

--- a/include/open62541pp/MonitoredItem.h
+++ b/include/open62541pp/MonitoredItem.h
@@ -59,10 +59,10 @@ public:
     }
 
     /// Get the monitored NodeId.
-    const NodeId& getNodeId() const;
+    const NodeId& getNodeId();
 
     /// Get the monitored AttributeId.
-    AttributeId getAttributeId() const;
+    AttributeId getAttributeId();
 
     /// Modify this monitored item.
     /// @note Not implemented for Server.

--- a/include/open62541pp/MonitoredItem.h
+++ b/include/open62541pp/MonitoredItem.h
@@ -34,18 +34,18 @@ public:
     MonitoredItem(
         Connection& connection, uint32_t subscriptionId, uint32_t monitoredItemId
     ) noexcept
-        : connection_(connection),
+        : connection_(&connection),
           subscriptionId_(std::is_same_v<Connection, Server> ? 0U : subscriptionId),
           monitoredItemId_(monitoredItemId) {}
 
     /// Get the server/client instance.
     Connection& connection() noexcept {
-        return connection_;
+        return *connection_;
     }
 
     /// Get the server/client instance.
     const Connection& connection() const noexcept {
-        return connection_;
+        return *connection_;
     }
 
     /// Get the server-assigned identifier of the underlying subscription.
@@ -68,7 +68,7 @@ public:
     /// @note Not implemented for Server.
     /// @see services::modifyMonitoredItem
     void setMonitoringParameters(MonitoringParametersEx& parameters) {
-        services::modifyMonitoredItem(connection_, subscriptionId_, monitoredItemId_, parameters)
+        services::modifyMonitoredItem(connection(), subscriptionId(), monitoredItemId(), parameters)
             .value();
     }
 
@@ -76,18 +76,18 @@ public:
     /// @note Not implemented for Server.
     /// @see services::setMonitoringMode
     void setMonitoringMode(MonitoringMode monitoringMode) {
-        services::setMonitoringMode(connection_, subscriptionId_, monitoredItemId_, monitoringMode)
+        services::setMonitoringMode(connection(), subscriptionId(), monitoredItemId(), monitoringMode)
             .value();
     }
 
     /// Delete this monitored item.
     /// @see services::deleteMonitoredItem
     void deleteMonitoredItem() {
-        services::deleteMonitoredItem(connection_, subscriptionId_, monitoredItemId_).value();
+        services::deleteMonitoredItem(connection(), subscriptionId(), monitoredItemId()).value();
     }
 
 private:
-    Connection& connection_;
+    Connection* connection_;
     uint32_t subscriptionId_{0U};
     uint32_t monitoredItemId_{0U};
 };

--- a/include/open62541pp/Node.h
+++ b/include/open62541pp/Node.h
@@ -79,7 +79,7 @@ public:
         const NodeId& referenceType = ReferenceTypeId::HasComponent
     ) {
         auto result = services::addFolder(
-            connection(), id_, id, browseName, attributes, referenceType
+            connection(), this->id(), id, browseName, attributes, referenceType
         );
         return {connection(), result.value()};
     }
@@ -93,7 +93,7 @@ public:
         const NodeId& referenceType = ReferenceTypeId::HasComponent
     ) {
         auto result = services::addObject(
-            connection(), id_, id, browseName, attributes, objectType, referenceType
+            connection(), this->id(), id, browseName, attributes, objectType, referenceType
         );
         return {connection(), result.value()};
     }
@@ -107,7 +107,7 @@ public:
         const NodeId& referenceType = ReferenceTypeId::HasComponent
     ) {
         auto result = services::addVariable(
-            connection(), id_, id, browseName, attributes, variableType, referenceType
+            connection(), this->id(), id, browseName, attributes, variableType, referenceType
         );
         return {connection(), result.value()};
     }
@@ -116,7 +116,7 @@ public:
     Node addProperty(
         const NodeId& id, std::string_view browseName, const VariableAttributes& attributes = {}
     ) {
-        auto result = services::addProperty(connection(), id_, id, browseName, attributes);
+        auto result = services::addProperty(connection(), this->id(), id, browseName, attributes);
         return {connection(), result.value()};
     }
 
@@ -133,7 +133,7 @@ public:
     ) {
         auto result = services::addMethod(
             connection(),
-            id_,
+            this->id(),
             id,
             browseName,
             std::move(callback),
@@ -154,7 +154,7 @@ public:
         const NodeId& referenceType = ReferenceTypeId::HasSubtype
     ) {
         auto result = services::addObjectType(
-            connection(), id_, id, browseName, attributes, referenceType
+            connection(), this->id(), id, browseName, attributes, referenceType
         );
         return {connection(), result.value()};
     }
@@ -168,7 +168,7 @@ public:
         const NodeId& referenceType = ReferenceTypeId::HasSubtype
     ) {
         auto result = services::addVariableType(
-            connection(), id_, id, browseName, attributes, variableType, referenceType
+            connection(), this->id(), id, browseName, attributes, variableType, referenceType
         );
         return {connection(), result.value()};
     }
@@ -181,7 +181,7 @@ public:
         const NodeId& referenceType = ReferenceTypeId::HasSubtype
     ) {
         auto result = services::addReferenceType(
-            connection(), id_, id, browseName, attributes, referenceType
+            connection(), this->id(), id, browseName, attributes, referenceType
         );
         return {connection(), result.value()};
     }
@@ -194,7 +194,7 @@ public:
         const NodeId& referenceType = ReferenceTypeId::HasSubtype
     ) {
         auto result = services::addDataType(
-            connection(), id_, id, browseName, attributes, referenceType
+            connection(), this->id(), id, browseName, attributes, referenceType
         );
         return {connection(), result.value()};
     }
@@ -207,26 +207,26 @@ public:
         const NodeId& referenceType = ReferenceTypeId::Organizes
     ) {
         auto result = services::addView(
-            connection(), id_, id, browseName, attributes, referenceType
+            connection(), this->id(), id, browseName, attributes, referenceType
         );
         return {connection(), result.value()};
     }
 
     /// @wrapper{services::addReference}
     Node& addReference(const NodeId& targetId, const NodeId& referenceType, bool forward = true) {
-        services::addReference(connection(), id_, targetId, referenceType, forward).value();
+        services::addReference(connection(), id(), targetId, referenceType, forward).value();
         return *this;
     }
 
     /// @wrapper{services::addModellingRule}
     Node& addModellingRule(ModellingRule rule) {
-        services::addModellingRule(connection(), id_, rule).value();
+        services::addModellingRule(connection(), id(), rule).value();
         return *this;
     }
 
     /// @wrapper{services::deleteNode}
     void deleteNode(bool deleteReferences = true) {
-        services::deleteNode(connection(), id_, deleteReferences).value();
+        services::deleteNode(connection(), id(), deleteReferences).value();
     }
 
     /// @wrapper{services::deleteReference}
@@ -237,7 +237,7 @@ public:
         bool deleteBidirectional
     ) {
         services::deleteReference(
-            connection(), id_, targetId, referenceType, isForward, deleteBidirectional
+            connection(), id(), targetId, referenceType, isForward, deleteBidirectional
         )
             .value();
         return *this;
@@ -251,7 +251,7 @@ public:
         Bitmask<NodeClass> nodeClassMask = NodeClass::Unspecified
     ) {
         const BrowseDescription bd(
-            id_,
+            id(),
             browseDirection,
             referenceType,
             includeSubtypes,
@@ -269,7 +269,7 @@ public:
         Bitmask<NodeClass> nodeClassMask = NodeClass::Unspecified
     ) {
         const BrowseDescription bd(
-            id_,
+            id(),
             browseDirection,
             referenceType,
             includeSubtypes,
@@ -299,7 +299,7 @@ public:
     /// The relative path is specified using browse names.
     /// @exception BadStatus (BadNoMatch) If path not found
     Node browseChild(Span<const QualifiedName> path) {
-        auto result = services::browseSimplifiedBrowsePath(connection(), id_, path).value();
+        auto result = services::browseSimplifiedBrowsePath(connection(), id(), path).value();
         for (auto&& target : result.getTargets()) {
             if (target.getTargetId().isLocal()) {
                 return {connection(), std::move(target.getTargetId().getNodeId())};
@@ -329,73 +329,73 @@ public:
     /// @param methodId NodeId of the method (`HasComponent` reference to current node required)
     /// @param inputArguments Input argument values
     std::vector<Variant> callMethod(const NodeId& methodId, Span<const Variant> inputArguments) {
-        return services::call(connection(), id_, methodId, inputArguments).value();
+        return services::call(connection(), id(), methodId, inputArguments).value();
     }
 #endif
 
     /// @wrapper{services::readNodeClass}
     NodeClass readNodeClass() {
-        return services::readNodeClass(connection(), id_).value();
+        return services::readNodeClass(connection(), id()).value();
     }
 
     /// @wrapper{services::readBrowseName}
     QualifiedName readBrowseName() {
-        return services::readBrowseName(connection(), id_).value();
+        return services::readBrowseName(connection(), id()).value();
     }
 
     /// @wrapper{services::readDisplayName}
     LocalizedText readDisplayName() {
-        return services::readDisplayName(connection(), id_).value();
+        return services::readDisplayName(connection(), id()).value();
     }
 
     /// @wrapper{services::readDescription}
     LocalizedText readDescription() {
-        return services::readDescription(connection(), id_).value();
+        return services::readDescription(connection(), id()).value();
     }
 
     /// @wrapper{services::readWriteMask}
     Bitmask<WriteMask> readWriteMask() {
-        return services::readWriteMask(connection(), id_).value();
+        return services::readWriteMask(connection(), id()).value();
     }
 
     /// @wrapper{services::readUserWriteMask}
     Bitmask<WriteMask> readUserWriteMask() {
-        return services::readUserWriteMask(connection(), id_).value();
+        return services::readUserWriteMask(connection(), id()).value();
     }
 
     /// @wrapper{services::readIsAbstract}
     bool readIsAbstract() {
-        return services::readIsAbstract(connection(), id_).value();
+        return services::readIsAbstract(connection(), id()).value();
     }
 
     /// @wrapper{services::readSymmetric}
     bool readSymmetric() {
-        return services::readSymmetric(connection(), id_).value();
+        return services::readSymmetric(connection(), id()).value();
     }
 
     /// @wrapper{services::readInverseName}
     LocalizedText readInverseName() {
-        return services::readInverseName(connection(), id_).value();
+        return services::readInverseName(connection(), id()).value();
     }
 
     /// @wrapper{services::readContainsNoLoops}
     bool readContainsNoLoops() {
-        return services::readContainsNoLoops(connection(), id_).value();
+        return services::readContainsNoLoops(connection(), id()).value();
     }
 
     /// @wrapper{services::readEventNotifier}
     Bitmask<EventNotifier> readEventNotifier() {
-        return services::readEventNotifier(connection(), id_).value();
+        return services::readEventNotifier(connection(), id()).value();
     }
 
     /// @wrapper{services::readDataValue}
     DataValue readDataValue() {
-        return services::readDataValue(connection(), id_).value();
+        return services::readDataValue(connection(), id()).value();
     }
 
     /// @wrapper{services::readValue}
     Variant readValue() {
-        return services::readValue(connection(), id_).value();
+        return services::readValue(connection(), id()).value();
     }
 
     /// Read scalar value from variable node.
@@ -412,52 +412,52 @@ public:
 
     /// @wrapper{services::readDataType}
     NodeId readDataType() {
-        return services::readDataType(connection(), id_).value();
+        return services::readDataType(connection(), id()).value();
     }
 
     /// @wrapper{services::readValueRank}
     ValueRank readValueRank() {
-        return services::readValueRank(connection(), id_).value();
+        return services::readValueRank(connection(), id()).value();
     }
 
     /// @wrapper{services::readArrayDimensions}
     std::vector<uint32_t> readArrayDimensions() {
-        return services::readArrayDimensions(connection(), id_).value();
+        return services::readArrayDimensions(connection(), id()).value();
     }
 
     /// @wrapper{services::readAccessLevel}
     Bitmask<AccessLevel> readAccessLevel() {
-        return services::readAccessLevel(connection(), id_).value();
+        return services::readAccessLevel(connection(), id()).value();
     }
 
     /// @wrapper{services::readUserAccessLevel}
     Bitmask<AccessLevel> readUserAccessLevel() {
-        return services::readUserAccessLevel(connection(), id_).value();
+        return services::readUserAccessLevel(connection(), id()).value();
     }
 
     /// @wrapper{services::readMinimumSamplingInterval}
     double readMinimumSamplingInterval() {
-        return services::readMinimumSamplingInterval(connection(), id_).value();
+        return services::readMinimumSamplingInterval(connection(), id()).value();
     }
 
     /// @wrapper{services::readHistorizing}
     bool readHistorizing() {
-        return services::readHistorizing(connection(), id_).value();
+        return services::readHistorizing(connection(), id()).value();
     }
 
     /// @wrapper{services::readExecutable}
     bool readExecutable() {
-        return services::readExecutable(connection(), id_).value();
+        return services::readExecutable(connection(), id()).value();
     }
 
     /// @wrapper{services::readUserExecutable}
     bool readUserExecutable() {
-        return services::readUserExecutable(connection(), id_).value();
+        return services::readUserExecutable(connection(), id()).value();
     }
 
     /// @wrapper{services::readDataTypeDefinition}
     Variant readDataTypeDefinition() {
-        return services::readDataTypeDefinition(connection(), id_).value();
+        return services::readDataTypeDefinition(connection(), id()).value();
     }
 
     /// Read the value of an object property.
@@ -468,67 +468,67 @@ public:
 
     /// @wrapper{services::writeDisplayName}
     Node& writeDisplayName(const LocalizedText& name) {
-        services::writeDisplayName(connection(), id_, name).value();
+        services::writeDisplayName(connection(), id(), name).value();
         return *this;
     }
 
     /// @wrapper{services::writeDescription}
     Node& writeDescription(const LocalizedText& desc) {
-        services::writeDescription(connection(), id_, desc).value();
+        services::writeDescription(connection(), id(), desc).value();
         return *this;
     }
 
     /// @wrapper{services::writeWriteMask}
     Node& writeWriteMask(Bitmask<WriteMask> mask) {
-        services::writeWriteMask(connection(), id_, mask).value();
+        services::writeWriteMask(connection(), id(), mask).value();
         return *this;
     }
 
     /// @wrapper{services::writeWriteMask}
     Node& writeUserWriteMask(Bitmask<WriteMask> mask) {
-        services::writeUserWriteMask(connection(), id_, mask).value();
+        services::writeUserWriteMask(connection(), id(), mask).value();
         return *this;
     }
 
     /// @wrapper{services::writeIsAbstract}
     Node& writeIsAbstract(bool isAbstract) {
-        services::writeIsAbstract(connection(), id_, isAbstract).value();
+        services::writeIsAbstract(connection(), id(), isAbstract).value();
         return *this;
     }
 
     /// @wrapper{services::writeSymmetric}
     Node& writeSymmetric(bool symmetric) {
-        services::writeSymmetric(connection(), id_, symmetric).value();
+        services::writeSymmetric(connection(), id(), symmetric).value();
         return *this;
     }
 
     /// @wrapper{services::writeInverseName}
     Node& writeInverseName(const LocalizedText& name) {
-        services::writeInverseName(connection(), id_, name).value();
+        services::writeInverseName(connection(), id(), name).value();
         return *this;
     }
 
     /// @wrapper{services::writeContainsNoLoops}
     Node& writeContainsNoLoops(bool containsNoLoops) {
-        services::writeContainsNoLoops(connection(), id_, containsNoLoops).value();
+        services::writeContainsNoLoops(connection(), id(), containsNoLoops).value();
         return *this;
     }
 
     /// @wrapper{services::writeEventNotifier}
     Node& writeEventNotifier(Bitmask<EventNotifier> mask) {
-        services::writeEventNotifier(connection(), id_, mask).value();
+        services::writeEventNotifier(connection(), id(), mask).value();
         return *this;
     }
 
     /// @wrapper{services::writeDataValue}
     Node& writeDataValue(const DataValue& value) {
-        services::writeDataValue(connection(), id_, value).value();
+        services::writeDataValue(connection(), id(), value).value();
         return *this;
     }
 
     /// @wrapper{services::writeValue}
     Node& writeValue(const Variant& value) {
-        services::writeValue(connection(), id_, value).value();
+        services::writeValue(connection(), id(), value).value();
         return *this;
     }
 
@@ -558,7 +558,7 @@ public:
 
     /// @wrapper{services::writeDataType}
     Node& writeDataType(const NodeId& typeId) {
-        services::writeDataType(connection(), id_, typeId).value();
+        services::writeDataType(connection(), id(), typeId).value();
         return *this;
     }
 
@@ -571,49 +571,49 @@ public:
 
     /// @wrapper{services::writeValueRank}
     Node& writeValueRank(ValueRank valueRank) {
-        services::writeValueRank(connection(), id_, valueRank).value();
+        services::writeValueRank(connection(), id(), valueRank).value();
         return *this;
     }
 
     /// @wrapper{services::writeArrayDimensions}
     Node& writeArrayDimensions(Span<const uint32_t> dimensions) {
-        services::writeArrayDimensions(connection(), id_, dimensions).value();
+        services::writeArrayDimensions(connection(), id(), dimensions).value();
         return *this;
     }
 
     /// @wrapper{services::writeAccessLevel}
     Node& writeAccessLevel(Bitmask<AccessLevel> mask) {
-        services::writeAccessLevel(connection(), id_, mask).value();
+        services::writeAccessLevel(connection(), id(), mask).value();
         return *this;
     }
 
     /// @wrapper{services::writeUserAccessLevel}
     Node& writeUserAccessLevel(Bitmask<AccessLevel> mask) {
-        services::writeUserAccessLevel(connection(), id_, mask).value();
+        services::writeUserAccessLevel(connection(), id(), mask).value();
         return *this;
     }
 
     /// @wrapper{services::writeMinimumSamplingInterval}
     Node& writeMinimumSamplingInterval(double milliseconds) {
-        services::writeMinimumSamplingInterval(connection(), id_, milliseconds).value();
+        services::writeMinimumSamplingInterval(connection(), id(), milliseconds).value();
         return *this;
     }
 
     /// @wrapper{services::writeHistorizing}
     Node& writeHistorizing(bool historizing) {
-        services::writeHistorizing(connection(), id_, historizing).value();
+        services::writeHistorizing(connection(), id(), historizing).value();
         return *this;
     }
 
     /// @wrapper{services::writeExecutable}
     Node& writeExecutable(bool executable) {
-        services::writeExecutable(connection(), id_, executable).value();
+        services::writeExecutable(connection(), id(), executable).value();
         return *this;
     }
 
     /// @wrapper{services::writeUserExecutable}
     Node& writeUserExecutable(bool userExecutable) {
-        services::writeUserExecutable(connection(), id_, userExecutable).value();
+        services::writeUserExecutable(connection(), id(), userExecutable).value();
         return *this;
     }
 
@@ -630,7 +630,7 @@ private:
         auto result =
             services::translateBrowsePathToNodeIds(
                 connection(),
-                BrowsePath(id_, {{ReferenceTypeId::HasProperty, false, true, propertyName}})
+                BrowsePath(id(), {{ReferenceTypeId::HasProperty, false, true, propertyName}})
             ).value();
         result.getStatusCode().throwIfBad();
         for (auto&& target : result.getTargets()) {

--- a/include/open62541pp/Node.h
+++ b/include/open62541pp/Node.h
@@ -43,22 +43,22 @@ class Node {
 public:
     /// Create a Node object.
     Node(Connection& connection, const NodeId& id)
-        : connection_(connection),
+        : connection_(&connection),
           id_(id) {}
 
     /// Create a Node object.
     Node(Connection& connection, NodeId&& id)
-        : connection_(connection),
+        : connection_(&connection),
           id_(std::move(id)) {}
 
     /// Get the server/client instance.
     Connection& connection() noexcept {
-        return connection_;
+        return *connection_;
     }
 
     /// Get the server/client instance.
     const Connection& connection() const noexcept {
-        return connection_;
+        return *connection_;
     }
 
     /// Get the node id.
@@ -79,9 +79,9 @@ public:
         const NodeId& referenceType = ReferenceTypeId::HasComponent
     ) {
         auto result = services::addFolder(
-            connection_, id_, id, browseName, attributes, referenceType
+            connection(), id_, id, browseName, attributes, referenceType
         );
-        return {connection_, result.value()};
+        return {connection(), result.value()};
     }
 
     /// @wrapper{services::addObject}
@@ -93,9 +93,9 @@ public:
         const NodeId& referenceType = ReferenceTypeId::HasComponent
     ) {
         auto result = services::addObject(
-            connection_, id_, id, browseName, attributes, objectType, referenceType
+            connection(), id_, id, browseName, attributes, objectType, referenceType
         );
-        return {connection_, result.value()};
+        return {connection(), result.value()};
     }
 
     /// @wrapper{services::addVariable}
@@ -107,17 +107,17 @@ public:
         const NodeId& referenceType = ReferenceTypeId::HasComponent
     ) {
         auto result = services::addVariable(
-            connection_, id_, id, browseName, attributes, variableType, referenceType
+            connection(), id_, id, browseName, attributes, variableType, referenceType
         );
-        return {connection_, result.value()};
+        return {connection(), result.value()};
     }
 
     /// @wrapper{services::addProperty}
     Node addProperty(
         const NodeId& id, std::string_view browseName, const VariableAttributes& attributes = {}
     ) {
-        auto result = services::addProperty(connection_, id_, id, browseName, attributes);
-        return {connection_, result.value()};
+        auto result = services::addProperty(connection(), id_, id, browseName, attributes);
+        return {connection(), result.value()};
     }
 
 #ifdef UA_ENABLE_METHODCALLS
@@ -132,7 +132,7 @@ public:
         const NodeId& referenceType = ReferenceTypeId::HasComponent
     ) {
         auto result = services::addMethod(
-            connection_,
+            connection(),
             id_,
             id,
             browseName,
@@ -142,7 +142,7 @@ public:
             attributes,
             referenceType
         );
-        return {connection_, result.value()};
+        return {connection(), result.value()};
     }
 #endif
 
@@ -154,9 +154,9 @@ public:
         const NodeId& referenceType = ReferenceTypeId::HasSubtype
     ) {
         auto result = services::addObjectType(
-            connection_, id_, id, browseName, attributes, referenceType
+            connection(), id_, id, browseName, attributes, referenceType
         );
-        return {connection_, result.value()};
+        return {connection(), result.value()};
     }
 
     /// @wrapper{services::addVariableType}
@@ -168,9 +168,9 @@ public:
         const NodeId& referenceType = ReferenceTypeId::HasSubtype
     ) {
         auto result = services::addVariableType(
-            connection_, id_, id, browseName, attributes, variableType, referenceType
+            connection(), id_, id, browseName, attributes, variableType, referenceType
         );
-        return {connection_, result.value()};
+        return {connection(), result.value()};
     }
 
     /// @wrapper{services::addReferenceType}
@@ -181,9 +181,9 @@ public:
         const NodeId& referenceType = ReferenceTypeId::HasSubtype
     ) {
         auto result = services::addReferenceType(
-            connection_, id_, id, browseName, attributes, referenceType
+            connection(), id_, id, browseName, attributes, referenceType
         );
-        return {connection_, result.value()};
+        return {connection(), result.value()};
     }
 
     /// @wrapper{services::addDataType}
@@ -194,9 +194,9 @@ public:
         const NodeId& referenceType = ReferenceTypeId::HasSubtype
     ) {
         auto result = services::addDataType(
-            connection_, id_, id, browseName, attributes, referenceType
+            connection(), id_, id, browseName, attributes, referenceType
         );
-        return {connection_, result.value()};
+        return {connection(), result.value()};
     }
 
     /// @wrapper{services::addView}
@@ -207,26 +207,26 @@ public:
         const NodeId& referenceType = ReferenceTypeId::Organizes
     ) {
         auto result = services::addView(
-            connection_, id_, id, browseName, attributes, referenceType
+            connection(), id_, id, browseName, attributes, referenceType
         );
-        return {connection_, result.value()};
+        return {connection(), result.value()};
     }
 
     /// @wrapper{services::addReference}
     Node& addReference(const NodeId& targetId, const NodeId& referenceType, bool forward = true) {
-        services::addReference(connection_, id_, targetId, referenceType, forward).value();
+        services::addReference(connection(), id_, targetId, referenceType, forward).value();
         return *this;
     }
 
     /// @wrapper{services::addModellingRule}
     Node& addModellingRule(ModellingRule rule) {
-        services::addModellingRule(connection_, id_, rule).value();
+        services::addModellingRule(connection(), id_, rule).value();
         return *this;
     }
 
     /// @wrapper{services::deleteNode}
     void deleteNode(bool deleteReferences = true) {
-        services::deleteNode(connection_, id_, deleteReferences).value();
+        services::deleteNode(connection(), id_, deleteReferences).value();
     }
 
     /// @wrapper{services::deleteReference}
@@ -237,7 +237,7 @@ public:
         bool deleteBidirectional
     ) {
         services::deleteReference(
-            connection_, id_, targetId, referenceType, isForward, deleteBidirectional
+            connection(), id_, targetId, referenceType, isForward, deleteBidirectional
         )
             .value();
         return *this;
@@ -258,7 +258,7 @@ public:
             nodeClassMask,
             BrowseResultMask::All
         );
-        return services::browseAll(connection_, bd).value();
+        return services::browseAll(connection(), bd).value();
     }
 
     /// Browse referenced nodes (only local nodes).
@@ -276,12 +276,12 @@ public:
             nodeClassMask,
             BrowseResultMask::TargetInfo  // only node id required here
         );
-        auto refs = services::browseAll(connection_, bd).value();
+        auto refs = services::browseAll(connection(), bd).value();
         std::vector<Node> nodes;
         nodes.reserve(refs.size());
         for (auto&& ref : refs) {
             if (ref.getNodeId().isLocal()) {
-                nodes.emplace_back(connection_, std::move(ref.getNodeId().getNodeId()));
+                nodes.emplace_back(connection(), std::move(ref.getNodeId().getNodeId()));
             }
         }
         return nodes;
@@ -299,10 +299,10 @@ public:
     /// The relative path is specified using browse names.
     /// @exception BadStatus (BadNoMatch) If path not found
     Node browseChild(Span<const QualifiedName> path) {
-        auto result = services::browseSimplifiedBrowsePath(connection_, id_, path).value();
+        auto result = services::browseSimplifiedBrowsePath(connection(), id_, path).value();
         for (auto&& target : result.getTargets()) {
             if (target.getTargetId().isLocal()) {
-                return {connection_, std::move(target.getTargetId().getNodeId())};
+                return {connection(), std::move(target.getTargetId().getNodeId())};
             }
         }
         throw BadStatus(UA_STATUSCODE_BADNOMATCH);
@@ -329,73 +329,73 @@ public:
     /// @param methodId NodeId of the method (`HasComponent` reference to current node required)
     /// @param inputArguments Input argument values
     std::vector<Variant> callMethod(const NodeId& methodId, Span<const Variant> inputArguments) {
-        return services::call(connection_, id_, methodId, inputArguments).value();
+        return services::call(connection(), id_, methodId, inputArguments).value();
     }
 #endif
 
     /// @wrapper{services::readNodeClass}
     NodeClass readNodeClass() {
-        return services::readNodeClass(connection_, id_).value();
+        return services::readNodeClass(connection(), id_).value();
     }
 
     /// @wrapper{services::readBrowseName}
     QualifiedName readBrowseName() {
-        return services::readBrowseName(connection_, id_).value();
+        return services::readBrowseName(connection(), id_).value();
     }
 
     /// @wrapper{services::readDisplayName}
     LocalizedText readDisplayName() {
-        return services::readDisplayName(connection_, id_).value();
+        return services::readDisplayName(connection(), id_).value();
     }
 
     /// @wrapper{services::readDescription}
     LocalizedText readDescription() {
-        return services::readDescription(connection_, id_).value();
+        return services::readDescription(connection(), id_).value();
     }
 
     /// @wrapper{services::readWriteMask}
     Bitmask<WriteMask> readWriteMask() {
-        return services::readWriteMask(connection_, id_).value();
+        return services::readWriteMask(connection(), id_).value();
     }
 
     /// @wrapper{services::readUserWriteMask}
     Bitmask<WriteMask> readUserWriteMask() {
-        return services::readUserWriteMask(connection_, id_).value();
+        return services::readUserWriteMask(connection(), id_).value();
     }
 
     /// @wrapper{services::readIsAbstract}
     bool readIsAbstract() {
-        return services::readIsAbstract(connection_, id_).value();
+        return services::readIsAbstract(connection(), id_).value();
     }
 
     /// @wrapper{services::readSymmetric}
     bool readSymmetric() {
-        return services::readSymmetric(connection_, id_).value();
+        return services::readSymmetric(connection(), id_).value();
     }
 
     /// @wrapper{services::readInverseName}
     LocalizedText readInverseName() {
-        return services::readInverseName(connection_, id_).value();
+        return services::readInverseName(connection(), id_).value();
     }
 
     /// @wrapper{services::readContainsNoLoops}
     bool readContainsNoLoops() {
-        return services::readContainsNoLoops(connection_, id_).value();
+        return services::readContainsNoLoops(connection(), id_).value();
     }
 
     /// @wrapper{services::readEventNotifier}
     Bitmask<EventNotifier> readEventNotifier() {
-        return services::readEventNotifier(connection_, id_).value();
+        return services::readEventNotifier(connection(), id_).value();
     }
 
     /// @wrapper{services::readDataValue}
     DataValue readDataValue() {
-        return services::readDataValue(connection_, id_).value();
+        return services::readDataValue(connection(), id_).value();
     }
 
     /// @wrapper{services::readValue}
     Variant readValue() {
-        return services::readValue(connection_, id_).value();
+        return services::readValue(connection(), id_).value();
     }
 
     /// Read scalar value from variable node.
@@ -412,52 +412,52 @@ public:
 
     /// @wrapper{services::readDataType}
     NodeId readDataType() {
-        return services::readDataType(connection_, id_).value();
+        return services::readDataType(connection(), id_).value();
     }
 
     /// @wrapper{services::readValueRank}
     ValueRank readValueRank() {
-        return services::readValueRank(connection_, id_).value();
+        return services::readValueRank(connection(), id_).value();
     }
 
     /// @wrapper{services::readArrayDimensions}
     std::vector<uint32_t> readArrayDimensions() {
-        return services::readArrayDimensions(connection_, id_).value();
+        return services::readArrayDimensions(connection(), id_).value();
     }
 
     /// @wrapper{services::readAccessLevel}
     Bitmask<AccessLevel> readAccessLevel() {
-        return services::readAccessLevel(connection_, id_).value();
+        return services::readAccessLevel(connection(), id_).value();
     }
 
     /// @wrapper{services::readUserAccessLevel}
     Bitmask<AccessLevel> readUserAccessLevel() {
-        return services::readUserAccessLevel(connection_, id_).value();
+        return services::readUserAccessLevel(connection(), id_).value();
     }
 
     /// @wrapper{services::readMinimumSamplingInterval}
     double readMinimumSamplingInterval() {
-        return services::readMinimumSamplingInterval(connection_, id_).value();
+        return services::readMinimumSamplingInterval(connection(), id_).value();
     }
 
     /// @wrapper{services::readHistorizing}
     bool readHistorizing() {
-        return services::readHistorizing(connection_, id_).value();
+        return services::readHistorizing(connection(), id_).value();
     }
 
     /// @wrapper{services::readExecutable}
     bool readExecutable() {
-        return services::readExecutable(connection_, id_).value();
+        return services::readExecutable(connection(), id_).value();
     }
 
     /// @wrapper{services::readUserExecutable}
     bool readUserExecutable() {
-        return services::readUserExecutable(connection_, id_).value();
+        return services::readUserExecutable(connection(), id_).value();
     }
 
     /// @wrapper{services::readDataTypeDefinition}
     Variant readDataTypeDefinition() {
-        return services::readDataTypeDefinition(connection_, id_).value();
+        return services::readDataTypeDefinition(connection(), id_).value();
     }
 
     /// Read the value of an object property.
@@ -468,67 +468,67 @@ public:
 
     /// @wrapper{services::writeDisplayName}
     Node& writeDisplayName(const LocalizedText& name) {
-        services::writeDisplayName(connection_, id_, name).value();
+        services::writeDisplayName(connection(), id_, name).value();
         return *this;
     }
 
     /// @wrapper{services::writeDescription}
     Node& writeDescription(const LocalizedText& desc) {
-        services::writeDescription(connection_, id_, desc).value();
+        services::writeDescription(connection(), id_, desc).value();
         return *this;
     }
 
     /// @wrapper{services::writeWriteMask}
     Node& writeWriteMask(Bitmask<WriteMask> mask) {
-        services::writeWriteMask(connection_, id_, mask).value();
+        services::writeWriteMask(connection(), id_, mask).value();
         return *this;
     }
 
     /// @wrapper{services::writeWriteMask}
     Node& writeUserWriteMask(Bitmask<WriteMask> mask) {
-        services::writeUserWriteMask(connection_, id_, mask).value();
+        services::writeUserWriteMask(connection(), id_, mask).value();
         return *this;
     }
 
     /// @wrapper{services::writeIsAbstract}
     Node& writeIsAbstract(bool isAbstract) {
-        services::writeIsAbstract(connection_, id_, isAbstract).value();
+        services::writeIsAbstract(connection(), id_, isAbstract).value();
         return *this;
     }
 
     /// @wrapper{services::writeSymmetric}
     Node& writeSymmetric(bool symmetric) {
-        services::writeSymmetric(connection_, id_, symmetric).value();
+        services::writeSymmetric(connection(), id_, symmetric).value();
         return *this;
     }
 
     /// @wrapper{services::writeInverseName}
     Node& writeInverseName(const LocalizedText& name) {
-        services::writeInverseName(connection_, id_, name).value();
+        services::writeInverseName(connection(), id_, name).value();
         return *this;
     }
 
     /// @wrapper{services::writeContainsNoLoops}
     Node& writeContainsNoLoops(bool containsNoLoops) {
-        services::writeContainsNoLoops(connection_, id_, containsNoLoops).value();
+        services::writeContainsNoLoops(connection(), id_, containsNoLoops).value();
         return *this;
     }
 
     /// @wrapper{services::writeEventNotifier}
     Node& writeEventNotifier(Bitmask<EventNotifier> mask) {
-        services::writeEventNotifier(connection_, id_, mask).value();
+        services::writeEventNotifier(connection(), id_, mask).value();
         return *this;
     }
 
     /// @wrapper{services::writeDataValue}
     Node& writeDataValue(const DataValue& value) {
-        services::writeDataValue(connection_, id_, value).value();
+        services::writeDataValue(connection(), id_, value).value();
         return *this;
     }
 
     /// @wrapper{services::writeValue}
     Node& writeValue(const Variant& value) {
-        services::writeValue(connection_, id_, value).value();
+        services::writeValue(connection(), id_, value).value();
         return *this;
     }
 
@@ -558,7 +558,7 @@ public:
 
     /// @wrapper{services::writeDataType}
     Node& writeDataType(const NodeId& typeId) {
-        services::writeDataType(connection_, id_, typeId).value();
+        services::writeDataType(connection(), id_, typeId).value();
         return *this;
     }
 
@@ -571,49 +571,49 @@ public:
 
     /// @wrapper{services::writeValueRank}
     Node& writeValueRank(ValueRank valueRank) {
-        services::writeValueRank(connection_, id_, valueRank).value();
+        services::writeValueRank(connection(), id_, valueRank).value();
         return *this;
     }
 
     /// @wrapper{services::writeArrayDimensions}
     Node& writeArrayDimensions(Span<const uint32_t> dimensions) {
-        services::writeArrayDimensions(connection_, id_, dimensions).value();
+        services::writeArrayDimensions(connection(), id_, dimensions).value();
         return *this;
     }
 
     /// @wrapper{services::writeAccessLevel}
     Node& writeAccessLevel(Bitmask<AccessLevel> mask) {
-        services::writeAccessLevel(connection_, id_, mask).value();
+        services::writeAccessLevel(connection(), id_, mask).value();
         return *this;
     }
 
     /// @wrapper{services::writeUserAccessLevel}
     Node& writeUserAccessLevel(Bitmask<AccessLevel> mask) {
-        services::writeUserAccessLevel(connection_, id_, mask).value();
+        services::writeUserAccessLevel(connection(), id_, mask).value();
         return *this;
     }
 
     /// @wrapper{services::writeMinimumSamplingInterval}
     Node& writeMinimumSamplingInterval(double milliseconds) {
-        services::writeMinimumSamplingInterval(connection_, id_, milliseconds).value();
+        services::writeMinimumSamplingInterval(connection(), id_, milliseconds).value();
         return *this;
     }
 
     /// @wrapper{services::writeHistorizing}
     Node& writeHistorizing(bool historizing) {
-        services::writeHistorizing(connection_, id_, historizing).value();
+        services::writeHistorizing(connection(), id_, historizing).value();
         return *this;
     }
 
     /// @wrapper{services::writeExecutable}
     Node& writeExecutable(bool executable) {
-        services::writeExecutable(connection_, id_, executable).value();
+        services::writeExecutable(connection(), id_, executable).value();
         return *this;
     }
 
     /// @wrapper{services::writeUserExecutable}
     Node& writeUserExecutable(bool userExecutable) {
-        services::writeUserExecutable(connection_, id_, userExecutable).value();
+        services::writeUserExecutable(connection(), id_, userExecutable).value();
         return *this;
     }
 
@@ -629,19 +629,19 @@ private:
     Node browseObjectProperty(const QualifiedName& propertyName) {
         auto result =
             services::translateBrowsePathToNodeIds(
-                connection_,
+                connection(),
                 BrowsePath(id_, {{ReferenceTypeId::HasProperty, false, true, propertyName}})
             ).value();
         result.getStatusCode().throwIfBad();
         for (auto&& target : result.getTargets()) {
             if (target.getTargetId().isLocal()) {
-                return {connection_, std::move(target.getTargetId().getNodeId())};
+                return {connection(), std::move(target.getTargetId().getNodeId())};
             }
         }
         throw BadStatus(UA_STATUSCODE_BADNOTFOUND);
     }
 
-    Connection& connection_;
+    Connection* connection_;
     NodeId id_;
 };
 

--- a/include/open62541pp/Session.h
+++ b/include/open62541pp/Session.h
@@ -23,17 +23,17 @@ class Variant;
 class Session {
 public:
     Session(Server& connection, NodeId sessionId) noexcept
-        : connection_(connection),
+        : connection_(&connection),
           sessionId_(std::move(sessionId)) {}
 
     /// Get the server instance.
     Server& connection() noexcept {
-        return connection_;
+        return *connection_;
     }
 
     /// Get the server instance.
     const Server& connection() const noexcept {
-        return connection_;
+        return *connection_;
     }
 
     /// Get the session identifier.
@@ -58,7 +58,7 @@ public:
     void close();
 
 private:
-    Server& connection_;
+    Server* connection_;
     NodeId sessionId_;
 };
 

--- a/include/open62541pp/Subscription.h
+++ b/include/open62541pp/Subscription.h
@@ -51,17 +51,17 @@ public:
     /// Wrap an existing subscription.
     /// The `subscriptionId` is ignored and set to `0U` for servers.
     Subscription(Connection& connection, uint32_t subscriptionId) noexcept
-        : connection_(connection),
+        : connection_(&connection),
           subscriptionId_(std::is_same_v<Connection, Server> ? 0U : subscriptionId) {}
 
     /// Get the server/client instance.
     Connection& connection() noexcept {
-        return connection_;
+        return *connection_;
     }
 
     /// Get the server/client instance.
     const Connection& connection() const noexcept {
-        return connection_;
+        return *connection_;
     }
 
     /// Get the server-assigned identifier of this subscription.
@@ -76,14 +76,14 @@ public:
     /// @note Not implemented for Server.
     /// @see services::modifySubscription
     void setSubscriptionParameters(SubscriptionParameters& parameters) {
-        services::modifySubscription(connection_, subscriptionId_, parameters).value();
+        services::modifySubscription(connection(), subscriptionId(), parameters).value();
     }
 
     /// Enable/disable publishing of notification messages.
     /// @note Not implemented for Server.
     /// @see services::setPublishingMode
     void setPublishingMode(bool publishing) {
-        services::setPublishingMode(connection_, subscriptionId_, publishing).value();
+        services::setPublishingMode(connection(), subscriptionId(), publishing).value();
     }
 
     /// Create a monitored item for data change notifications.
@@ -96,14 +96,14 @@ public:
         DataChangeNotificationCallback onDataChange
     ) {
         const auto result = services::createMonitoredItemDataChange(
-            connection_,
-            subscriptionId_,
+            connection(),
+            subscriptionId(),
             {id, attribute},
             monitoringMode,
             parameters,
             std::move(onDataChange)
         );
-        return {connection_, subscriptionId_, result.value()};
+        return {connection(), subscriptionId(), result.value()};
     }
 
     /// Create a monitored item for data change notifications (default settings).
@@ -129,14 +129,14 @@ public:
         EventNotificationCallback onEvent  // NOLINT(*-unnecessary-value-param), false positive?
     ) {
         const auto result = services::createMonitoredItemEvent(
-            connection_,
-            subscriptionId_,
+            connection(),
+            subscriptionId(),
             {id, AttributeId::EventNotifier},
             monitoringMode,
             parameters,
             std::move(onEvent)
         );
-        return {connection_, subscriptionId_, result.value()};
+        return {connection(), subscriptionId(), result.value()};
     }
 
     /// Create a monitored item for event notifications (default settings).
@@ -154,11 +154,11 @@ public:
     /// Delete this subscription.
     /// @note Not implemented for Server.
     void deleteSubscription() {
-        services::deleteSubscription(connection_, subscriptionId_).value();
+        services::deleteSubscription(connection(), subscriptionId()).value();
     }
 
 private:
-    Connection& connection_;
+    Connection* connection_;
     uint32_t subscriptionId_{0U};
 };
 

--- a/src/Event.cpp
+++ b/src/Event.cpp
@@ -13,7 +13,7 @@ namespace opcua {
 #ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS
 
 Event::Event(Server& connection, const NodeId& eventType)
-    : connection_(connection) {
+    : connection_(&connection) {
     throwIfBad(UA_Server_createEvent(connection.handle(), eventType, id_.handle()));
 }
 

--- a/src/MonitoredItem.cpp
+++ b/src/MonitoredItem.cpp
@@ -24,22 +24,22 @@ inline static auto& getMonitoredItemContext(
 }
 
 template <typename T>
-const NodeId& MonitoredItem<T>::getNodeId() const {
-    return getMonitoredItemContext(connection_, subscriptionId_, monitoredItemId_)
+const NodeId& MonitoredItem<T>::getNodeId() {
+    return getMonitoredItemContext(connection(), subscriptionId(), monitoredItemId())
         .itemToMonitor.getNodeId();
 }
 
 template <typename T>
-AttributeId MonitoredItem<T>::getAttributeId() const {
-    return getMonitoredItemContext(connection_, subscriptionId_, monitoredItemId_)
+AttributeId MonitoredItem<T>::getAttributeId() {
+    return getMonitoredItemContext(connection(), subscriptionId(), monitoredItemId())
         .itemToMonitor.getAttributeId();
 }
 
 // explicit template instantiations
-template const NodeId& MonitoredItem<Client>::getNodeId() const;
-template const NodeId& MonitoredItem<Server>::getNodeId() const;
-template AttributeId MonitoredItem<Client>::getAttributeId() const;
-template AttributeId MonitoredItem<Server>::getAttributeId() const;
+template const NodeId& MonitoredItem<Client>::getNodeId();
+template const NodeId& MonitoredItem<Server>::getNodeId();
+template AttributeId MonitoredItem<Client>::getAttributeId();
+template AttributeId MonitoredItem<Server>::getAttributeId();
 
 }  // namespace opcua
 

--- a/src/Subscription.cpp
+++ b/src/Subscription.cpp
@@ -11,7 +11,7 @@ namespace opcua {
 
 template <typename T>
 std::vector<MonitoredItem<T>> Subscription<T>::getMonitoredItems() {
-    auto& monitoredItems = opcua::detail::getContext(connection_).monitoredItems;
+    auto& monitoredItems = opcua::detail::getContext(connection()).monitoredItems;
     monitoredItems.eraseStale();
     auto lock = monitoredItems.acquireLock();
     const auto& map = monitoredItems.underlying();
@@ -19,8 +19,8 @@ std::vector<MonitoredItem<T>> Subscription<T>::getMonitoredItems() {
     result.reserve(map.size());
     for (const auto& [subMonId, _] : map) {
         const auto [subId, monId] = subMonId;
-        if (subId == subscriptionId_) {
-            result.emplace_back(connection_, subId, monId);
+        if (subId == subscriptionId()) {
+            result.emplace_back(connection(), subId, monId);
         }
     }
     return result;

--- a/tests/Node.cpp
+++ b/tests/Node.cpp
@@ -21,13 +21,13 @@ TEST_CASE_TEMPLATE("Node", T, Server, Client) {
     services::writeAccessLevel(setup.server, varId, 0xFF).value();
     services::writeWriteMask(setup.server, varId, 0xFFFFFFFF).value();
 
-    opcua::Node rootNode(connection, opcua::ObjectId::RootFolder);
-    opcua::Node objNode(connection, opcua::ObjectId::ObjectsFolder);
-    opcua::Node varNode(connection, varId);
-    opcua::Node refNode(connection, ReferenceTypeId::References);
+    Node rootNode(connection, ObjectId::RootFolder);
+    Node objNode(connection, ObjectId::ObjectsFolder);
+    Node varNode(connection, varId);
+    Node refNode(connection, ReferenceTypeId::References);
 
     SUBCASE("connection") {
-        CHECK(rootNode.connection() == connection);
+        CHECK(Node(connection, {}).connection() == connection);
     }
 
     SUBCASE("id") {
@@ -54,12 +54,12 @@ TEST_CASE_TEMPLATE("Node", T, Server, Client) {
 
     SUBCASE("Add type nodes") {
         CHECK(
-            opcua::Node(connection, ObjectTypeId::BaseObjectType)
+            Node(connection, ObjectTypeId::BaseObjectType)
                 .addObjectType({1, 1000}, "objecttype")
                 .readNodeClass() == NodeClass::ObjectType
         );
         CHECK(
-            opcua::Node(connection, VariableTypeId::BaseVariableType)
+            Node(connection, VariableTypeId::BaseVariableType)
                 .addVariableType({1, 1001}, "variabletype")
                 .readNodeClass() == NodeClass::VariableType
         );
@@ -116,8 +116,7 @@ TEST_CASE_TEMPLATE("Node", T, Server, Client) {
     SUBCASE("Read/write variable node attributes") {
         // https://github.com/open62541/open62541/issues/6723
         CHECK_EQ(
-            varNode.writeDisplayName({{}, "name"}).readDisplayName(),
-            LocalizedText({{}, "name"})
+            varNode.writeDisplayName({{}, "name"}).readDisplayName(), LocalizedText({{}, "name"})
         );
         CHECK_EQ(
             varNode.writeDescription({"en-US", "desc"}).readDescription(),


### PR DESCRIPTION
Following types store the server/client connection as a reference which makes them non-copyable and non-movable:
- `Node`
- `Event`
- `Subscription`
- `MonitoredItem`
- `Session`

This PR replaces the reference with a pointer to make the types copyable and movable:
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-constref