### PR TITLE
refactor: clean up forward declarations

### DIFF
--- a/include/open62541pp/client.hpp
+++ b/include/open62541pp/client.hpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "open62541pp/config.hpp"
+#include "open62541pp/datatype.hpp"
 #include "open62541pp/detail/open62541/client.h"
 #include "open62541pp/plugin/log.hpp"
 #include "open62541pp/span.hpp"
@@ -15,10 +16,8 @@
 #include "open62541pp/types.hpp"
 #include "open62541pp/types_composed.hpp"
 
-// forward declaration
 namespace opcua {
 class Client;
-class DataType;
 struct Login;
 template <typename Connection>
 class Node;

--- a/include/open62541pp/event.hpp
+++ b/include/open62541pp/event.hpp
@@ -8,10 +8,7 @@
 
 namespace opcua {
 
-// forward declare
-class DateTime;
 class Server;
-class Variant;
 
 /**
  * Create and trigger events.

--- a/include/open62541pp/monitoreditem.hpp
+++ b/include/open62541pp/monitoreditem.hpp
@@ -12,7 +12,6 @@
 
 namespace opcua {
 
-// forward declarations
 class Server;
 
 using MonitoringParametersEx = services::MonitoringParametersEx;

--- a/include/open62541pp/plugin/accesscontrol.hpp
+++ b/include/open62541pp/plugin/accesscontrol.hpp
@@ -7,17 +7,12 @@
 #include "open62541pp/common.hpp"  // AccessLevel, WriteMask
 #include "open62541pp/detail/open62541/common.h"  // UA_AccessControl
 #include "open62541pp/plugin/pluginadapter.hpp"
+#include "open62541pp/session.hpp"
 #include "open62541pp/span.hpp"
 #include "open62541pp/types.hpp"
 #include "open62541pp/types_composed.hpp"  // UserTokenPolicy, PerformUpdateType
 
 namespace opcua {
-
-// forward declare
-class DataValue;
-class DateTime;
-class ExtensionObject;
-class Session;
 
 /// Login credentials.
 struct Login {

--- a/include/open62541pp/plugin/log.hpp
+++ b/include/open62541pp/plugin/log.hpp
@@ -57,7 +57,7 @@ using Logger = std::function<void(LogLevel, LogCategory, std::string_view msg)>;
  */
 class LoggerHandler : public LoggerBase {
 public:
-    LoggerHandler(Logger logger)
+    explicit LoggerHandler(Logger logger)
         : logger_(std::move(logger)) {}
 
     virtual void log(LogLevel level, LogCategory category, std::string_view msg) {

--- a/include/open62541pp/plugin/nodestore.hpp
+++ b/include/open62541pp/plugin/nodestore.hpp
@@ -2,11 +2,9 @@
 
 #include <functional>
 
-namespace opcua {
+#include "open62541pp/types.hpp"
 
-// forward declaration
-class NodeId;
-class DataValue;
+namespace opcua {
 
 /**
  * Value callbacks for variable nodes.

--- a/include/open62541pp/server.hpp
+++ b/include/open62541pp/server.hpp
@@ -8,25 +8,22 @@
 
 #include "open62541pp/common.hpp"  // NamespaceIndex
 #include "open62541pp/config.hpp"
+#include "open62541pp/datatype.hpp"
 #include "open62541pp/detail/open62541/server.h"
+#include "open62541pp/event.hpp"
 #include "open62541pp/nodeids.hpp"
 #include "open62541pp/plugin/log.hpp"
+#include "open62541pp/plugin/accesscontrol.hpp"
+#include "open62541pp/plugin/nodestore.hpp"
 #include "open62541pp/span.hpp"
 #include "open62541pp/subscription.hpp"
+#include "open62541pp/types.hpp"
+#include "open62541pp/session.hpp"
 
-// forward declaration
 namespace opcua {
-class AccessControlBase;
-class ByteString;
-class DataType;
-class Event;
 template <typename Connection>
 class Node;
-class NodeId;
 class Server;
-class Session;
-struct ValueBackendDataSource;
-struct ValueCallback;
 
 namespace detail {
 struct ServerConnection;

--- a/include/open62541pp/services/detail/monitoreditem_context.hpp
+++ b/include/open62541pp/services/detail/monitoreditem_context.hpp
@@ -8,7 +8,6 @@
 #include "open62541pp/types_composed.hpp"  // DataValue, Variant
 #include "open62541pp/wrapper.hpp"  // asWrapper
 
-// forward declare
 struct UA_Client;
 struct UA_Server;
 

--- a/include/open62541pp/services/detail/subscription_context.hpp
+++ b/include/open62541pp/services/detail/subscription_context.hpp
@@ -7,7 +7,6 @@
 #include "open62541pp/types_composed.hpp"  // StatusChangeNotification
 #include "open62541pp/wrapper.hpp"  // asWrapper
 
-// forward declare
 struct UA_Client;
 
 namespace opcua::services::detail {

--- a/include/open62541pp/session.hpp
+++ b/include/open62541pp/session.hpp
@@ -6,10 +6,7 @@
 
 namespace opcua {
 
-// forward declare
-class QualifiedName;
 class Server;
-class Variant;
 
 /**
  * High-level session class to manage client sessions.

--- a/include/open62541pp/subscription.hpp
+++ b/include/open62541pp/subscription.hpp
@@ -16,7 +16,6 @@
 
 namespace opcua {
 
-// forward declarations
 class EventFilter;
 class Server;
 

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -875,7 +875,6 @@ enum class VariantPolicy {
     // clang-format on
 };
 
-// forward declarations
 namespace detail {
 template <VariantPolicy>
 struct VariantHandler;


### PR DESCRIPTION
The headers `server.hpp` and `client.hpp` should include all necessary types to run a server/client instance.
The extensive usage of forward declarations makes it harder to get started.