### PR TITLE
feat!: remove log function overloads

### DIFF
--- a/include/open62541pp/client.hpp
+++ b/include/open62541pp/client.hpp
@@ -224,14 +224,4 @@ inline bool operator!=(const Client& lhs, const Client& rhs) noexcept {
     return !(lhs == rhs);
 }
 
-/// Log a message with UA_Client's logger.
-inline void log(UA_Client* client, LogLevel level, LogCategory category, std::string_view msg) {
-    log(detail::getLogger(client), level, category, msg);
-}
-
-/// Log a message with Client's logger.
-inline void log(Client& client, LogLevel level, LogCategory category, std::string_view msg) {
-    log(detail::getLogger(client), level, category, msg);
-}
-
 }  // namespace opcua

--- a/include/open62541pp/plugin/log.hpp
+++ b/include/open62541pp/plugin/log.hpp
@@ -47,12 +47,4 @@ public:
     void clear(UA_Logger& native) noexcept override;
 };
 
-/* ---------------------------------------------------------------------------------------------- */
-
-/// Log a message with a UA_Logger instance (pointer).
-void log(const UA_Logger* logger, LogLevel level, LogCategory category, std::string_view msg);
-
-/// Log a message with a UA_Logger instance (reference).
-void log(const UA_Logger& logger, LogLevel level, LogCategory category, std::string_view msg);
-
 }  // namespace opcua

--- a/include/open62541pp/server.hpp
+++ b/include/open62541pp/server.hpp
@@ -195,14 +195,4 @@ inline bool operator!=(const Server& lhs, const Server& rhs) noexcept {
     return !(lhs == rhs);
 }
 
-/// Log a message with UA_Server's logger.
-inline void log(UA_Server* server, LogLevel level, LogCategory category, std::string_view msg) {
-    log(detail::getLogger(server), level, category, msg);
-}
-
-/// Log a message with Server's logger.
-inline void log(Server& server, LogLevel level, LogCategory category, std::string_view msg) {
-    log(detail::getLogger(server), level, category, msg);
-}
-
 }  // namespace opcua

--- a/src/plugin/accesscontrol.cpp
+++ b/src/plugin/accesscontrol.cpp
@@ -4,7 +4,6 @@
 #include <exception>
 #include <functional>  // invoke
 #include <optional>
-#include <string>
 #include <string_view>
 #include <type_traits>  // invoke_result_t
 
