### PR TITLE
refactor: optionally move adapter ownership to plugin

### DIFF
--- a/include/open62541pp/plugin/accesscontrol.hpp
+++ b/include/open62541pp/plugin/accesscontrol.hpp
@@ -105,7 +105,7 @@ public:
     ) = 0;
 
     UA_AccessControl create(bool ownsAdapter) override;
-    void clear(UA_AccessControl& ac) const noexcept override;
+    void clear(UA_AccessControl& native) const noexcept override;
 };
 
 }  // namespace opcua

--- a/include/open62541pp/plugin/accesscontrol.hpp
+++ b/include/open62541pp/plugin/accesscontrol.hpp
@@ -104,8 +104,8 @@ public:
         bool isDeleteModified
     ) = 0;
 
-    UA_AccessControl create() override;
-    void clear(UA_AccessControl& ac) noexcept override;
+    UA_AccessControl create(bool ownsAdapter) override;
+    void clear(UA_AccessControl& ac) const noexcept override;
 };
 
 }  // namespace opcua

--- a/include/open62541pp/plugin/accesscontrol.hpp
+++ b/include/open62541pp/plugin/accesscontrol.hpp
@@ -105,7 +105,10 @@ public:
     ) = 0;
 
     UA_AccessControl create(bool ownsAdapter) override;
-    void clear(UA_AccessControl& native) const noexcept override;
 };
+
+namespace detail {
+void clear(UA_AccessControl& ac) noexcept;
+}  // namespace detail
 
 }  // namespace opcua

--- a/include/open62541pp/plugin/log.hpp
+++ b/include/open62541pp/plugin/log.hpp
@@ -43,8 +43,8 @@ class LoggerBase : public PluginAdapter<UA_Logger> {
 public:
     virtual void log(LogLevel level, LogCategory category, std::string_view msg) = 0;
 
-    UA_Logger create() override;
-    void clear(UA_Logger& native) noexcept override;
+    UA_Logger create(bool ownsAdapter) override;
+    void clear(UA_Logger& native) const noexcept override;
 };
 
 }  // namespace opcua

--- a/include/open62541pp/plugin/log.hpp
+++ b/include/open62541pp/plugin/log.hpp
@@ -36,7 +36,7 @@ enum class LogCategory {
 
 /**
  * Logger base class.
- * 
+ *
  * Custom logger can be implemented by deriving from this class and overwriting the log function.
  */
 class LoggerBase : public PluginAdapter<UA_Logger> {
@@ -44,7 +44,10 @@ public:
     virtual void log(LogLevel level, LogCategory category, std::string_view msg) = 0;
 
     UA_Logger create(bool ownsAdapter) override;
-    void clear(UA_Logger& native) const noexcept override;
 };
+
+namespace detail {
+void clear(UA_Logger& logger) noexcept;
+}  // namespace detail
 
 }  // namespace opcua

--- a/include/open62541pp/plugin/pluginadapter.hpp
+++ b/include/open62541pp/plugin/pluginadapter.hpp
@@ -9,7 +9,6 @@ namespace opcua {
  * For example AccessControlBase is the plugin adapter for UA_AccessControl.
  *
  * The native plugin is created via the PluginAdapter::create function.
- * The PluginAdapter::clear function is used to clear the created plugin after usage.
  * Usually, the native plugin carries a `void* context` pointer which will refer back to the plugin
  * adapter. Either move the adapter ownership to the plugin with `ownsAdapter = true` or make sure
  * that the plugin adapter outlives the native plugin to avoid dangling pointers.
@@ -30,33 +29,6 @@ public:
     PluginAdapter& operator=(PluginAdapter&&) noexcept = default;
 
     virtual T create(bool ownsAdapter) = 0;
-
-    virtual void clear(T& plugin) const noexcept = 0;
-
-    virtual void clear(T*& plugin) const noexcept {
-        if (plugin != nullptr) {
-            clear(*plugin);
-        }
-    }
 };
-
-namespace detail {
-
-template <typename T>
-void assignPlugin(T& plugin, PluginAdapter<T>& adapter, bool ownsAdapter) {
-    adapter.clear(plugin);
-    plugin = adapter.create(ownsAdapter);
-}
-
-template <typename T>
-void assignPlugin(T*& plugin, PluginAdapter<T>& adapter, bool ownsAdapter) {
-    adapter.clear(plugin);
-    if (plugin == nullptr) {
-        plugin = new T{};  // NOLINT
-    }
-    *plugin = adapter.create(ownsAdapter);
-}
-
-}  // namespace detail
 
 }  // namespace opcua

