### PR TITLE
feat: asWrapper overloads for UA_Client*/UA_Server*

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -80,7 +80,7 @@ configure_file(
     ${doxygen_output_dir}/Doxyfile
 )
 
-file(GLOB_RECURSE open62541pp_headers "${PROJECT_SOURCE_DIR}/include/*.h")
+file(GLOB_RECURSE open62541pp_headers "${PROJECT_SOURCE_DIR}/include/*.hpp")
 file(GLOB_RECURSE open62541pp_examples "${PROJECT_SOURCE_DIR}/examples/*.cpp")
 file(GLOB_RECURSE open62541pp_doc_files "*.dox" "*.html" "*.md" "fragments/*")
 

--- a/include/open62541pp/client.hpp
+++ b/include/open62541pp/client.hpp
@@ -36,7 +36,6 @@ namespace detail {
 UA_ClientConfig* getConfig(UA_Client* client) noexcept;
 UA_ClientConfig& getConfig(Client& client) noexcept;
 UA_Logger* getLogger(UA_ClientConfig* config) noexcept;
-Client* getWrapper(UA_Client* client) noexcept;
 ClientContext* getContext(UA_Client* client) noexcept;
 ClientContext& getContext(Client& client) noexcept;
 
@@ -129,6 +128,10 @@ using InactivityCallback = std::function<void()>;
  *
  * Use the handle() method to get access the underlying UA_Server instance and use the full power
  * of open62541.
+ *
+ * Don't overwrite the UA_ClientConfig::clientContext pointer! The context pointer is used to store
+ * a pointer to the Client instance (for asWrapper(UA_Client*)) and to get access to the underlying
+ * client context.
  */
 class Client {
 public:
@@ -282,6 +285,10 @@ private:
     std::unique_ptr<detail::ClientContext> context_;
     std::unique_ptr<UA_Client, Deleter> client_;
 };
+
+/// Convert native UA_Client pointer to its wrapper instance.
+/// The native client must be owned by a Client instance.
+Client* asWrapper(UA_Client* client) noexcept;
 
 inline bool operator==(const Client& lhs, const Client& rhs) noexcept {
     return (lhs.handle() == rhs.handle());

--- a/include/open62541pp/server.hpp
+++ b/include/open62541pp/server.hpp
@@ -39,7 +39,6 @@ namespace detail {
 UA_ServerConfig* getConfig(UA_Server* server) noexcept;
 UA_ServerConfig& getConfig(Server& server) noexcept;
 UA_Logger* getLogger(UA_ServerConfig* config) noexcept;
-Server* getWrapper(UA_Server* server) noexcept;
 ServerContext* getContext(UA_Server* server) noexcept;
 ServerContext& getContext(Server& server) noexcept;
 
@@ -138,6 +137,10 @@ public:
  *
  * Use the handle() method to get access the underlying UA_Server instance and use the full power
  * of open62541.
+ *
+ * Don't overwrite the UA_ServerConfig::context pointer! The context pointer is used to store a
+ * pointer to the Server instance (for asWrapper(UA_Server*)) and to get access to the underlying
+ * server context.
  */
 class Server {
 public:
@@ -278,6 +281,10 @@ private:
     std::unique_ptr<detail::ServerContext> context_;
     std::unique_ptr<UA_Server, Deleter> server_;
 };
+
+/// Convert native UA_Server pointer to its wrapper instance.
+/// The native server must be owned by a Server instance.
+Server* asWrapper(UA_Server* server) noexcept;
 
 inline bool operator==(const Server& lhs, const Server& rhs) noexcept {
     return (lhs.handle() == rhs.handle());

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -514,6 +514,14 @@ void Client::Deleter::operator()(UA_Client* client) noexcept {
     }
 }
 
+Client* asWrapper(UA_Client* client) noexcept {
+    auto* config = detail::getConfig(client);
+    if (config == nullptr) {
+        return nullptr;
+    }
+    return static_cast<Client*>(config->clientContext);
+}
+
 /* -------------------------------------- Helper functions -------------------------------------- */
 
 namespace detail {
@@ -537,17 +545,8 @@ UA_Logger* getLogger(UA_ClientConfig* config) noexcept {
 #endif
 }
 
-Client* getWrapper(UA_Client* client) noexcept {
-    auto* config = getConfig(client);
-    if (config == nullptr) {
-        return nullptr;
-    }
-    assert(config->clientContext != nullptr);
-    return static_cast<Client*>(config->clientContext);
-}
-
 ClientContext* getContext(UA_Client* client) noexcept {
-    auto* wrapper = getWrapper(client);
+    auto* wrapper = asWrapper(client);
     if (wrapper == nullptr) {
         return nullptr;
     }

--- a/src/plugin/accesscontrol.cpp
+++ b/src/plugin/accesscontrol.cpp
@@ -29,7 +29,7 @@ inline static const WrapperType& asWrapperRef(const NativeType* nativePtr) {
 inline static std::optional<Session> getSession(
     UA_Server* server, const UA_NodeId* sessionId
 ) noexcept {
-    auto* wrapper = detail::getWrapper(server);
+    auto* wrapper = asWrapper(server);
     if (wrapper == nullptr) {
         return std::nullopt;
     }

--- a/tests/client_server_common.cpp
+++ b/tests/client_server_common.cpp
@@ -113,10 +113,6 @@ TEST_CASE_TEMPLATE("Connection", T, Client, Server) {
         CHECK(detail::getConfig(connection.handle()) != nullptr);
         CHECK(detail::getConfig(connection.handle()) == &detail::getConfig(connection));
 
-        CHECK(detail::getWrapper(nativeNull) == nullptr);
-        CHECK(detail::getWrapper(connection.handle()) != nullptr);
-        CHECK(detail::getWrapper(connection.handle())->handle() == connection.handle());
-
         CHECK(detail::getContext(nativeNull) == nullptr);
         CHECK(detail::getContext(connection.handle()) != nullptr);
         CHECK(detail::getContext(connection.handle()) == &detail::getContext(connection));
@@ -130,19 +126,25 @@ TEST_CASE_TEMPLATE("Connection", T, Client, Server) {
     }
 }
 
-TEST_CASE_TEMPLATE("Connection getWrapper", T, Client, Server) {
-    T connection;
-    auto* native = connection.handle();
+TEST_CASE_TEMPLATE("Connection asWrapper", T, Client, Server) {
+    using NativeType = std::remove_pointer_t<decltype(std::declval<T>().handle())>;
 
-    CHECK(detail::getWrapper(native) == &connection);
+    T connection;
+    NativeType* native = connection.handle();
+    NativeType* nativeNull{nullptr};
+
+    CHECK(asWrapper(nativeNull) == nullptr);
+    CHECK(asWrapper(native) != nullptr);
+    CHECK(asWrapper(native) == &connection);
+    CHECK(asWrapper(native)->handle() == native);
 
     SUBCASE("Move construct") {
         T connectionMoved(std::move(connection));
-        CHECK(detail::getWrapper(native) == &connectionMoved);
+        CHECK(asWrapper(native) == &connectionMoved);
     }
     SUBCASE("Move assignment") {
         T connectionMoved;
         connectionMoved = std::move(connection);
-        CHECK(detail::getWrapper(native) == &connectionMoved);
+        CHECK(asWrapper(native) == &connectionMoved);
     }
 }


### PR DESCRIPTION
Convert native `UA_Client*`/`UA_Server*` pointer to it's wrapper instance with:
```cpp
Client* asWrapper(UA_Client* client) noexcept;
Server* asWrapper(UA_Server* server) noexcept;
```

The implementation makes use of the context pointers `UA_ClientConfig::clientContext` and `UA_ServerConfig::context`.
If the native pointer is not owned by a wrapper instance, the behavior is undefined.