### PR TITLE
revert: asNative overloads for Client*/Server*

### DIFF
--- a/include/open62541pp/client.hpp
+++ b/include/open62541pp/client.hpp
@@ -285,12 +285,9 @@ private:
     std::unique_ptr<UA_Client, Deleter> client_;
 };
 
-/// Convert native UA_Client pointer to its wrapper pointer.
+/// Convert native UA_Client pointer to its wrapper instance.
 /// The native client must be owned by a Client instance.
 Client* asWrapper(UA_Client* client) noexcept;
-
-/// Convert Client wrapper pointer to native pointer.
-UA_Client* asNative(Client* client) noexcept;
 
 inline bool operator==(const Client& lhs, const Client& rhs) noexcept {
     return (lhs.handle() == rhs.handle());

--- a/include/open62541pp/server.hpp
+++ b/include/open62541pp/server.hpp
@@ -283,12 +283,9 @@ private:
     std::unique_ptr<UA_Server, Deleter> server_;
 };
 
-/// Convert native UA_Server pointer to its wrapper pointer.
+/// Convert native UA_Server pointer to its wrapper instance.
 /// The native server must be owned by a Server instance.
 Server* asWrapper(UA_Server* server) noexcept;
-
-/// Convert Server wrapper pointer to native pointer.
-UA_Server* asNative(Server* server) noexcept;
 
 inline bool operator==(const Server& lhs, const Server& rhs) noexcept {
     return (lhs.handle() == rhs.handle());

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -522,10 +522,6 @@ Client* asWrapper(UA_Client* client) noexcept {
     return static_cast<Client*>(config->clientContext);
 }
 
-UA_Client* asNative(Client* client) noexcept {
-    return client == nullptr ? nullptr : client->handle();
-}
-
 /* -------------------------------------- Helper functions -------------------------------------- */
 
 namespace detail {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -546,10 +546,6 @@ Server* asWrapper(UA_Server* server) noexcept {
 #endif
 }
 
-UA_Server* asNative(Server* server) noexcept {
-    return server == nullptr ? nullptr : server->handle();
-}
-
 /* -------------------------------------- Helper functions -------------------------------------- */
 
 namespace detail {

--- a/tests/client_server_common.cpp
+++ b/tests/client_server_common.cpp
@@ -147,12 +147,3 @@ TEST_CASE_TEMPLATE("Connection asWrapper", T, Client, Server) {
         CHECK(asWrapper(native) == &connectionMoved);
     }
 }
-
-TEST_CASE_TEMPLATE("Connection asNative", T, Client, Server) {
-    T connection;
-    T* connectionNull{nullptr};
-
-    CHECK(asNative(connectionNull) == nullptr);
-    CHECK(asNative(&connection) != nullptr);
-    CHECK(asNative(&connection) == connection.handle());
-}


### PR DESCRIPTION
Just use `Client::handle`/`Server::handle`.
This reverts commit e77944edd296a866689ec8b0d8eb4c3204a09830.