--- a/include/open62541pp/plugin/pluginadapter.hpp
+++ b/include/open62541pp/plugin/pluginadapter.hpp
@@ -10,8 +10,9 @@ namespace opcua {
  *
  * The native plugin is created via the PluginAdapter::create function.
  * The PluginAdapter::clear function is used to clear the created plugin after usage.
- * Usually the native plugin carries a `void* context` pointer which will refer back to the plugin
- * adapter. Make sure that the plugin adapter outlives the native plugin to avoid dangling pointers.
+ * Usually, the native plugin carries a `void* context` pointer which will refer back to the plugin
+ * adapter. Either move the adapter ownership to the plugin with `ownsAdapter = true` or make sure
+ * that the plugin adapter outlives the native plugin to avoid dangling pointers.
  *
  * @tparam T Type of the native plugin, e.g. UA_AccessControl
  */
@@ -28,29 +29,34 @@ public:
     PluginAdapter& operator=(const PluginAdapter&) = default;
     PluginAdapter& operator=(PluginAdapter&&) noexcept = default;
 
-    virtual T create() = 0;
+    virtual T create(bool ownsAdapter) = 0;
 
-    virtual void clear(T& plugin) noexcept = 0;
+    virtual void clear(T& plugin) const noexcept = 0;
 
-    virtual void clear(T*& plugin) noexcept {
+    virtual void clear(T*& plugin) const noexcept {
         if (plugin != nullptr) {
             clear(*plugin);
         }
     }
-
-    void assign(T& plugin) {
-        clear(plugin);
-        plugin = create();
-    }
-
-    void assign(T*& plugin) {
-        if (plugin == nullptr) {
-            plugin = new T{};  // NOLINT
-        } else {
-            clear(plugin);
-        }
-        *plugin = create();
-    }
 };
+
+namespace detail {
+
+template <typename T>
+void assignPlugin(T& plugin, PluginAdapter<T>& adapter, bool ownsAdapter) {
+    adapter.clear(plugin);
+    plugin = adapter.create(ownsAdapter);
+}
+
+template <typename T>
+void assignPlugin(T*& plugin, PluginAdapter<T>& adapter, bool ownsAdapter) {
+    adapter.clear(plugin);
+    if (plugin == nullptr) {
+        plugin = new T{};  // NOLINT
+    }
+    *plugin = adapter.create(ownsAdapter);
+}
+
+}  // namespace detail
 
 }  // namespace opcua

--- a/src/client_config.hpp
+++ b/src/client_config.hpp
@@ -30,10 +30,13 @@ public:
         if (logger) {
             auto adapter = std::make_unique<LoggerDefault>(std::move(logger));
 #if UAPP_OPEN62541_VER_GE(1, 4)
-            detail::assignPlugin(handle()->logging, *adapter, true);
+            assert(handle()->logging != nullptr);
+            auto& native = *handle()->logging;
 #else
-            detail::assignPlugin(handle()->logger, *adapter, true);
+            auto& native = handle()->logger;
 #endif
+            detail::clear(native);
+            native = adapter->create(true);
             adapter.release();
         }
     }

--- a/src/client_config.hpp
+++ b/src/client_config.hpp
@@ -28,12 +28,13 @@ public:
 
     void setLogger(LogFunction logger) {
         if (logger) {
-            logger_ = std::make_unique<LoggerDefault>(std::move(logger));
+            auto adapter = std::make_unique<LoggerDefault>(std::move(logger));
 #if UAPP_OPEN62541_VER_GE(1, 4)
-            logger_->assign(handle()->logging);
+            detail::assignPlugin(handle()->logging, *adapter, true);
 #else
-            logger_->assign(handle()->logger);
+            detail::assignPlugin(handle()->logger, *adapter, true);
 #endif
+            adapter.release();
         }
     }
 
@@ -63,7 +64,6 @@ private:
     UA_ClientConfig& config_;
     std::unique_ptr<std::vector<DataType>> types_;
     std::unique_ptr<UA_DataTypeArray> customDataTypes_;
-    std::unique_ptr<LoggerBase> logger_;
 };
 
 }  // namespace opcua

