### PR TITLE
refactor: minimize client services dependencies

### DIFF
--- a/include/open62541pp/client.hpp
+++ b/include/open62541pp/client.hpp
@@ -26,6 +26,7 @@ template <typename Connection>
 class Node;
 
 namespace detail {
+class ExceptionCatcher;
 struct ClientContext;
 }  // namespace detail
 
@@ -37,6 +38,7 @@ UA_ClientConfig* getConfig(UA_Client* client) noexcept;
 UA_Logger* getLogger(UA_ClientConfig* config) noexcept;
 ClientContext* getContext(UA_Client* client) noexcept;
 ClientContext& getContext(Client& client) noexcept;
+ExceptionCatcher* getExceptionCatcher(UA_Client* client) noexcept;
 
 }  // namespace detail
 

--- a/include/open62541pp/client.hpp
+++ b/include/open62541pp/client.hpp
@@ -9,6 +9,7 @@
 
 #include "open62541pp/config.hpp"
 #include "open62541pp/datatype.hpp"
+#include "open62541pp/detail/client_utils.hpp"
 #include "open62541pp/detail/open62541/client.h"
 #include "open62541pp/span.hpp"
 #include "open62541pp/subscription.hpp"
@@ -20,27 +21,9 @@
 #include "open62541pp/plugin/log_default.hpp"  // LogFunction
 
 namespace opcua {
-class Client;
 struct Login;
 template <typename Connection>
 class Node;
-
-namespace detail {
-class ExceptionCatcher;
-struct ClientContext;
-}  // namespace detail
-
-/* -------------------------------------- Helper functions -------------------------------------- */
-
-namespace detail {
-
-UA_ClientConfig* getConfig(UA_Client* client) noexcept;
-UA_Logger* getLogger(UA_ClientConfig* config) noexcept;
-ClientContext* getContext(UA_Client* client) noexcept;
-ClientContext& getContext(Client& client) noexcept;
-ExceptionCatcher* getExceptionCatcher(UA_Client* client) noexcept;
-
-}  // namespace detail
 
 /* ---------------------------------------- ClientConfig ---------------------------------------- */
 

--- a/include/open62541pp/detail/client_utils.hpp
+++ b/include/open62541pp/detail/client_utils.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "open62541pp/detail/open62541/client.h"
+
+namespace opcua {
+class Client;
+
+namespace detail {
+class ExceptionCatcher;
+struct ClientContext;
+}  // namespace detail
+}  // namespace opcua
+
+namespace opcua::detail {
+
+UA_ClientConfig* getConfig(UA_Client* client) noexcept;
+UA_Logger* getLogger(UA_ClientConfig* config) noexcept;
+ClientContext* getContext(UA_Client* client) noexcept;
+ClientContext& getContext(Client& client) noexcept;
+ExceptionCatcher* getExceptionCatcher(UA_Client* client) noexcept;
+ExceptionCatcher& getExceptionCatcher(Client& client) noexcept;
+UA_Client* getHandle(Client& client) noexcept;
+
+}  // namespace opcua::detail

--- a/include/open62541pp/detail/server_utils.hpp
+++ b/include/open62541pp/detail/server_utils.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "open62541pp/detail/open62541/server.h"
+
+namespace opcua {
+class Server;
+
+namespace detail {
+class ExceptionCatcher;
+struct ServerContext;
+}  // namespace detail
+}  // namespace opcua
+
+namespace opcua::detail {
+
+UA_ServerConfig* getConfig(UA_Server* server) noexcept;
+UA_Logger* getLogger(UA_ServerConfig* config) noexcept;
+ServerContext* getContext(UA_Server* server) noexcept;
+ServerContext& getContext(Server& server) noexcept;
+ExceptionCatcher* getExceptionCatcher(UA_Server* server) noexcept;
+ExceptionCatcher& getExceptionCatcher(Server& server) noexcept;
+UA_Server* getHandle(Server& server) noexcept;
+
+}  // namespace opcua::detail

--- a/include/open62541pp/server.hpp
+++ b/include/open62541pp/server.hpp
@@ -10,6 +10,7 @@
 #include "open62541pp/config.hpp"
 #include "open62541pp/datatype.hpp"
 #include "open62541pp/detail/open62541/server.h"
+#include "open62541pp/detail/server_utils.hpp"
 #include "open62541pp/event.hpp"
 #include "open62541pp/nodeids.hpp"
 #include "open62541pp/session.hpp"
@@ -26,22 +27,6 @@
 namespace opcua {
 template <typename Connection>
 class Node;
-class Server;
-
-namespace detail {
-struct ServerContext;
-}  // namespace detail
-
-/* -------------------------------------- Helper functions -------------------------------------- */
-
-namespace detail {
-
-UA_ServerConfig* getConfig(UA_Server* server) noexcept;
-UA_Logger* getLogger(UA_ServerConfig* config) noexcept;
-ServerContext* getContext(UA_Server* server) noexcept;
-ServerContext& getContext(Server& server) noexcept;
-
-}  // namespace detail
 
 /* ---------------------------------------- ServerConfig ---------------------------------------- */
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -516,10 +516,7 @@ void Client::Deleter::operator()(UA_Client* client) noexcept {
 
 Client* asWrapper(UA_Client* client) noexcept {
     auto* config = detail::getConfig(client);
-    if (config == nullptr) {
-        return nullptr;
-    }
-    return static_cast<Client*>(config->clientContext);
+    return config == nullptr ? nullptr : static_cast<Client*>(config->clientContext);
 }
 
 /* -------------------------------------- Helper functions -------------------------------------- */
@@ -531,26 +528,25 @@ UA_ClientConfig* getConfig(UA_Client* client) noexcept {
 }
 
 UA_Logger* getLogger(UA_ClientConfig* config) noexcept {
-    if (config == nullptr) {
-        return nullptr;
-    }
 #if UAPP_OPEN62541_VER_GE(1, 4)
-    return config->logging;
+    return config == nullptr ? nullptr : config->logging;
 #else
-    return &config->logger;
+    return config == nullptr ? nullptr : &config->logger;
 #endif
 }
 
 ClientContext* getContext(UA_Client* client) noexcept {
     auto* wrapper = asWrapper(client);
-    if (wrapper == nullptr) {
-        return nullptr;
-    }
-    return &getContext(*wrapper);
+    return wrapper == nullptr ? nullptr : &getContext(*wrapper);
 }
 
 ClientContext& getContext(Client& client) noexcept {
     return client.context();
+}
+
+ExceptionCatcher* getExceptionCatcher(UA_Client* client) noexcept {
+    auto* context = getContext(client);
+    return context == nullptr ? nullptr : &context->exceptionCatcher;
 }
 
 }  // namespace detail

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -523,7 +523,7 @@ UA_Client* asNative(Client* client) noexcept {
     return client == nullptr ? nullptr : client->handle();
 }
 
-/* -------------------------------------- Helper functions -------------------------------------- */
+/* -------------------------------------- Utility functions ------------------------------------- */
 
 namespace detail {
 
@@ -551,6 +551,14 @@ ClientContext& getContext(Client& client) noexcept {
 ExceptionCatcher* getExceptionCatcher(UA_Client* client) noexcept {
     auto* context = getContext(client);
     return context == nullptr ? nullptr : &context->exceptionCatcher;
+}
+
+ExceptionCatcher& getExceptionCatcher(Client& client) noexcept {
+    return getContext(client).exceptionCatcher;
+}
+
+UA_Client* getHandle(Client& client) noexcept {
+    return client.handle();
 }
 
 }  // namespace detail

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -547,7 +547,7 @@ UA_Server* asNative(Server* server) noexcept {
     return server == nullptr ? nullptr : server->handle();
 }
 
-/* -------------------------------------- Helper functions -------------------------------------- */
+/* -------------------------------------- Utility functions ------------------------------------- */
 
 namespace detail {
 
@@ -570,6 +570,19 @@ ServerContext* getContext(UA_Server* server) noexcept {
 
 ServerContext& getContext(Server& server) noexcept {
     return server.context();
+}
+
+ExceptionCatcher* getExceptionCatcher(UA_Server* server) noexcept {
+    auto* context = getContext(server);
+    return context == nullptr ? nullptr : &context->exceptionCatcher;
+}
+
+ExceptionCatcher& getExceptionCatcher(Server& server) noexcept {
+    return getContext(server).exceptionCatcher;
+}
+
+UA_Server* getHandle(Server& server) noexcept {
+    return server.handle();
 }
 
 }  // namespace detail

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -526,10 +526,7 @@ void Server::Deleter::operator()(UA_Server* server) noexcept {
 Server* asWrapper(UA_Server* server) noexcept {
 #if UAPP_OPEN62541_VER_GE(1, 3)
     auto* config = detail::getConfig(server);
-    if (config == nullptr) {
-        return nullptr;
-    }
-    return static_cast<Server*>(config->context);
+    return config == nullptr ? nullptr : static_cast<Server*>(config->context);
 #else
     if (server == nullptr) {
         return nullptr;
@@ -555,22 +552,16 @@ UA_ServerConfig* getConfig(UA_Server* server) noexcept {
 }
 
 UA_Logger* getLogger(UA_ServerConfig* config) noexcept {
-    if (config == nullptr) {
-        return nullptr;
-    }
 #if UAPP_OPEN62541_VER_GE(1, 4)
-    return config->logging;
+    return config == nullptr ? nullptr : config->logging;
 #else
-    return &config->logger;
+    return config == nullptr ? nullptr: &config->logger;
 #endif
 }
 
 ServerContext* getContext(UA_Server* server) noexcept {
     auto* wrapper = asWrapper(server);
-    if (wrapper == nullptr) {
-        return nullptr;
-    }
-    return &getContext(*wrapper);
+    return wrapper == nullptr ? nullptr : &getContext(*wrapper);
 }
 
 ServerContext& getContext(Server& server) noexcept {

--- a/tests/client_server_common.cpp
+++ b/tests/client_server_common.cpp
@@ -102,19 +102,6 @@ TEST_CASE_TEMPLATE("Connection", T, Client, Server) {
         CHECK(connection.config()->customDataTypes->types != nullptr);
         CHECK(connection.config()->customDataTypes->types[0] == UA_TYPES[UA_TYPES_STRING]);
         CHECK(connection.config()->customDataTypes->types[1] == UA_TYPES[UA_TYPES_INT32]);
-        
-    }
-
-    SUBCASE("Helper functions") {
-        NativeType* nativeNull{nullptr};
-
-        CHECK(detail::getConfig(nativeNull) == nullptr);
-        CHECK(detail::getConfig(connection.handle()) != nullptr);
-        CHECK(detail::getConfig(connection.handle()) == connection.config().handle());
-
-        CHECK(detail::getContext(nativeNull) == nullptr);
-        CHECK(detail::getContext(connection.handle()) != nullptr);
-        CHECK(detail::getContext(connection.handle()) == &detail::getContext(connection));
     }
 
     SUBCASE("Equality operators") {
@@ -122,6 +109,27 @@ TEST_CASE_TEMPLATE("Connection", T, Client, Server) {
         CHECK(connection == connection);
         CHECK(connection != other);
         CHECK(other == other);
+    }
+
+    SUBCASE("Utility functions") {
+        NativeType* native = connection.handle();
+        NativeType* nativeNull{nullptr};
+
+        CHECK(detail::getConfig(nativeNull) == nullptr);
+        CHECK(detail::getConfig(native) != nullptr);
+        CHECK(detail::getConfig(native) == connection.config().handle());
+
+        CHECK(detail::getLogger(detail::getConfig(native)) != nullptr);
+
+        CHECK(detail::getContext(nativeNull) == nullptr);
+        CHECK(detail::getContext(native) != nullptr);
+        CHECK(detail::getContext(native) == &detail::getContext(connection));
+
+        CHECK(detail::getExceptionCatcher(nativeNull) == nullptr);
+        CHECK(detail::getExceptionCatcher(native) != nullptr);
+        CHECK(detail::getExceptionCatcher(native) == &detail::getExceptionCatcher(connection));
+
+        CHECK(detail::getHandle(connection) == connection.handle());
     }
 }
 

--- a/tests/clientservice.cpp
+++ b/tests/clientservice.cpp
@@ -25,7 +25,7 @@ TEST_CASE("AsyncServiceAdapter") {
         detail::ExceptionCatcher catcher;
 
         auto callbackAndContext = Adapter::createCallbackAndContext(
-            catcher,
+            &catcher,
             [&](int val) {
                 if (throwInTransform) {
                     throw std::runtime_error("Transform");

--- a/tests/clientservice.cpp
+++ b/tests/clientservice.cpp
@@ -25,7 +25,7 @@ TEST_CASE("AsyncServiceAdapter") {
         detail::ExceptionCatcher catcher;
 
         auto callbackAndContext = Adapter::createCallbackAndContext(
-            &catcher,
+            catcher,
             [&](int val) {
                 if (throwInTransform) {
                     throw std::runtime_error("Transform");


### PR DESCRIPTION
The header `client_services.hpp` is included in all services headers mainly for async implementations. This PR removes the `client.hpp` dependency, which makes the services headers agnostic to both `Client` and `Server`.