@@ -40,12 +39,16 @@ inline static std::optional<Session> getSession(
 static void logException(
     UA_Server* server, std::string_view callbackName, std::string_view exceptionMessage
 ) {
-    const auto message =
-        std::string("Exception in access control callback ")
-            .append(callbackName)
-            .append(": ")
-            .append(exceptionMessage);
-    log(server, LogLevel::Warning, LogCategory::Server, message);
+    // NOLINTNEXTLINE
+    UA_LOG_WARNING(
+        detail::getLogger(server),
+        UA_LOGCATEGORY_SERVER,
+        "Exception in access control callback %.*s: %.*s",
+        static_cast<int>(callbackName.size()),
+        callbackName.data(),
+        static_cast<int>(exceptionMessage.size()),
+        exceptionMessage.data()
+    );
 }
 
 template <typename F, typename ReturnType = std::invoke_result_t<F>>

--- a/src/plugin/log.cpp
+++ b/src/plugin/log.cpp
@@ -2,7 +2,6 @@
 
 #include <cassert>
 #include <cstdarg>  // va_list
-#include <string>
 
 #include "open62541pp/config.hpp"
 #include "open62541pp/detail/string_utils.hpp"  // detail::toString
@@ -54,25 +53,5 @@ void LoggerBase::clear(UA_Logger& native) noexcept {
 //         plugin = nullptr;
 //     }
 // }
-
-/* ---------------------------------------------------------------------------------------------- */
-
-void log(const UA_Logger* logger, LogLevel level, LogCategory category, std::string_view msg) {
-    if (logger == nullptr || logger->log == nullptr) {
-        return;
-    }
-    va_list args{};  // NOLINT
-    logger->log(
-        logger->context,
-        static_cast<UA_LogLevel>(level),
-        static_cast<UA_LogCategory>(category),
-        std::string(msg).c_str(),
-        args  // NOLINT
-    );
-}
-
-void log(const UA_Logger& logger, LogLevel level, LogCategory category, std::string_view msg) {
-    log(&logger, level, category, msg);
-}
 
 }  // namespace opcua

--- a/tests/logger.cpp
+++ b/tests/logger.cpp
@@ -26,30 +26,9 @@ TEST_CASE_TEMPLATE("Log with custom logger", T, Server, Client) {
     // passing a nullptr should do nothing
     connection.setLogger(nullptr);
 
-    SUBCASE("Wrapper") {
-        counter = 0;
-        log(connection, LogLevel::Info, LogCategory::Server, "Message");
-        CHECK(counter == 1);
-        CHECK(lastLogLevel == LogLevel::Info);
-        CHECK(lastLogCategory == LogCategory::Server);
-        CHECK(lastMessage == "Message");
-    }
-
-    SUBCASE("Native") {
-        auto native = connection.handle();
-        counter = 0;
-        log(native, LogLevel::Warning, LogCategory::Server, "Message from native");
-        CHECK(counter == 1);
-        CHECK(lastLogLevel == LogLevel::Warning);
-        CHECK(lastLogCategory == LogCategory::Server);
-        CHECK(lastMessage == "Message from native");
-    }
-
-    SUBCASE("Native nullptr") {
-        auto native = connection.handle();
-        native = nullptr;
-        counter = 0;
-        log(native, LogLevel::Warning, LogCategory::Server, "Message from null");
-        CHECK(counter == 0);
-    }
+    UA_LOG_INFO(detail::getLogger(connection), UA_LOGCATEGORY_SERVER, "Message");
+    CHECK(counter == 1);
+    CHECK(lastLogLevel == LogLevel::Info);
+    CHECK(lastLogCategory == LogCategory::Server);
+    CHECK(lastMessage == "Message");
 }

--- a/tests/plugin_log.cpp
+++ b/tests/plugin_log.cpp
@@ -36,27 +36,3 @@ TEST_CASE("LoggerBase") {
 
     logger.clear(native);
 }
-
-TEST_CASE("log") {
-    struct LogContext {
-        UA_LogLevel level;
-        UA_LogCategory category;
-        std::string message;
-    };
-
-    UA_Logger logger{};
-    LogContext context;
-    logger.context = &context;
-    logger.log =
-        [](void* logContext, UA_LogLevel level, UA_LogCategory category, const char* msg, va_list) {
-            CHECK(logContext != nullptr);
-            static_cast<LogContext*>(logContext)->level = level;
-            static_cast<LogContext*>(logContext)->category = category;
-            static_cast<LogContext*>(logContext)->message = msg;
-        };
-
-    log(logger, LogLevel::Info, LogCategory::Userland, "message");
-    CHECK(context.level == UA_LOGLEVEL_INFO);
-    CHECK(context.category == UA_LOGCATEGORY_USERLAND);
-    CHECK(context.message == "message");
-}

--- a/tests/server.cpp
+++ b/tests/server.cpp
@@ -81,13 +81,6 @@ TEST_CASE("Server constructors") {
     SUBCASE("Custom port and certificate") {
         Server server(4850, ByteString("certificate"));
     }
-
-    SUBCASE("Custom logger") {
-        bool gotMessage = false;
-        Server server(4850, {}, [&gotMessage](auto&&...) { gotMessage = true; });
-        log(server, LogLevel::Error, LogCategory::Server, "Message");
-        CHECK(gotMessage);
-    }
 }
 
 #ifdef UA_ENABLE_ENCRYPTION


### PR DESCRIPTION
The usage of `log` was mainly internal. I expect that users plug in their own logging system and don't use open62541pp's log functions. Use `UA_LOG_*` if you still want to use the server's and client's loggers.