--- a/src/datatype.cpp
+++ b/src/datatype.cpp
@@ -132,7 +132,7 @@ UA_DataType createDataType(
 UA_DataTypeArray createDataTypeArray(
     Span<const DataType> types, const UA_DataTypeArray* next
 ) noexcept {
-    return UA_DataTypeArray {
+    return UA_DataTypeArray{
         next,
         types.size(),
         asNative(types.data()),

--- a/src/plugin/accesscontrol.cpp
+++ b/src/plugin/accesscontrol.cpp
@@ -334,17 +334,19 @@ UA_AccessControl AccessControlBase::create(bool ownsAdapter) {
     return native;
 }
 
-void AccessControlBase::clear(UA_AccessControl& native) const noexcept {
+namespace detail {
+void clear(UA_AccessControl& ac) noexcept {
 #if UAPP_OPEN62541_VER_GE(1, 1)
-    if (native.clear != nullptr) {
-        native.clear(&native);
+    if (ac.clear != nullptr) {
+        ac.clear(&ac);
     }
 #else
-    if (native.deleteMembers != nullptr) {
-        native.deleteMembers(&native);
+    if (ac.deleteMembers != nullptr) {
+        ac.deleteMembers(&ac);
     }
 #endif
-    native = {};
+    ac = {};
 }
+}  // namespace detail
 
 }  // namespace opcua

--- a/src/plugin/accesscontrol.cpp
+++ b/src/plugin/accesscontrol.cpp
@@ -334,13 +334,17 @@ UA_AccessControl AccessControlBase::create(bool ownsAdapter) {
     return native;
 }
 
-void AccessControlBase::clear(UA_AccessControl& ac) const noexcept {
+void AccessControlBase::clear(UA_AccessControl& native) const noexcept {
 #if UAPP_OPEN62541_VER_GE(1, 1)
-    ac.clear(&ac);
+    if (native.clear != nullptr) {
+        native.clear(&native);
+    }
 #else
-    ac.deleteMembers(&ac);
+    if (native.deleteMembers != nullptr) {
+        native.deleteMembers(&native);
+    }
 #endif
-    ac = {};
+    native = {};
 }
 
 }  // namespace opcua

--- a/src/plugin/accesscontrol.cpp
+++ b/src/plugin/accesscontrol.cpp
@@ -340,7 +340,7 @@ void AccessControlBase::clear(UA_AccessControl& ac) const noexcept {
 #else
     ac.deleteMembers(&ac);
 #endif
-    ac = UA_AccessControl{};
+    ac = {};
 }
 
 }  // namespace opcua

--- a/src/plugin/create_certificate.cpp
+++ b/src/plugin/create_certificate.cpp
@@ -38,7 +38,7 @@ CreateCertificateResult createCertificate(
             }
         }
     );
-    const UA_Logger logger = loggerAdapter.create();
+    const UA_Logger logger = loggerAdapter.create(false);
 
     CreateCertificateResult result;
     const auto status = UA_CreateCertificate(

--- a/src/plugin/log.cpp
+++ b/src/plugin/log.cpp
@@ -36,7 +36,7 @@ UA_Logger LoggerBase::create(bool ownsAdapter) {
     } else {
         native.clear = [](UA_Logger* logger) {
             UA_free(logger);
-            logger = nullptr
+            logger = nullptr;
         };
     }
 #else

--- a/src/plugin/log.cpp
+++ b/src/plugin/log.cpp
@@ -50,8 +50,9 @@ UA_Logger LoggerBase::create(bool ownsAdapter) {
     return native;
 }
 
-void LoggerBase::clear(UA_Logger& native) const noexcept {
-    if (native.clear != nullptr) {
+namespace detail {
+void clear(UA_Logger& logger) noexcept {
+    if (logger.clear != nullptr) {
 #if UAPP_OPEN62541_VER_GE(1, 4)
         // Open62541 v1.4 transitioned to pointers for UA_Logger instances.
         // The clear function doesn't clear the context anymore but frees the memory and
@@ -60,21 +61,15 @@ void LoggerBase::clear(UA_Logger& native) const noexcept {
         // 1. allocate new logger instance
         // 2. shallow copy the existing logger
         // 3. clear & free logger copy
-        auto* nativeCopy = static_cast<UA_Logger*>(UA_malloc(sizeof(UA_Logger)));
-        *nativeCopy = native;  // shallow copy
-        native.clear(nativeCopy);
+        auto* loggerCopy = static_cast<UA_Logger*>(UA_malloc(sizeof(UA_Logger)));
+        *loggerCopy = logger;  // shallow copy
+        logger.clear(loggerCopy);
 #else
-        native.clear(native.context);
+        logger.clear(logger.context);
 #endif
-        native = {};
+        logger = {};
     }
 }
-
-// void LoggerBase::clear(UA_Logger*& plugin) const noexcept override {
-//     if (plugin != nullptr) {
-//         clear(*plugin);
-//         plugin = nullptr;
-//     }
-// }
+}  // namespace detail
 
 }  // namespace opcua

--- a/src/server_config.hpp
+++ b/src/server_config.hpp
@@ -24,10 +24,13 @@ public:
         if (logger) {
             auto adapter = std::make_unique<LoggerDefault>(std::move(logger));
 #if UAPP_OPEN62541_VER_GE(1, 4)
-            detail::assignPlugin(handle()->logging, *adapter, true);
+            assert(handle()->logging != nullptr);
+            auto& native = *handle()->logging;
 #else
-            detail::assignPlugin(handle()->logger, *adapter, true);
+            auto& native = handle()->logger;
 #endif
+            detail::clear(native);
+            native = adapter->create(true);
             adapter.release();
         }
     }
@@ -39,14 +42,16 @@ public:
     }
 
     void setAccessControl(AccessControlBase& accessControl) {
-        detail::assignPlugin(handle()->accessControl, accessControl, false);
+        detail::clear(handle()->accessControl);
+        handle()->accessControl = accessControl.create(false);
         setHighestSecurityPolicyForUserTokenTransfer();
         copyUserTokenPoliciesToEndpoints();
     }
 
     void setAccessControl(std::unique_ptr<AccessControlBase>&& accessControl) {
         if (accessControl != nullptr) {
-            detail::assignPlugin(handle()->accessControl, *accessControl, true);
+            detail::clear(handle()->accessControl);
+            handle()->accessControl = accessControl->create(true);
             accessControl.release();
             setHighestSecurityPolicyForUserTokenTransfer();
             copyUserTokenPoliciesToEndpoints();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
     plugin_accesscontrol.cpp
     plugin_create_certificate.cpp
     plugin_log.cpp
+    pluginadapter.cpp
     result.cpp
     scope.cpp
     server.cpp

--- a/tests/plugin_accesscontrol.cpp
+++ b/tests/plugin_accesscontrol.cpp
@@ -138,7 +138,7 @@ public:
 TEST_CASE("AccessControlBase") {
     Server server;
     AccessControlTest accessControl;
-    UA_AccessControl native = accessControl.create();
+    UA_AccessControl native = accessControl.create(false);
 
     CHECK(native.context != nullptr);
     CHECK(native.userTokenPoliciesSize == 1);  // anonymous only
@@ -316,4 +316,11 @@ TEST_CASE("AccessControlBase") {
         ) == true
     );
 #endif
+}
+
+TEST_CASE("AccessControlBase move adapter ownership") {
+    auto ac = std::make_unique<AccessControlTest>();
+    auto native = ac->create(true);
+    auto* acPtr = ac.release();
+    acPtr->clear(native);
 }

--- a/tests/plugin_accesscontrol.cpp
+++ b/tests/plugin_accesscontrol.cpp
@@ -321,6 +321,6 @@ TEST_CASE("AccessControlBase") {
 TEST_CASE("AccessControlBase move adapter ownership") {
     auto ac = std::make_unique<AccessControlTest>();
     auto native = ac->create(true);
-    auto* acPtr = ac.release();
-    acPtr->clear(native);
+    ac.release();
+    detail::clear(native);
 }

--- a/tests/plugin_log.cpp
+++ b/tests/plugin_log.cpp
@@ -1,4 +1,5 @@
 #include <string>
+#include <memory>
 
 #include <doctest/doctest.h>
 
@@ -22,8 +23,8 @@ public:
 
 TEST_CASE("LoggerBase") {
     LoggerTest logger;
-    auto native = logger.create();
-    
+    auto native = logger.create(false);
+
     CHECK(native.context == &logger);
     CHECK(native.log != nullptr);
 
@@ -35,4 +36,11 @@ TEST_CASE("LoggerBase") {
     CHECK(logger.lastMessage == "message");
 
     logger.clear(native);
+}
+
+TEST_CASE("LoggerBase move adapter ownership") {
+    auto logger = std::make_unique<LoggerTest>();
+    auto native = logger->create(true);
+    auto* loggerPtr = logger.release();
+    loggerPtr->clear(native);
 }

--- a/tests/plugin_log.cpp
+++ b/tests/plugin_log.cpp
@@ -35,12 +35,12 @@ TEST_CASE("LoggerBase") {
     CHECK(logger.lastCategory == LogCategory::Userland);
     CHECK(logger.lastMessage == "message");
 
-    logger.clear(native);
+    detail::clear(native);
 }
 
 TEST_CASE("LoggerBase move adapter ownership") {
     auto logger = std::make_unique<LoggerTest>();
     auto native = logger->create(true);
-    auto* loggerPtr = logger.release();
-    loggerPtr->clear(native);
+    logger.release();
+    detail::clear(native);
 }

--- a/tests/pluginadapter.cpp
+++ b/tests/pluginadapter.cpp
@@ -26,86 +26,26 @@ public:
         }
         return plugin;
     }
-
-    void clear(TestPlugin& plugin) const noexcept override {
-        if (plugin.clear != nullptr) {
-            plugin.clear(plugin.context);
-        }
-    }
-
-    void clear(TestPlugin*& plugin) const noexcept override {
-        if (plugin != nullptr) {
-            clear(*plugin);
-            delete plugin;  // NOLINT
-            plugin = nullptr;
-        }
-    }
 };
 
 TEST_CASE("PluginAdapter") {
     auto adapter = std::make_unique<TestAdapter>();
+    TestPlugin plugin{};
 
-    SUBCASE("Ref") {
-        TestPlugin plugin{};
+    SUBCASE("Borrow") {
         plugin = adapter->create(false);
         CHECK(plugin.context != nullptr);
         CHECK(plugin.clear == nullptr);
-        adapter->clear(plugin);
     }
 
-    SUBCASE("Ref with owning adapter") {
-        TestPlugin plugin{};
-        auto* adapterPtr = adapter.release();
-        plugin = adapterPtr->create(true);
+    SUBCASE("Owning") {
+        plugin = adapter->create(true);
+        adapter.release();
         CHECK(plugin.context != nullptr);
         CHECK(plugin.clear != nullptr);
-        adapterPtr->clear(plugin);
     }
 
-    SUBCASE("Pointer with owning adapter") {
-        TestPlugin* pluginPtr = new TestPlugin{};  // NOLINT
-        auto* adapterPtr = adapter.release();
-        *pluginPtr = adapterPtr->create(true);
-        CHECK(pluginPtr->context != nullptr);
-        CHECK(pluginPtr->clear != nullptr);
-        adapterPtr->clear(pluginPtr);
+    if (plugin.clear != nullptr) {
+        plugin.clear(plugin.context);
     }
-}
-
-TEST_CASE("PluginAdapter helper") {
-    auto adapter = std::make_unique<TestAdapter>();
-
-    SUBCASE("assignPlugin ref") {
-        TestPlugin plugin{};
-        detail::assignPlugin(plugin, *adapter, false);
-        CHECK(plugin.context != nullptr);
-        CHECK(plugin.clear == nullptr);
-        adapter->clear(plugin);
-    }
-
-    SUBCASE("assignPlugin ref with owning adapter") {
-        TestPlugin plugin{};
-        auto* adapterPtr = adapter.release();
-        detail::assignPlugin(plugin, *adapterPtr, true);
-        CHECK(plugin.context != nullptr);
-        CHECK(plugin.clear != nullptr);
-        adapterPtr->clear(plugin);
-    }
-
-    SUBCASE("assignPlugin pointer") {
-        TestPlugin* pluginPtr = new TestPlugin{};
-        detail::assignPlugin(pluginPtr, *adapter, false);
-        CHECK(pluginPtr->context != nullptr);
-        CHECK(pluginPtr->clear == nullptr);
-        adapter->clear(pluginPtr);
-    }
-
-    // SUBCASE("assignPlugin pointer with owning adapter") {
-    //     TestPlugin* pluginPtr = new TestPlugin{};
-    //     auto* adapterPtr = adapter.release();
-    //     detail::assignPlugin(pluginPtr, *adapterPtr, true);
-    //     CHECK(pluginPtr->context != nullptr);
-    //     CHECK(pluginPtr->clear != nullptr);
-    //     adapter->clear(pluginPtr);
-    // }
 }

--- a/tests/pluginadapter.cpp
+++ b/tests/pluginadapter.cpp
@@ -1,0 +1,111 @@
+#include <memory>
+
+#include <doctest/doctest.h>
+
+#include "open62541pp/plugin/pluginadapter.hpp"
+
+using namespace opcua;
+
+struct TestPlugin {
+    void* context;
+    void (*clear)(void* context);
+};
+
+class TestAdapter : public PluginAdapter<TestPlugin> {
+public:
+    TestPlugin create(bool ownsAdapter) override {
+        TestPlugin plugin{};
+        plugin.context = this;
+        if (ownsAdapter) {
+            plugin.clear = [](void* context) {
+                if (context != nullptr) {
+                    delete static_cast<TestAdapter*>(context);  // NOLINT
+                    context = nullptr;
+                }
+            };
+        }
+        return plugin;
+    }
+
+    void clear(TestPlugin& plugin) const noexcept override {
+        if (plugin.clear != nullptr) {
+            plugin.clear(plugin.context);
+        }
+    }
+
+    void clear(TestPlugin*& plugin) const noexcept override {
+        if (plugin != nullptr) {
+            clear(*plugin);
+            delete plugin;  // NOLINT
+            plugin = nullptr;
+        }
+    }
+};
+
+TEST_CASE("PluginAdapter") {
+    auto adapter = std::make_unique<TestAdapter>();
+
+    SUBCASE("Ref") {
+        TestPlugin plugin{};
+        plugin = adapter->create(false);
+        CHECK(plugin.context != nullptr);
+        CHECK(plugin.clear == nullptr);
+        adapter->clear(plugin);
+    }
+
+    SUBCASE("Ref with owning adapter") {
+        TestPlugin plugin{};
+        auto* adapterPtr = adapter.release();
+        plugin = adapterPtr->create(true);
+        CHECK(plugin.context != nullptr);
+        CHECK(plugin.clear != nullptr);
+        adapterPtr->clear(plugin);
+    }
+
+    SUBCASE("Pointer with owning adapter") {
+        TestPlugin* pluginPtr = new TestPlugin{};  // NOLINT
+        auto* adapterPtr = adapter.release();
+        *pluginPtr = adapterPtr->create(true);
+        CHECK(pluginPtr->context != nullptr);
+        CHECK(pluginPtr->clear != nullptr);
+        adapterPtr->clear(pluginPtr);
+    }
+}
+
+TEST_CASE("PluginAdapter helper") {
+    auto adapter = std::make_unique<TestAdapter>();
+
+    SUBCASE("assignPlugin ref") {
+        TestPlugin plugin{};
+        detail::assignPlugin(plugin, *adapter, false);
+        CHECK(plugin.context != nullptr);
+        CHECK(plugin.clear == nullptr);
+        adapter->clear(plugin);
+    }
+
+    SUBCASE("assignPlugin ref with owning adapter") {
+        TestPlugin plugin{};
+        auto* adapterPtr = adapter.release();
+        detail::assignPlugin(plugin, *adapterPtr, true);
+        CHECK(plugin.context != nullptr);
+        CHECK(plugin.clear != nullptr);
+        adapterPtr->clear(plugin);
+    }
+
+    SUBCASE("assignPlugin pointer") {
+        TestPlugin* pluginPtr = new TestPlugin{};
+        detail::assignPlugin(pluginPtr, *adapter, false);
+        CHECK(pluginPtr->context != nullptr);
+        CHECK(pluginPtr->clear == nullptr);
+        adapter->clear(pluginPtr);
+    }
+
+    // SUBCASE("assignPlugin pointer with owning adapter") {
+    //     TestPlugin* pluginPtr = new TestPlugin{};
+    //     auto* adapterPtr = adapter.release();
+    //     detail::assignPlugin(pluginPtr, *adapterPtr, true);
+    //     CHECK(pluginPtr->context != nullptr);
+    //     CHECK(pluginPtr->clear != nullptr);
+    //     adapter->clear(pluginPtr);
+    // }
+}

--- a/tests/server.cpp
+++ b/tests/server.cpp
@@ -23,6 +23,15 @@ TEST_CASE("ServerConfig") {
     ServerConfig config(native);
 
     SUBCASE("AccessControl") {
+        SUBCASE("Set by ref or owning") {
+            AccessControlDefault accessControl;
+            config.setAccessControl(accessControl);
+            config.setAccessControl(accessControl);
+
+            config.setAccessControl(std::unique_ptr<AccessControlDefault>{});
+            config.setAccessControl(std::make_unique<AccessControlDefault>());
+        }
+
         SUBCASE("Copy user token policies to endpoints") {
             CHECK(config->endpointsSize > 0);
 


### PR DESCRIPTION
Add boolean `ownsAdapter` parameter to `PluginAdapter::create` function to optionally move the adapter ownership to the native plugin.

```diff
- virtual T PluginAdapter::create() = 0;
+ virtual T PluginAdapter::create(bool ownsAdapter) = 0;
```
