### PR TITLE
feat!: return CallMethodResult from services::call overload / Node::callMethod

### DIFF
--- a/examples/method/client_method.cpp
+++ b/examples/method/client_method.cpp
@@ -14,8 +14,8 @@ int main() {
     const opcua::Node greetMethodNode = objectsNode.browseChild({{1, "Greet"}});
 
     // Call method from parent node (Objects)
-    const auto outputs = objectsNode.callMethod(
+    const auto result = objectsNode.callMethod(
         greetMethodNode.id(), {opcua::Variant::fromScalar("World")}
     );
-    std::cout << outputs.at(0).getScalar<opcua::String>() << std::endl;
+    std::cout << result.getOutputArguments()[0].getScalar<opcua::String>() << std::endl;
 }

--- a/examples/method/client_method_async.cpp
+++ b/examples/method/client_method_async.cpp
@@ -32,7 +32,8 @@ int main() {
 
         std::cout << "Future ready, get method output\n";
         auto result = future.get();
-        std::cout << result.value().at(0).getScalar<opcua::String>() << std::endl;
+        std::cout << "Future with status code: " << result.getStatusCode() << std::endl;
+        std::cout << result.getOutputArguments()[0].getScalar<opcua::String>() << std::endl;
     }
 
     // Asynchronously call method (callback variant)
@@ -42,10 +43,9 @@ int main() {
             objectsNode.id(),
             greetMethodNode.id(),
             {opcua::Variant::fromScalar("Callback World")},
-            [](const opcua::Result<std::vector<opcua::Variant>>& result) {
-                std::cout
-                    << "Callback with status code " << result.code() << ", get method output\n";
-                std::cout << result.value().at(0).getScalar<opcua::String>() << std::endl;
+            [](opcua::CallMethodResult& result) {
+                std::cout << "Callback with status code: " << result.getStatusCode() << std::endl;
+                std::cout << result.getOutputArguments()[0].getScalar<opcua::String>() << std::endl;
             }
         );
     }

--- a/include/open62541pp/node.hpp
+++ b/include/open62541pp/node.hpp
@@ -325,11 +325,11 @@ public:
     }
 
 #ifdef UA_ENABLE_METHODCALLS
-    /// Call a server method and return results.
+    /// Call a server method.
     /// @param methodId NodeId of the method (`HasComponent` reference to current node required)
     /// @param inputArguments Input argument values
-    std::vector<Variant> callMethod(const NodeId& methodId, Span<const Variant> inputArguments) {
-        return services::call(connection(), id(), methodId, inputArguments).value();
+    CallMethodResult callMethod(const NodeId& methodId, Span<const Variant> inputArguments) {
+        return services::call(connection(), id(), methodId, inputArguments);
     }
 #endif
 

--- a/src/services_method.cpp
+++ b/src/services_method.cpp
@@ -14,19 +14,18 @@ CallResponse call(Client& connection, const CallRequest& request) noexcept {
 }
 
 template <>
-Result<std::vector<Variant>> call(
+CallMethodResult call(
     Server& connection,
     const NodeId& objectId,
     const NodeId& methodId,
     Span<const Variant> inputArguments
 ) noexcept {
     const auto item = detail::createCallMethodRequest(objectId, methodId, inputArguments);
-    CallMethodResult result = UA_Server_call(connection.handle(), &item);
-    return detail::getOutputArguments(result);
+    return UA_Server_call(connection.handle(), &item);
 }
 
 template <>
-Result<std::vector<Variant>> call(
+CallMethodResult call(
     Client& connection,
     const NodeId& objectId,
     const NodeId& methodId,

--- a/tests/services_method.cpp
+++ b/tests/services_method.cpp
@@ -73,7 +73,7 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
     }
 
     SUBCASE("Check result") {
-        Result<std::vector<Variant>> result = call(
+        const CallMethodResult result = call(
             connection,
             objectsId,
             methodId,
@@ -82,13 +82,14 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
                 Variant::fromScalar(int32_t{2}),
             }
         );
-        CHECK(result.value().size() == 1);
-        CHECK(result.value()[0].getScalarCopy<int32_t>() == 3);
+        CHECK(result.getStatusCode().isGood());
+        CHECK(result.getOutputArguments().size() == 1);
+        CHECK(result.getOutputArguments()[0].getScalarCopy<int32_t>() == 3);
     }
 
     SUBCASE("Propagate exception") {
         throwException = true;
-        auto result = call(
+        const CallMethodResult result = call(
             connection,
             objectsId,
             methodId,
@@ -97,11 +98,11 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
                 Variant::fromScalar(int32_t{2}),
             }
         );
-        CHECK(result.code() == UA_STATUSCODE_BADUNEXPECTEDERROR);
+        CHECK(result.getStatusCode() == UA_STATUSCODE_BADUNEXPECTEDERROR);
     }
 
     SUBCASE("Invalid input arguments") {
-        auto result = call(
+        const CallMethodResult result = call(
             connection,
             objectsId,
             methodId,
@@ -110,16 +111,18 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
                 Variant::fromScalar(11.11f),
             }
         );
-        CHECK(result.code() == UA_STATUSCODE_BADINVALIDARGUMENT);
+        CHECK(result.getStatusCode() == UA_STATUSCODE_BADINVALIDARGUMENT);
     }
 
     SUBCASE("Missing arguments") {
-        auto result = call(connection, objectsId, methodId, Span<const Variant>{});
-        CHECK(result.code() == UA_STATUSCODE_BADARGUMENTSMISSING);
+        const CallMethodResult result = call(
+            connection, objectsId, methodId, Span<const Variant>{}
+        );
+        CHECK(result.getStatusCode() == UA_STATUSCODE_BADARGUMENTSMISSING);
     }
 
     SUBCASE("Too many arguments") {
-        auto result = call(
+        const CallMethodResult result = call(
             connection,
             objectsId,
             methodId,
@@ -129,7 +132,7 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
                 Variant::fromScalar(int32_t{3}),
             }
         );
-        CHECK(result.code() == UA_STATUSCODE_BADTOOMANYARGUMENTS);
+        CHECK(result.getStatusCode() == UA_STATUSCODE_BADTOOMANYARGUMENTS);
     }
 }
 #endif


### PR DESCRIPTION
Returning `CallMethodResult` instead of just the output arguments `Result<std::vector<Variant>>` gives more details about the invocation with status codes for each input argument and optionally diagnostic info.
The solution is also more performant because the output arguments do not have to be copied/moved into a new vector.