### PR TITLE
feat!: return MonitoredItemCreateResult from services::createMonitoredItem*

### DIFF
--- a/include/open62541pp/services/detail/response_handling.hpp
+++ b/include/open62541pp/services/detail/response_handling.hpp
@@ -82,11 +82,4 @@ inline Result<NodeId> getAddedNodeId(UA_AddNodesResult& result) noexcept {
     return {std::exchange(result.addedNodeId, {})};
 }
 
-inline Result<uint32_t> getMonitoredItemId(const UA_MonitoredItemCreateResult& result) noexcept {
-    if (const StatusCode code = result.statusCode; code.isBad()) {
-        return BadResult(code);
-    }
-    return result.monitoredItemId;
-}
-
 }  // namespace opcua::services::detail

--- a/include/open62541pp/services/monitoreditem.hpp
+++ b/include/open62541pp/services/monitoreditem.hpp
@@ -108,7 +108,7 @@ using EventNotificationCallback =
  * @param dataChangeCallback Invoked when the monitored item is changed
  * @param deleteCallback Invoked when the monitored item is deleted
  */
-CreateMonitoredItemsResponse createMonitoredItemsDataChange(
+[[nodiscard]] CreateMonitoredItemsResponse createMonitoredItemsDataChange(
     Client& connection,
     const CreateMonitoredItemsRequest& request,
     DataChangeNotificationCallback dataChangeCallback,
@@ -131,7 +131,7 @@ CreateMonitoredItemsResponse createMonitoredItemsDataChange(
  * @param deleteCallback Invoked when the monitored item is deleted
  */
 template <typename T>
-[[nodiscard]] Result<uint32_t> createMonitoredItemDataChange(
+[[nodiscard]] MonitoredItemCreateResult createMonitoredItemDataChange(
     T& connection,
     uint32_t subscriptionId,
     const ReadValueId& itemToMonitor,
@@ -150,7 +150,7 @@ template <typename T>
  * @param eventCallback Invoked when an event is published
  * @param deleteCallback Invoked when the monitored item is deleted
  */
-CreateMonitoredItemsResponse createMonitoredItemsEvent(
+[[nodiscard]] CreateMonitoredItemsResponse createMonitoredItemsEvent(
     Client& connection,
     const CreateMonitoredItemsRequest& request,
     EventNotificationCallback eventCallback,
@@ -170,7 +170,7 @@ CreateMonitoredItemsResponse createMonitoredItemsEvent(
  * @param eventCallback Invoked when an event is published
  * @param deleteCallback Invoked when the monitored item is deleted
  */
-[[nodiscard]] Result<uint32_t> createMonitoredItemEvent(
+[[nodiscard]] MonitoredItemCreateResult createMonitoredItemEvent(
     Client& connection,
     uint32_t subscriptionId,
     const ReadValueId& itemToMonitor,

--- a/include/open62541pp/subscription.hpp
+++ b/include/open62541pp/subscription.hpp
@@ -99,7 +99,8 @@ public:
             parameters,
             std::move(onDataChange)
         );
-        return {connection(), subscriptionId(), result.value()};
+        result.getStatusCode().throwIfBad();
+        return {connection(), subscriptionId(), result.getMonitoredItemId()};
     }
 
     /// Create a monitored item for data change notifications (default settings).
@@ -130,7 +131,8 @@ public:
             parameters,
             std::move(onEvent)
         );
-        return {connection(), subscriptionId(), result.value()};
+        result.getStatusCode().throwIfBad();
+        return {connection(), subscriptionId(), result.getMonitoredItemId()};
     }
 
     /// Create a monitored item for event notifications (default settings).

--- a/src/services_monitoreditem.cpp
+++ b/src/services_monitoreditem.cpp
@@ -115,7 +115,7 @@ CreateMonitoredItemsResponse createMonitoredItemsDataChange(
 }
 
 template <>
-Result<uint32_t> createMonitoredItemDataChange<Client>(
+MonitoredItemCreateResult createMonitoredItemDataChange<Client>(
     Client& connection,
     uint32_t subscriptionId,
     const ReadValueId& itemToMonitor,
@@ -127,7 +127,7 @@ Result<uint32_t> createMonitoredItemDataChange<Client>(
     auto context = createMonitoredItemContext(
         connection, itemToMonitor, std::move(dataChangeCallback), {}, std::move(deleteCallback)
     );
-    const MonitoredItemCreateResult result = UA_Client_MonitoredItems_createDataChange(
+    MonitoredItemCreateResult result = UA_Client_MonitoredItems_createDataChange(
         connection.handle(),
         subscriptionId,
         static_cast<UA_TimestampsToReturn>(parameters.timestamps),
@@ -137,11 +137,11 @@ Result<uint32_t> createMonitoredItemDataChange<Client>(
         context->deleteCallbackNative
     );
     storeMonitoredItemContext(connection, subscriptionId, result, context);
-    return detail::getMonitoredItemId(result);
+    return result;
 }
 
 template <>
-Result<uint32_t> createMonitoredItemDataChange<Server>(
+MonitoredItemCreateResult createMonitoredItemDataChange<Server>(
     Server& connection,
     [[maybe_unused]] uint32_t subscriptionId,
     const ReadValueId& itemToMonitor,
@@ -153,7 +153,7 @@ Result<uint32_t> createMonitoredItemDataChange<Server>(
     auto context = createMonitoredItemContext(
         connection, itemToMonitor, std::move(dataChangeCallback), {}, std::move(deleteCallback)
     );
-    const MonitoredItemCreateResult result = UA_Server_createDataChangeMonitoredItem(
+    MonitoredItemCreateResult result = UA_Server_createDataChangeMonitoredItem(
         connection.handle(),
         static_cast<UA_TimestampsToReturn>(parameters.timestamps),
         detail::createMonitoredItemCreateRequest(itemToMonitor, monitoringMode, parameters),
@@ -161,7 +161,7 @@ Result<uint32_t> createMonitoredItemDataChange<Server>(
         context->dataChangeCallbackNativeServer
     );
     storeMonitoredItemContext(connection, 0U, result, context);
-    return detail::getMonitoredItemId(result);
+    return result;
 }
 
 CreateMonitoredItemsResponse createMonitoredItemsEvent(
@@ -192,7 +192,7 @@ CreateMonitoredItemsResponse createMonitoredItemsEvent(
     return response;
 }
 
-Result<uint32_t> createMonitoredItemEvent(
+MonitoredItemCreateResult createMonitoredItemEvent(
     Client& connection,
     uint32_t subscriptionId,
     const ReadValueId& itemToMonitor,
@@ -204,7 +204,7 @@ Result<uint32_t> createMonitoredItemEvent(
     auto context = createMonitoredItemContext(
         connection, itemToMonitor, {}, std::move(eventCallback), std::move(deleteCallback)
     );
-    const MonitoredItemCreateResult result = UA_Client_MonitoredItems_createEvent(
+    MonitoredItemCreateResult result = UA_Client_MonitoredItems_createEvent(
         connection.handle(),
         subscriptionId,
         static_cast<UA_TimestampsToReturn>(parameters.timestamps),
@@ -214,7 +214,7 @@ Result<uint32_t> createMonitoredItemEvent(
         context->deleteCallbackNative
     );
     storeMonitoredItemContext(connection, subscriptionId, result, context);
-    return detail::getMonitoredItemId(result);
+    return result;
 }
 
 ModifyMonitoredItemsResponse modifyMonitoredItems(


### PR DESCRIPTION
Return `MonitoredItemCreateResult` from `services::createMonitoredItemDataChange`/`services::createMonitoredItemEvent` to allow further diagnostics like checking the revised parameters.

```cpp
const auto result = services::createMonitoredItemDataChange(/* ... */);

result.getStatusCode().throwIfBad();  // check status code
result.getMonitoredItemId();
result.getRevisedSamplingInterval();
result.getRevisedQueueSize();
// ...
```