### PR TITLE
refactor!: rename Logger -> LogFunction

### DIFF
--- a/include/open62541pp/client.hpp
+++ b/include/open62541pp/client.hpp
@@ -69,7 +69,7 @@ public:
      * @param logger Custom log function. If the passed function is empty, the default logger is
      * used.
      */
-    explicit Client(Logger logger = nullptr);
+    explicit Client(LogFunction logger = nullptr);
 
 #ifdef UA_ENABLE_ENCRYPTION
     /**
@@ -117,9 +117,9 @@ public:
      */
     std::vector<EndpointDescription> getEndpoints(std::string_view serverUrl);
 
-    /// Set custom logging function.
+    /// Set custom log function.
     /// Does nothing if the passed function is empty or a nullptr.
-    void setLogger(Logger logger);
+    void setLogger(LogFunction logger);
 
     /// Set response timeout in milliseconds.
     void setTimeout(uint32_t milliseconds);

--- a/include/open62541pp/plugin/log_default.hpp
+++ b/include/open62541pp/plugin/log_default.hpp
@@ -8,14 +8,14 @@
 namespace opcua {
 
 /// Log function.
-using Logger = std::function<void(LogLevel, LogCategory, std::string_view msg)>;
+using LogFunction = std::function<void(LogLevel, LogCategory, std::string_view msg)>;
 
 /**
- * Logger class that wraps a `Logger`.
+ * Logger class that wraps a `LogFunction`.
  */
 class LoggerDefault : public LoggerBase {
 public:
-    explicit LoggerDefault(Logger func)
+    explicit LoggerDefault(LogFunction func)
         : func_(std::move(func)) {}
 
     void log(LogLevel level, LogCategory category, std::string_view msg) override {
@@ -25,7 +25,7 @@ public:
     }
 
 private:
-    Logger func_;
+    LogFunction func_;
 };
 
 }  // namespace opcua

--- a/include/open62541pp/server.hpp
+++ b/include/open62541pp/server.hpp
@@ -72,7 +72,9 @@ public:
      * @param logger Custom log function. If the passed function is empty, the default logger is
      * used.
      */
-    explicit Server(uint16_t port = 4840, ByteString certificate = {}, Logger logger = nullptr);
+    explicit Server(
+        uint16_t port = 4840, ByteString certificate = {}, LogFunction logger = nullptr
+    );
 
 #ifdef UA_ENABLE_ENCRYPTION
     /**
@@ -112,9 +114,9 @@ public:
     Server& operator=(const Server&) = delete;
     Server& operator=(Server&&) noexcept = default;
 
-    /// Set custom logging function.
+    /// Set custom log function.
     /// Does nothing if the passed function is empty or a nullptr.
-    void setLogger(Logger logger);
+    void setLogger(LogFunction logger);
 
     /// Set custom access control.
     /// @note Supported since open62541 v1.3

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -205,7 +205,7 @@ struct ClientConnection : public ConnectionBase<Client> {
 
 /* ------------------------------------------- Client ------------------------------------------- */
 
-Client::Client(Logger logger)
+Client::Client(LogFunction logger)
     : connection_(std::make_unique<detail::ClientConnection>()) {
     // The logger should be set as soon as possible, ideally even before UA_ClientConfig_setDefault.
     // However, the logger gets overwritten by UA_ClientConfig_setDefault() in older versions of
@@ -287,7 +287,7 @@ std::vector<EndpointDescription> Client::getEndpoints(std::string_view serverUrl
     return result;
 }
 
-void Client::setLogger(Logger logger) {
+void Client::setLogger(LogFunction logger) {
     connection_->config.setLogger(std::move(logger));
 }
 

--- a/src/client_config.hpp
+++ b/src/client_config.hpp
@@ -26,7 +26,7 @@ public:
         setUserIdentityToken(ExtensionObject::fromDecodedCopy(std::forward<T>(token)));
     }
 
-    void setLogger(Logger logger) {
+    void setLogger(LogFunction logger) {
         if (logger) {
             logger_.assign(LoggerDefault(std::move(logger)));
         }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -179,7 +179,7 @@ struct ServerConnection : public ConnectionBase<Server> {
 
 /* ------------------------------------------- Server ------------------------------------------- */
 
-Server::Server(uint16_t port, ByteString certificate, Logger logger)
+Server::Server(uint16_t port, ByteString certificate, LogFunction logger)
     : connection_(std::make_unique<detail::ServerConnection>()) {
     // The logger should be set as soon as possible, ideally even before UA_ServerConfig_setMinimal.
     // However, the logger gets overwritten by UA_ServerConfig_setMinimal() in older versions of
@@ -230,7 +230,7 @@ Server::Server(
 
 Server::~Server() = default;
 
-void Server::setLogger(Logger logger) {
+void Server::setLogger(LogFunction logger) {
     connection_->config.setLogger(std::move(logger));
 }
 

--- a/src/server_config.hpp
+++ b/src/server_config.hpp
@@ -26,7 +26,7 @@ public:
     ServerConfig(UA_ServerConfig& config)
         : config_(config) {}
 
-    void setLogger(Logger logger) {
+    void setLogger(LogFunction logger) {
         if (logger) {
             logger_.assign(LoggerDefault(std::move(logger)));
         }


### PR DESCRIPTION
Rename `Logger` to `LogFunction`.
The name `Logger` was a ambiguous, because it refers to `UA_Logger`/`Logger` the plugin.
