### PR TITLE
refactor: workaround to get Server instance from UA_Server* for v1.0-v1.2

### DIFF
--- a/include/open62541pp/datatype.hpp
+++ b/include/open62541pp/datatype.hpp
@@ -46,7 +46,7 @@ public:
 #endif
     }
 
-    void setTypeName(const char* typeName) noexcept {
+    void setTypeName([[maybe_unused]] const char* typeName) noexcept {
 #ifdef UA_ENABLE_TYPEDESCRIPTION
         handle()->typeName = typeName;
 #endif

--- a/include/open62541pp/server.hpp
+++ b/include/open62541pp/server.hpp
@@ -119,10 +119,8 @@ public:
     void setLogger(LogFunction logger);
 
     /// Set custom access control.
-    /// @note Supported since open62541 v1.3
     void setAccessControl(AccessControlBase& accessControl);
     /// Set custom access control (transfer ownership to Server).
-    /// @note Supported since open62541 v1.3
     void setAccessControl(std::unique_ptr<AccessControlBase> accessControl);
 
     /// Set custom hostname, default: system's host name.

--- a/include/open62541pp/server.hpp
+++ b/include/open62541pp/server.hpp
@@ -134,7 +134,6 @@ public:
     void setProductUri(std::string_view uri);
 
     /// Get active server session.
-    /// @note Supported since open62541 v1.3
     std::vector<Session> getSessions();
 
     /// Get all defined namespaces.

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -487,32 +487,32 @@ ClientConnection* getConnection(UA_Client* client) noexcept {
     if (config == nullptr) {
         return nullptr;
     }
-    auto* state = static_cast<detail::ClientConnection*>(config->clientContext);
-    assert(state != nullptr);
-    assert(state->client == client);
-    return state;
+    auto* connection = static_cast<detail::ClientConnection*>(config->clientContext);
+    assert(connection != nullptr);
+    assert(connection->client == client);
+    return connection;
 }
 
 ClientConnection& getConnection(Client& client) noexcept {
-    auto* state = client.connection_.get();
-    assert(state != nullptr);
-    return *state;
+    auto* connection = client.connection_.get();
+    assert(connection != nullptr);
+    return *connection;
 }
 
 Client* getWrapper(UA_Client* client) noexcept {
-    auto* state = getConnection(client);
-    if (state == nullptr) {
+    auto* connection = getConnection(client);
+    if (connection == nullptr) {
         return nullptr;
     }
-    return state->wrapperPtr();
+    return connection->wrapperPtr();
 }
 
 ClientContext* getContext(UA_Client* client) noexcept {
-    auto* state = getConnection(client);
-    if (state == nullptr) {
+    auto* connection = getConnection(client);
+    if (connection == nullptr) {
         return nullptr;
     }
-    return &state->context;
+    return &connection->context;
 }
 
 ClientContext& getContext(Client& client) noexcept {

--- a/src/plugin/accesscontrol.cpp
+++ b/src/plugin/accesscontrol.cpp
@@ -91,12 +91,11 @@ static void closeSessionNative(
     const UA_NodeId* sessionId,
     [[maybe_unused]] void* sessionContext
 ) {
-    try {
+    invokeAccessCallback(server, "activateSession", UA_STATUSCODE_GOOD, [&] {
         auto session = getSession(server, sessionId);
         getAdapter(ac).closeSession(session.value());  // NOLINT(bugprone-unchecked-optional-access)
-    } catch (const std::exception& e) {
-        logException(server, "closeSession", e.what());
-    }
+        return UA_STATUSCODE_GOOD;
+    });
 }
 
 static UA_UInt32 getUserRightsMaskNative(

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -117,10 +117,20 @@ struct ServerConnection : public ConnectionBase<Server> {
 #if UAPP_OPEN62541_VER_GE(1, 3)
         config->context = this;
 #else
-        const auto status = UA_Server_setNodeContext(
-            server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER), this
-        );
-        assert(status == UA_STATUSCODE_GOOD);
+        {
+            const auto status = UA_Server_setNodeContext(
+                server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER), this
+            );
+            assert(status == UA_STATUSCODE_GOOD);
+        }
+        {
+            void* nodeContext = nullptr;
+            const auto status = UA_Server_getNodeContext(
+                server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER), &nodeContext
+            );
+            assert(status == UA_STATUSCODE_GOOD);
+            assert(nodeContext == this);
+        }
 #endif
 #ifdef UA_ENABLE_SUBSCRIPTIONS
         config->publishingIntervalLimits.min = 10;  // ms

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -98,7 +98,6 @@ struct ServerConnection : public ConnectionBase<Server> {
     ServerConnection& operator=(ServerConnection&&) noexcept = delete;
 
     void applySessionRegistry() {
-#if UAPP_OPEN62541_VER_GE(1, 3)
         // Make sure to call this function only once after access control is initialized or changed.
         // The function pointers to activateSession / closeSession might not be unique and the
         // the pointer comparison might fail resulting in stack overflows:
@@ -112,7 +111,6 @@ struct ServerConnection : public ConnectionBase<Server> {
             context.sessionRegistry.closeSessionUser = config->accessControl.closeSession;
             config->accessControl.closeSession = &closeSession;
         }
-#endif
     }
 
     void applyDefaults() {
@@ -500,7 +498,7 @@ ServerConnection* getConnection([[maybe_unused]] UA_Server* server) noexcept {
     // use node context of server object as fallback
     detail::ServerConnection* connection = nullptr;
     const auto status = UA_Server_getNodeContext(
-        server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER), &connection
+        server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER), &static_cast<void*>(connection)
     );
     assert(status == UA_STATUSCODE_GOOD);
 #endif

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -495,6 +495,9 @@ ServerConnection* getConnection(UA_Server* server) noexcept {
     // UA_ServerConfig.context pointer available since open62541 v1.3
     auto* connection = static_cast<detail::ServerConnection*>(config->context);
 #else
+    if (server == nullptr) {
+        return nullptr;
+    }
     // use node context of server object as fallback
     void* nodeContext = nullptr;
     const auto status = UA_Server_getNodeContext(

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -486,7 +486,7 @@ UA_Logger* getLogger(Server& server) noexcept {
     return getLogger(server.handle());
 }
 
-ServerConnection* getConnection([[maybe_unused]] UA_Server* server) noexcept {
+ServerConnection* getConnection(UA_Server* server) noexcept {
 #if UAPP_OPEN62541_VER_GE(1, 3)
     auto* config = getConfig(server);
     if (config == nullptr) {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -117,20 +117,10 @@ struct ServerConnection : public ConnectionBase<Server> {
 #if UAPP_OPEN62541_VER_GE(1, 3)
         config->context = this;
 #else
-        {
-            const auto status = UA_Server_setNodeContext(
-                server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER), this
-            );
-            assert(status == UA_STATUSCODE_GOOD);
-        }
-        {
-            void* nodeContext = nullptr;
-            const auto status = UA_Server_getNodeContext(
-                server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER), &nodeContext
-            );
-            assert(status == UA_STATUSCODE_GOOD);
-            assert(nodeContext == this);
-        }
+        const auto status = UA_Server_setNodeContext(
+            server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER), this
+        );
+        assert(status == UA_STATUSCODE_GOOD);
 #endif
 #ifdef UA_ENABLE_SUBSCRIPTIONS
         config->publishingIntervalLimits.min = 10;  // ms

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -496,11 +496,12 @@ ServerConnection* getConnection([[maybe_unused]] UA_Server* server) noexcept {
     auto* connection = static_cast<detail::ServerConnection*>(config->context);
 #else
     // use node context of server object as fallback
-    detail::ServerConnection* connection = nullptr;
+    void* nodeContext = nullptr;
     const auto status = UA_Server_getNodeContext(
-        server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER), &static_cast<void*>(connection)
+        server, UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER), &nodeContext
     );
     assert(status == UA_STATUSCODE_GOOD);
+    auto* connection = static_cast<detail::ServerConnection*>(nodeContext);
 #endif
     assert(connection != nullptr);
     assert(connection->server == server);

--- a/tests/client.cpp
+++ b/tests/client.cpp
@@ -214,15 +214,18 @@ TEST_CASE("Client helper functions") {
     Client client;
 
     CHECK(detail::getConfig(clientNull) == nullptr);
-    CHECK(&detail::getConfig(client) == detail::getConfig(client.handle()));
+    CHECK(detail::getConfig(client.handle()) != nullptr);
+    CHECK(detail::getConfig(client.handle()) == &detail::getConfig(client));
 
     CHECK(detail::getConnection(clientNull) == nullptr);
-    CHECK(&detail::getConnection(client) == detail::getConnection(client.handle()));
+    CHECK(detail::getConnection(client.handle()) != nullptr);
+    CHECK(detail::getConnection(client.handle()) == &detail::getConnection(client));
 
     CHECK(detail::getWrapper(clientNull) == nullptr);
     CHECK(detail::getWrapper(client.handle()) != nullptr);
     CHECK(detail::getWrapper(client.handle())->handle() == client.handle());
 
     CHECK(detail::getContext(clientNull) == nullptr);
-    CHECK(&detail::getContext(client) == detail::getContext(client.handle()));
+    CHECK(detail::getContext(client.handle()) != nullptr);
+    CHECK(detail::getContext(client.handle()) == &detail::getContext(client));
 }

--- a/tests/plugin_accesscontrol.cpp
+++ b/tests/plugin_accesscontrol.cpp
@@ -260,6 +260,7 @@ TEST_CASE("AccessControlBase") {
         ) == false
     );
 
+#if UAPP_OPEN62541_VER_GE(1, 1)
     CHECK(native.allowBrowseNode != nullptr);
     CHECK(
         native.allowBrowseNode(
@@ -271,8 +272,9 @@ TEST_CASE("AccessControlBase") {
             nullptr  // node context
         ) == true
     );
+#endif
 
-#ifdef UA_ENABLE_SUBSCRIPTIONS
+#if UAPP_OPEN62541_VER_GE(1, 2) && defined(UA_ENABLE_SUBSCRIPTIONS)
     CHECK(native.allowTransferSubscription != nullptr);
     CHECK(
         native.allowTransferSubscription(

--- a/tests/plugin_accesscontrol.cpp
+++ b/tests/plugin_accesscontrol.cpp
@@ -135,7 +135,6 @@ public:
     }
 };
 
-#if UAPP_OPEN62541_VER_GE(1, 3)
 TEST_CASE("AccessControlBase") {
     Server server;
     AccessControlTest accessControl;
@@ -316,4 +315,3 @@ TEST_CASE("AccessControlBase") {
     );
 #endif
 }
-#endif

--- a/tests/server.cpp
+++ b/tests/server.cpp
@@ -176,7 +176,6 @@ TEST_CASE("Server helper functions") {
     CHECK(detail::getConfig(serverNull) == nullptr);
     CHECK(&detail::getConfig(server) == detail::getConfig(server.handle()));
 
-#if UAPP_OPEN62541_VER_GE(1, 3)
     CHECK(detail::getConnection(serverNull) == nullptr);
     CHECK(&detail::getConnection(server) == detail::getConnection(server.handle()));
 
@@ -186,7 +185,6 @@ TEST_CASE("Server helper functions") {
 
     CHECK(detail::getContext(serverNull) == nullptr);
     CHECK(&detail::getContext(server) == detail::getContext(server.handle()));
-#endif
 }
 
 TEST_CASE("ValueCallback") {

--- a/tests/server.cpp
+++ b/tests/server.cpp
@@ -177,15 +177,6 @@ TEST_CASE("Server helper functions") {
     CHECK(detail::getConfig(server.handle()) != nullptr);
     CHECK(detail::getConfig(server.handle()) == &detail::getConfig(server));
 
-#if UAPP_OPEN62541_VER_LE(1, 2)
-    void* nodeContext = nullptr;
-    const auto status = UA_Server_getNodeContext(
-        server.handle(), UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER), &nodeContext
-    );
-    CHECK(status == UA_STATUSCODE_GOOD);
-    CHECK(nodeContext == &detail::getConnection(server));
-#endif
-
     CHECK(detail::getConnection(serverNull) == nullptr);
     CHECK(detail::getConnection(server.handle()) != nullptr);
     CHECK(detail::getConnection(server.handle()) == &detail::getConnection(server));

--- a/tests/server.cpp
+++ b/tests/server.cpp
@@ -174,17 +174,20 @@ TEST_CASE("Server helper functions") {
     Server server;
 
     CHECK(detail::getConfig(serverNull) == nullptr);
-    CHECK(&detail::getConfig(server) == detail::getConfig(server.handle()));
+    CHECK(detail::getConfig(server.handle()) != nullptr);
+    CHECK(detail::getConfig(server.handle()) == &detail::getConfig(server));
 
     CHECK(detail::getConnection(serverNull) == nullptr);
-    CHECK(&detail::getConnection(server) == detail::getConnection(server.handle()));
+    CHECK(detail::getConnection(server.handle()) != nullptr);
+    CHECK(detail::getConnection(server.handle()) == &detail::getConnection(server));
 
     CHECK(detail::getWrapper(serverNull) == nullptr);
     CHECK(detail::getWrapper(server.handle()) != nullptr);
     CHECK(detail::getWrapper(server.handle())->handle() == server.handle());
 
     CHECK(detail::getContext(serverNull) == nullptr);
-    CHECK(&detail::getContext(server) == detail::getContext(server.handle()));
+    CHECK(detail::getContext(server.handle()) != nullptr);
+    CHECK(detail::getContext(server.handle()) == &detail::getContext(server));
 }
 
 TEST_CASE("ValueCallback") {

--- a/tests/server.cpp
+++ b/tests/server.cpp
@@ -177,6 +177,15 @@ TEST_CASE("Server helper functions") {
     CHECK(detail::getConfig(server.handle()) != nullptr);
     CHECK(detail::getConfig(server.handle()) == &detail::getConfig(server));
 
+#if UAPP_OPEN62541_VER_LE(1, 2)
+    void* nodeContext = nullptr;
+    const auto status = UA_Server_getNodeContext(
+        server.handle(), UA_NODEID_NUMERIC(0, UA_NS0ID_SERVER), &nodeContext
+    );
+    CHECK(status == UA_STATUSCODE_GOOD);
+    CHECK(nodeContext == &detail::getConnection(server));
+#endif
+
     CHECK(detail::getConnection(serverNull) == nullptr);
     CHECK(detail::getConnection(server.handle()) != nullptr);
     CHECK(detail::getConnection(server.handle()) == &detail::getConnection(server));


### PR DESCRIPTION
Open62541 provides a context pointer in `UA_ServerConfig` which is used to store a pointer to the underlying connection of the `Server` connection. Therefore, the `Server` instance can be retrieved from a `UA_Server` instance.

This is a workaround for open62541 v1.0-v1.2, where the context pointer didn't exist. Instead, the node context of the `Server` object (`UA_NS0ID_SERVER`) is used. This workaround is also used in `QUaServer`: https://github.com/QUaServer/QUaServer/blob/master/src/wrapper/quaserver.cpp#L1337