### PR TITLE
feat!: return MonitoredItemModifyResult from services::modifyMonitoredItem

### DIFF
--- a/include/open62541pp/monitoreditem.hpp
+++ b/include/open62541pp/monitoreditem.hpp
@@ -67,15 +67,19 @@ public:
     /// @note Not implemented for Server.
     /// @see services::modifyMonitoredItem
     void setMonitoringParameters(const MonitoringParametersEx& parameters) {
-        services::modifyMonitoredItem(connection(), subscriptionId(), monitoredItemId(), parameters)
-            .value();
+        const auto result = services::modifyMonitoredItem(
+            connection(), subscriptionId(), monitoredItemId(), parameters
+        );
+        result.getStatusCode().throwIfBad();
     }
 
     /// Set the monitoring mode of this monitored item.
     /// @note Not implemented for Server.
     /// @see services::setMonitoringMode
     void setMonitoringMode(MonitoringMode monitoringMode) {
-        services::setMonitoringMode(connection(), subscriptionId(), monitoredItemId(), monitoringMode)
+        services::setMonitoringMode(
+            connection(), subscriptionId(), monitoredItemId(), monitoringMode
+        )
             .value();
     }
 

--- a/include/open62541pp/services/monitoreditem.hpp
+++ b/include/open62541pp/services/monitoreditem.hpp
@@ -206,7 +206,7 @@ ModifyMonitoredItemsResponse modifyMonitoredItems(
  * @param monitoredItemId Identifier of the monitored item
  * @param parameters Monitoring parameters
  */
-Result<void> modifyMonitoredItem(
+MonitoredItemModifyResult modifyMonitoredItem(
     Client& connection,
     uint32_t subscriptionId,
     uint32_t monitoredItemId,

--- a/src/services_monitoreditem.cpp
+++ b/src/services_monitoreditem.cpp
@@ -223,7 +223,7 @@ ModifyMonitoredItemsResponse modifyMonitoredItems(
     return UA_Client_MonitoredItems_modify(connection.handle(), request);
 }
 
-Result<void> modifyMonitoredItem(
+MonitoredItemModifyResult modifyMonitoredItem(
     Client& connection,
     uint32_t subscriptionId,
     uint32_t monitoredItemId,
@@ -231,13 +231,10 @@ Result<void> modifyMonitoredItem(
 ) noexcept {
     auto item = detail::createMonitoredItemModifyRequest(monitoredItemId, parameters);
     auto request = detail::createModifyMonitoredItemsRequest(subscriptionId, parameters, item);
-    const ModifyMonitoredItemsResponse response = UA_Client_MonitoredItems_modify(
-        connection.handle(), request
+    auto response = modifyMonitoredItems(
+        connection, asWrapper<ModifyMonitoredItemsRequest>(request)
     );
-    return detail::getSingleResult(asNative(response))
-        .andThen([&](UA_MonitoredItemModifyResult& result) {
-            return detail::toResult(result.statusCode);
-        });
+    return detail::wrapSingleResultWithStatus<MonitoredItemModifyResult>(asNative(response));
 }
 
 SetMonitoringModeResponse setMonitoringMode(

--- a/tests/services_monitoreditem.cpp
+++ b/tests/services_monitoreditem.cpp
@@ -162,7 +162,8 @@ TEST_CASE("MonitoredItem service set (client)") {
 
         services::MonitoringParametersEx modifiedParameters{};
         modifiedParameters.samplingInterval = 1000.0;
-        CHECK(services::modifyMonitoredItem(client, subId, monId, modifiedParameters));
+        const auto result = services::modifyMonitoredItem(client, subId, monId, modifiedParameters);
+        CHECK(result.getStatusCode().isGood());
     }
 
     SUBCASE("setMonitoringMode") {


### PR DESCRIPTION
Return `MonitoredItemModifyResult ` from `services::modifyMonitoredItem` to allow further diagnostics like checking the revised parameters.

```cpp
const auto result = services::modifyMonitoredItem(/* ... */);

result.getStatusCode().throwIfBad();  // check status code
result.getRevisedSamplingInterval();
result.getRevisedQueueSize();
// ...
```