### PR TITLE
feat!: return CallMethodResult from services::call / Node::callMethod

### DIFF
--- a/examples/method/client_method.cpp
+++ b/examples/method/client_method.cpp
@@ -14,8 +14,8 @@ int main() {
     const opcua::Node greetMethodNode = objectsNode.browseChild({{1, "Greet"}});
 
     // Call method from parent node (Objects)
-    const auto outputs = objectsNode.callMethod(
+    const auto result = objectsNode.callMethod(
         greetMethodNode.id(), {opcua::Variant::fromScalar("World")}
     );
-    std::cout << outputs.at(0).getScalar<opcua::String>() << std::endl;
+    std::cout << result.getOutputArguments()[0].getScalar<opcua::String>() << std::endl;
 }

--- a/examples/method/client_method_async.cpp
+++ b/examples/method/client_method_async.cpp
@@ -32,7 +32,8 @@ int main() {
 
         std::cout << "Future ready, get method output\n";
         auto result = future.get();
-        std::cout << result.value().at(0).getScalar<opcua::String>() << std::endl;
+        auto outputs = result.value().getOutputArguments();
+        std::cout << outputs[0].getScalar<opcua::String>() << std::endl;
     }
 
     // Asynchronously call method (callback variant)
@@ -42,10 +43,10 @@ int main() {
             objectsNode.id(),
             greetMethodNode.id(),
             {opcua::Variant::fromScalar("Callback World")},
-            [](const opcua::Result<std::vector<opcua::Variant>>& result) {
-                std::cout
-                    << "Callback with status code " << result.code() << ", get method output\n";
-                std::cout << result.value().at(0).getScalar<opcua::String>() << std::endl;
+            [](const opcua::Result<opcua::CallMethodResult>& result) {
+                std::cout << "Callback invoked, get method output\n";
+                auto outputs = result.value().getOutputArguments();
+                std::cout << outputs[0].getScalar<opcua::String>() << std::endl;
             }
         );
     }

--- a/include/open62541pp/node.hpp
+++ b/include/open62541pp/node.hpp
@@ -328,7 +328,7 @@ public:
     /// Call a server method and return results.
     /// @param methodId NodeId of the method (`HasComponent` reference to current node required)
     /// @param inputArguments Input argument values
-    std::vector<Variant> callMethod(const NodeId& methodId, Span<const Variant> inputArguments) {
+    CallMethodResult callMethod(const NodeId& methodId, Span<const Variant> inputArguments) {
         return services::call(connection(), id(), methodId, inputArguments).value();
     }
 #endif

--- a/include/open62541pp/services/detail/response_handling.hpp
+++ b/include/open62541pp/services/detail/response_handling.hpp
@@ -72,24 +72,6 @@ inline Result<NodeId> getAddedNodeId(UA_AddNodesResult& result) noexcept {
     return {std::exchange(result.addedNodeId, {})};
 }
 
-inline Result<std::vector<Variant>> getOutputArguments(UA_CallMethodResult& result) noexcept {
-    if (const StatusCode code = result.statusCode; code.isBad()) {
-        return BadResult(result.statusCode);
-    }
-    for (const StatusCode code :
-         Span(result.inputArgumentResults, result.inputArgumentResultsSize)) {
-        if (code.isBad()) {
-            return BadResult(code);
-        }
-    }
-    return opcua::detail::tryInvoke([&] {
-        return std::vector<Variant>{
-            std::make_move_iterator(result.outputArguments),
-            std::make_move_iterator(result.outputArguments + result.outputArgumentsSize)  // NOLINT
-        };
-    });
-}
-
 template <typename SubscriptionParameters, typename Response>
 inline void reviseSubscriptionParameters(
     SubscriptionParameters& parameters, const Response& response

--- a/include/open62541pp/services/method.hpp
+++ b/include/open62541pp/services/method.hpp
@@ -71,7 +71,7 @@ auto callAsync(
  * @exception BadStatus (BadTooManyArguments) If too many input arguments provided
  */
 template <typename T>
-Result<std::vector<Variant>> call(
+Result<CallMethodResult> call(
     T& connection,
     const NodeId& objectId,
     const NodeId& methodId,
@@ -85,7 +85,7 @@ Result<std::vector<Variant>> call(
  * @param objectId NodeId of the object on which the method is invoked
  * @param methodId NodeId of the method to invoke
  * @param inputArguments Input argument values
- * @param token @completiontoken{void(Result<std::vector<Variant>>&)}
+ * @param token @completiontoken{void(Result<CallMethodResult>&)}
  * @exception BadStatus
  */
 template <typename CompletionToken = DefaultCompletionToken>
@@ -104,7 +104,7 @@ auto callAsync(
         connection,
         request,
         [](UA_CallResponse& response) {
-            return detail::getSingleResult(response).andThen(detail::getOutputArguments);
+            return detail::getSingleResult(response).transform(detail::Wrap<CallMethodResult>{});
         },
         std::forward<CompletionToken>(token)
     );

--- a/src/services_method.cpp
+++ b/src/services_method.cpp
@@ -14,7 +14,7 @@ CallResponse call(Client& connection, const CallRequest& request) noexcept {
 }
 
 template <>
-Result<std::vector<Variant>> call(
+Result<CallMethodResult> call(
     Server& connection,
     const NodeId& objectId,
     const NodeId& methodId,
@@ -22,11 +22,11 @@ Result<std::vector<Variant>> call(
 ) noexcept {
     const auto item = detail::createCallMethodRequest(objectId, methodId, inputArguments);
     CallMethodResult result = UA_Server_call(connection.handle(), &item);
-    return detail::getOutputArguments(result);
+    return result;
 }
 
 template <>
-Result<std::vector<Variant>> call(
+Result<CallMethodResult> call(
     Client& connection,
     const NodeId& objectId,
     const NodeId& methodId,

--- a/tests/services_method.cpp
+++ b/tests/services_method.cpp
@@ -73,7 +73,7 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
     }
 
     SUBCASE("Check result") {
-        Result<std::vector<Variant>> result = call(
+        Result<CallMethodResult> result = call(
             connection,
             objectsId,
             methodId,
@@ -82,8 +82,8 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
                 Variant::fromScalar(int32_t{2}),
             }
         );
-        CHECK(result.value().size() == 1);
-        CHECK(result.value()[0].getScalarCopy<int32_t>() == 3);
+        CHECK(result.value().getOutputArguments().size() == 1);
+        CHECK(result.value().getOutputArguments()[0].getScalarCopy<int32_t>() == 3);
     }
 
     SUBCASE("Propagate exception") {


### PR DESCRIPTION
Return `CallMethodResult` instead of just the output arguments `std::vector<Variant>` from `services::call` and `Node::callMethod`.

The `CallMethodResult` includes `inputArgumentResults` and `inputArgumentDiagnosticInfos`, which are very helpful for error handling and debugging: https://reference.opcfoundation.org/Core/Part4/v105/docs/5.11.2