### PR TITLE
feat!: remove services::setTriggering overload

### DIFF
--- a/include/open62541pp/services/monitoreditem.hpp
+++ b/include/open62541pp/services/monitoreditem.hpp
@@ -268,25 +268,6 @@ SetTriggeringResponse setTriggering(
 ) noexcept;
 
 /**
- * Add and delete triggering links of a monitored item.
- * The triggering item and the items to report shall belong to the same subscription.
- * @note Supported since open62541 v1.2
- *
- * @param connection Instance of type Client
- * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
- * @param triggeringItemId Identifier of the triggering monitored item
- * @param linksToAdd List of monitoring item identifiers to be added as triggering links
- * @param linksToRemove List of monitoring item identifiers to be removed as triggering links
- */
-Result<void> setTriggering(
-    Client& connection,
-    uint32_t subscriptionId,
-    uint32_t triggeringItemId,
-    Span<const uint32_t> linksToAdd,
-    Span<const uint32_t> linksToRemove
-) noexcept;
-
-/**
  * @}
  * @defgroup DeleteMonitoredItems DeleteMonitoredItems service
  * Delete a monitored items from subscriptions.

--- a/tests/services_monitoreditem.cpp
+++ b/tests/services_monitoreditem.cpp
@@ -213,14 +213,19 @@ TEST_CASE("MonitoredItem service set (client)") {
         CHECK(notificationCountTriggering > 0);
         CHECK(notificationCount == 0);  // no triggering links yet
 
-        auto result = services::setTriggering(
+        const auto response = services::setTriggering(
             client,
-            subId,
-            monIdTriggering,
-            {monId},  // links to add
-            {}  // links to remove
+            SetTriggeringRequest(
+                {},
+                subId,
+                monIdTriggering,
+                {monId},  // links to add
+                {}  // links to remove
+            )
         );
-        CHECK(result);
+        CHECK(response.getResponseHeader().getServiceResult().isGood());
+        CHECK(response.getAddResults().size() == 1);
+        CHECK(response.getAddResults()[0].isGood());
 
         client.runIterate();
 #if UAPP_OPEN62541_VER_LE(1, 3)


### PR DESCRIPTION
Has no benefit, just use `services::setTriggering` with a `SetTriggeringRequest` instead.