### PR TITLE
refactor: keep deprecated Logger alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deprecate `String::get()`, `ByteString::get()` and `XmlElement::get()`, use `static_cast<std::string_view>(...)` instead (#328, #329, #335)
 - Rename `NumericRange::get` -> `NumericRange::dimensions`
 - Remove `ByteString::fromFile`, `ByteString::toFile` (#337)
-- Rename `Logger` -> `LogFunction` (#355)
+- Rename `Logger` -> `LogFunction` (#355, #360)
 - Remove `log(...)` overloads (#356)
 - New header file structure (#348, #353): The header file structure became quite complex and tangled over time. The new structure is similar to open62541. All headers are now snake case with the extension `.hpp`. When coming from open62541, usually you just have to make a small adjustment in your includes:
   ```diff

--- a/include/open62541pp/plugin/log_default.hpp
+++ b/include/open62541pp/plugin/log_default.hpp
@@ -10,6 +10,8 @@ namespace opcua {
 /// Log function.
 using LogFunction = std::function<void(LogLevel, LogCategory, std::string_view msg)>;
 
+using Logger [[deprecated("use alias LogFunction instead")]] = LogFunction;
+
 /**
  * Logger class that wraps a `LogFunction`.
  */


### PR DESCRIPTION
Don't break existing code by removing `Logger` type alias completely. Keep it but deprecate it.