### PR TITLE
feat!: return raw responses from subscription service function overloads

### DIFF
--- a/include/open62541pp/services/monitoreditem.hpp
+++ b/include/open62541pp/services/monitoreditem.hpp
@@ -41,7 +41,7 @@ namespace opcua::services {
  * @see https://reference.opcfoundation.org/Core/Part4/v105/docs/7.21
  */
 struct MonitoringParametersEx {
-    /// Timestamps to be transmitted. Won't be revised by the server.
+    /// Timestamps to be transmitted.
     TimestampsToReturn timestamps = TimestampsToReturn::Both;
     /// Interval in milliseconds that defines the fastest rate at which the MonitoredItem should be
     /// accessed and evaluated. The following values have special meaning:
@@ -126,7 +126,7 @@ CreateMonitoredItemsResponse createMonitoredItemsDataChange(
  *                       Use `0U` for a local server-side monitored item.
  * @param itemToMonitor Item to monitor
  * @param monitoringMode Monitoring mode
- * @param parameters Monitoring parameters, may be revised by server
+ * @param parameters Monitoring parameters
  * @param dataChangeCallback Invoked when the monitored item is changed
  * @param deleteCallback Invoked when the monitored item is deleted
  */
@@ -166,7 +166,7 @@ CreateMonitoredItemsResponse createMonitoredItemsEvent(
  * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
  * @param itemToMonitor Item to monitor
  * @param monitoringMode Monitoring mode
- * @param parameters Monitoring parameters, may be revised by server
+ * @param parameters Monitoring parameters
  * @param eventCallback Invoked when an event is published
  * @param deleteCallback Invoked when the monitored item is deleted
  */
@@ -204,7 +204,7 @@ ModifyMonitoredItemsResponse modifyMonitoredItems(
  * @param connection Instance of type Client
  * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
  * @param monitoredItemId Identifier of the monitored item
- * @param parameters Monitoring parameters, may be revised by server
+ * @param parameters Monitoring parameters
  */
 Result<void> modifyMonitoredItem(
     Client& connection,

--- a/include/open62541pp/services/subscription.hpp
+++ b/include/open62541pp/services/subscription.hpp
@@ -74,7 +74,7 @@ using StatusChangeNotificationCallback =
  * @param statusChangeCallback Invoked when the status of a subscription is changed
  * @param deleteCallback Invoked when the subscription is deleted
  */
-CreateSubscriptionResponse createSubscription(
+[[nodiscard]] CreateSubscriptionResponse createSubscription(
     Client& connection,
     const CreateSubscriptionRequest& request,
     StatusChangeNotificationCallback statusChangeCallback = {},
@@ -82,15 +82,9 @@ CreateSubscriptionResponse createSubscription(
 );
 
 /**
- * Create a subscription.
- * @param connection Instance of type Client
- * @param parameters Subscription parameters, may be revised by server
- * @param publishingEnabled Enable/disable publishing of the subscription
- * @param statusChangeCallback Invoked when the status of a subscription is changed
- * @param deleteCallback Invoked when the subscription is deleted
- * @return Server-assigned identifier of the subscription
+ * @overload
  */
-[[nodiscard]] Result<uint32_t> createSubscription(
+[[nodiscard]] CreateSubscriptionResponse createSubscription(
     Client& connection,
     const SubscriptionParameters& parameters,
     bool publishingEnabled = true,
@@ -119,7 +113,7 @@ ModifySubscriptionResponse modifySubscription(
  * Modify a subscription.
  * @param connection Instance of type Client
  * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
- * @param parameters Subscription parameters, may be revised by server
+ * @param parameters Subscription parameters
  */
 Result<void> modifySubscription(
     Client& connection, uint32_t subscriptionId, const SubscriptionParameters& parameters

--- a/include/open62541pp/services/subscription.hpp
+++ b/include/open62541pp/services/subscription.hpp
@@ -110,12 +110,9 @@ ModifySubscriptionResponse modifySubscription(
 ) noexcept;
 
 /**
- * Modify a subscription.
- * @param connection Instance of type Client
- * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
- * @param parameters Subscription parameters
+ * @overload
  */
-Result<void> modifySubscription(
+ModifySubscriptionResponse modifySubscription(
     Client& connection, uint32_t subscriptionId, const SubscriptionParameters& parameters
 ) noexcept;
 

--- a/include/open62541pp/subscription.hpp
+++ b/include/open62541pp/subscription.hpp
@@ -70,7 +70,10 @@ public:
     /// @note Not implemented for Server.
     /// @see services::modifySubscription
     void setSubscriptionParameters(const SubscriptionParameters& parameters) {
-        services::modifySubscription(connection(), subscriptionId(), parameters).value();
+        const auto response = services::modifySubscription(
+            connection(), subscriptionId(), parameters
+        );
+        response.getResponseHeader().getServiceResult().throwIfBad();
     }
 
     /// Enable/disable publishing of notification messages.

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -428,8 +428,9 @@ Subscription<Client> Client::createSubscription() {
 }
 
 Subscription<Client> Client::createSubscription(const SubscriptionParameters& parameters) {
-    const uint32_t subscriptionId = services::createSubscription(*this, parameters, true).value();
-    return {*this, subscriptionId};
+    const auto response = services::createSubscription(*this, parameters, true);
+    response.getResponseHeader().getServiceResult().throwIfBad();
+    return {*this, response.getSubscriptionId()};
 }
 
 std::vector<Subscription<Client>> Client::getSubscriptions() {

--- a/src/services_subscription.cpp
+++ b/src/services_subscription.cpp
@@ -42,7 +42,7 @@ CreateSubscriptionResponse createSubscription(
     return response;
 }
 
-Result<uint32_t> createSubscription(
+CreateSubscriptionResponse createSubscription(
     Client& connection,
     const SubscriptionParameters& parameters,
     bool publishingEnabled,
@@ -56,17 +56,12 @@ Result<uint32_t> createSubscription(
     request.maxNotificationsPerPublish = parameters.maxNotificationsPerPublish;
     request.publishingEnabled = publishingEnabled;
     request.priority = parameters.priority;
-    const auto response = createSubscription(
+    return createSubscription(
         connection,
         asWrapper<CreateSubscriptionRequest>(request),
         std::move(statusChangeCallback),
         std::move(deleteCallback)
     );
-    if (const StatusCode serviceResult = detail::getServiceResult(response);
-        serviceResult.isBad()) {
-        return BadResult(serviceResult);
-    }
-    return response.getSubscriptionId();
 }
 
 ModifySubscriptionResponse modifySubscription(

--- a/src/services_subscription.cpp
+++ b/src/services_subscription.cpp
@@ -70,7 +70,7 @@ ModifySubscriptionResponse modifySubscription(
     return UA_Client_Subscriptions_modify(connection.handle(), request);
 }
 
-Result<void> modifySubscription(
+ModifySubscriptionResponse modifySubscription(
     Client& connection, uint32_t subscriptionId, const SubscriptionParameters& parameters
 ) noexcept {
     UA_ModifySubscriptionRequest request{};
@@ -80,10 +80,7 @@ Result<void> modifySubscription(
     request.requestedMaxKeepAliveCount = parameters.maxKeepAliveCount;
     request.maxNotificationsPerPublish = parameters.maxNotificationsPerPublish;
     request.priority = parameters.priority;
-    const ModifySubscriptionResponse response = UA_Client_Subscriptions_modify(
-        connection.handle(), request
-    );
-    return detail::toResult(detail::getServiceResult(response));
+    return modifySubscription(connection, asWrapper<ModifySubscriptionRequest>(request));
 }
 
 SetPublishingModeResponse setPublishingMode(

--- a/tests/services_monitoreditem.cpp
+++ b/tests/services_monitoreditem.cpp
@@ -42,7 +42,8 @@ TEST_CASE("MonitoredItem service set (client)") {
         ));
     }
 
-    const auto subId = services::createSubscription(client, subscriptionParameters).value();
+    const auto subId =
+        services::createSubscription(client, subscriptionParameters).getSubscriptionId();
     CAPTURE(subId);
 
     SUBCASE("createMonitoredItemDataChange") {
@@ -163,7 +164,6 @@ TEST_CASE("MonitoredItem service set (client)") {
         services::MonitoringParametersEx modifiedParameters{};
         modifiedParameters.samplingInterval = 1000.0;
         CHECK(services::modifyMonitoredItem(client, subId, monId, modifiedParameters));
-        CHECK(modifiedParameters.samplingInterval == 1000.0);  // should not be revised
     }
 
     SUBCASE("setMonitoringMode") {

--- a/tests/services_subscription.cpp
+++ b/tests/services_subscription.cpp
@@ -16,12 +16,13 @@ TEST_CASE("Subscription service set (client)") {
     services::SubscriptionParameters parameters{};
 
     SUBCASE("createSubscription") {
-        const auto subId = services::createSubscription(client, parameters).value();
-        CAPTURE(subId);
+        const auto response = services::createSubscription(client, parameters);
+        CHECK(response.getResponseHeader().getServiceResult().isGood());
+        CAPTURE(response.getSubscriptionId());
     }
 
     SUBCASE("modifySubscription") {
-        const auto subId = services::createSubscription(client, parameters).value();
+        const auto subId = services::createSubscription(client, parameters).getSubscriptionId();
 
         parameters.priority = 1;
         CHECK(services::modifySubscription(client, subId, parameters));
@@ -32,12 +33,12 @@ TEST_CASE("Subscription service set (client)") {
     }
 
     SUBCASE("setPublishingMode") {
-        const auto subId = services::createSubscription(client, parameters).value();
+        const auto subId = services::createSubscription(client, parameters).getSubscriptionId();
         CHECK(services::setPublishingMode(client, subId, false));
     }
 
     SUBCASE("deleteSubscription") {
-        const auto subId = services::createSubscription(client, parameters).value();
+        const auto subId = services::createSubscription(client, parameters).getSubscriptionId();
         CHECK(services::deleteSubscription(client, subId));
         CHECK(
             services::deleteSubscription(client, subId + 1).code() ==
@@ -49,7 +50,8 @@ TEST_CASE("Subscription service set (client)") {
         bool deleted = false;
         const auto deleteCallback = [&](uint32_t) { deleted = true; };
         const auto subId =
-            services::createSubscription(client, parameters, true, {}, deleteCallback).value();
+            services::createSubscription(client, parameters, true, {}, deleteCallback)
+                .getSubscriptionId();
 
         CHECK(services::deleteSubscription(client, subId));
         CHECK(deleted == true);

--- a/tests/services_subscription.cpp
+++ b/tests/services_subscription.cpp
@@ -25,11 +25,17 @@ TEST_CASE("Subscription service set (client)") {
         const auto subId = services::createSubscription(client, parameters).getSubscriptionId();
 
         parameters.priority = 1;
-        CHECK(services::modifySubscription(client, subId, parameters));
-        CHECK(
-            services::modifySubscription(client, subId + 1, parameters).code() ==
-            UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID
-        );
+        {
+            const auto response = services::modifySubscription(client, subId, parameters);
+            CHECK(response.getResponseHeader().getServiceResult().isGood());
+        }
+        {
+            const auto response = services::modifySubscription(client, subId + 1, parameters);
+            CHECK(
+                response.getResponseHeader().getServiceResult() ==
+                UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID
+            );
+        }
     }
 
     SUBCASE("setPublishingMode") {

--- a/tests/subscription_monitoreditem.cpp
+++ b/tests/subscription_monitoreditem.cpp
@@ -96,8 +96,6 @@ TEST_CASE("Subscription & MonitoredItem (client)") {
         SubscriptionParameters parameters{};
         parameters.priority = 10;
         sub.setSubscriptionParameters(parameters);
-
-        CHECK(parameters.priority == 10);  // not revised by server
     }
 
     SUBCASE("Monitor data change") {


### PR DESCRIPTION
- return `CreateSubscriptionResponse` from all `services::createSubscription` overloads
- return `ModifySubscriptionResponse` from all `services::modifySubscription` overloads