### PR TITLE
feat!: don't revise subscription parameters

### DIFF
--- a/include/open62541pp/client.hpp
+++ b/include/open62541pp/client.hpp
@@ -243,7 +243,7 @@ public:
     /// Create a subscription to monitor data changes and events (default subscription parameters).
     Subscription<Client> createSubscription();
     /// Create a subscription to monitor data changes and events.
-    Subscription<Client> createSubscription(SubscriptionParameters& parameters);
+    Subscription<Client> createSubscription(const SubscriptionParameters& parameters);
     /// Get all active subscriptions
     std::vector<Subscription<Client>> getSubscriptions();
 #endif

--- a/include/open62541pp/services/detail/response_handling.hpp
+++ b/include/open62541pp/services/detail/response_handling.hpp
@@ -90,15 +90,6 @@ inline Result<std::vector<Variant>> getOutputArguments(UA_CallMethodResult& resu
     });
 }
 
-template <typename SubscriptionParameters, typename Response>
-inline void reviseSubscriptionParameters(
-    SubscriptionParameters& parameters, const Response& response
-) noexcept {
-    parameters.publishingInterval = response.revisedPublishingInterval;
-    parameters.lifetimeCount = response.revisedLifetimeCount;
-    parameters.maxKeepAliveCount = response.revisedMaxKeepAliveCount;
-}
-
 template <typename MonitoringParameters, typename Result>
 inline void reviseMonitoringParameters(
     MonitoringParameters& parameters, const Result& result

--- a/include/open62541pp/services/subscription.hpp
+++ b/include/open62541pp/services/subscription.hpp
@@ -31,9 +31,6 @@ namespace opcua::services {
 
 /**
  * Subscription parameters with default values from open62541.
- *
- * Parameters are passed by reference because illegal parameters can be revised by the server.
- * The updated parameters reflect the actual values that the server will use.
  */
 struct SubscriptionParameters {
     /// Cyclic interval in milliseconds that the subscription is requested to return notifications.
@@ -86,7 +83,6 @@ CreateSubscriptionResponse createSubscription(
 
 /**
  * Create a subscription.
- * @copydetails SubscriptionParameters
  * @param connection Instance of type Client
  * @param parameters Subscription parameters, may be revised by server
  * @param publishingEnabled Enable/disable publishing of the subscription
@@ -96,7 +92,7 @@ CreateSubscriptionResponse createSubscription(
  */
 [[nodiscard]] Result<uint32_t> createSubscription(
     Client& connection,
-    SubscriptionParameters& parameters,
+    const SubscriptionParameters& parameters,
     bool publishingEnabled = true,
     StatusChangeNotificationCallback statusChangeCallback = {},
     DeleteSubscriptionCallback deleteCallback = {}
@@ -121,13 +117,12 @@ ModifySubscriptionResponse modifySubscription(
 
 /**
  * Modify a subscription.
- * @copydetails SubscriptionParameters
  * @param connection Instance of type Client
  * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
  * @param parameters Subscription parameters, may be revised by server
  */
 Result<void> modifySubscription(
-    Client& connection, uint32_t subscriptionId, SubscriptionParameters& parameters
+    Client& connection, uint32_t subscriptionId, const SubscriptionParameters& parameters
 ) noexcept;
 
 /**

--- a/include/open62541pp/subscription.hpp
+++ b/include/open62541pp/subscription.hpp
@@ -69,7 +69,7 @@ public:
     /// Modify this subscription.
     /// @note Not implemented for Server.
     /// @see services::modifySubscription
-    void setSubscriptionParameters(SubscriptionParameters& parameters) {
+    void setSubscriptionParameters(const SubscriptionParameters& parameters) {
         services::modifySubscription(connection(), subscriptionId(), parameters).value();
     }
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -424,11 +424,10 @@ std::vector<std::string> Client::getNamespaceArray() {
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
 Subscription<Client> Client::createSubscription() {
-    SubscriptionParameters parameters{};
-    return createSubscription(parameters);
+    return createSubscription({});
 }
 
-Subscription<Client> Client::createSubscription(SubscriptionParameters& parameters) {
+Subscription<Client> Client::createSubscription(const SubscriptionParameters& parameters) {
     const uint32_t subscriptionId = services::createSubscription(*this, parameters, true).value();
     return {*this, subscriptionId};
 }

--- a/src/services_subscription.cpp
+++ b/src/services_subscription.cpp
@@ -44,7 +44,7 @@ CreateSubscriptionResponse createSubscription(
 
 Result<uint32_t> createSubscription(
     Client& connection,
-    SubscriptionParameters& parameters,
+    const SubscriptionParameters& parameters,
     bool publishingEnabled,
     StatusChangeNotificationCallback statusChangeCallback,
     DeleteSubscriptionCallback deleteCallback
@@ -66,7 +66,6 @@ Result<uint32_t> createSubscription(
         serviceResult.isBad()) {
         return BadResult(serviceResult);
     }
-    detail::reviseSubscriptionParameters(parameters, asNative(response));
     return response.getSubscriptionId();
 }
 
@@ -77,7 +76,7 @@ ModifySubscriptionResponse modifySubscription(
 }
 
 Result<void> modifySubscription(
-    Client& connection, uint32_t subscriptionId, SubscriptionParameters& parameters
+    Client& connection, uint32_t subscriptionId, const SubscriptionParameters& parameters
 ) noexcept {
     UA_ModifySubscriptionRequest request{};
     request.subscriptionId = subscriptionId;
@@ -89,12 +88,7 @@ Result<void> modifySubscription(
     const ModifySubscriptionResponse response = UA_Client_Subscriptions_modify(
         connection.handle(), request
     );
-    if (const StatusCode serviceResult = detail::getServiceResult(response);
-        serviceResult.isBad()) {
-        return BadResult(serviceResult);
-    }
-    detail::reviseSubscriptionParameters(parameters, asNative(response));
-    return {};
+    return detail::toResult(detail::getServiceResult(response));
 }
 
 SetPublishingModeResponse setPublishingMode(

--- a/tests/services_monitoreditem.cpp
+++ b/tests/services_monitoreditem.cpp
@@ -27,7 +27,7 @@ TEST_CASE("MonitoredItem service set (client)") {
     const NodeId id{1, 1000};
     services::addVariable(server, {0, UA_NS0ID_OBJECTSFOLDER}, id, "Variable").value();
 
-    services::SubscriptionParameters subscriptionParameters{};
+    const services::SubscriptionParameters subscriptionParameters{};
     services::MonitoringParametersEx monitoringParameters{};
     monitoringParameters.samplingInterval = 0.0;  // fastest
 

--- a/tests/subscription_monitoreditem.cpp
+++ b/tests/subscription_monitoreditem.cpp
@@ -75,7 +75,7 @@ TEST_CASE("Subscription & MonitoredItem (client)") {
     SUBCASE("Create & delete subscription") {
         CHECK(client.getSubscriptions().empty());
 
-        SubscriptionParameters parameters{};
+        const SubscriptionParameters parameters{};
         auto sub = client.createSubscription(parameters);
         CAPTURE(sub.subscriptionId());
 
@@ -101,7 +101,7 @@ TEST_CASE("Subscription & MonitoredItem (client)") {
     }
 
     SUBCASE("Monitor data change") {
-        SubscriptionParameters subscriptionParameters{};
+        const SubscriptionParameters subscriptionParameters{};
         MonitoringParametersEx monitoringParameters{};
 
         auto sub = client.createSubscription(subscriptionParameters);


### PR DESCRIPTION
Use the raw service to inspect the revised parameters.