### PR TITLE
feat!: return BrowseResult from browse/browseNext overloads

### DIFF
--- a/include/open62541pp/services/view.hpp
+++ b/include/open62541pp/services/view.hpp
@@ -70,15 +70,15 @@ auto browseAsync(
  * @param maxReferences The maximum number of references to return (0 if no limit)
  */
 template <typename T>
-Result<BrowseResult> browse(
+BrowseResult browse(
     T& connection, const BrowseDescription& bd, uint32_t maxReferences = 0
 ) noexcept;
 
 /**
  * Asynchronously discover the references of a specified node.
  * @copydetails browse(T&, const BrowseDescription&, uint32_t)
- * @param token @completiontoken{void(Result<BrowseResult>&)}
- * @return @asyncresult{Result<BrowseResult>}
+ * @param token @completiontoken{void(BrowseResult&)}
+ * @return @asyncresult{BrowseResult}
  */
 template <typename CompletionToken = DefaultCompletionToken>
 auto browseAsync(
@@ -91,7 +91,7 @@ auto browseAsync(
         connection,
         detail::createBrowseRequest(bd, maxReferences),
         [](UA_BrowseResponse& response) {
-            return detail::getSingleResult(response).transform(detail::Wrap<BrowseResult>{});
+            return detail::wrapSingleResultWithStatus<BrowseResult>(response);
         },
         std::forward<CompletionToken>(token)
     );
@@ -143,15 +143,15 @@ auto browseNextAsync(
  * @param continuationPoint Continuation point from a preview browse/browseNext request
  */
 template <typename T>
-Result<BrowseResult> browseNext(
+BrowseResult browseNext(
     T& connection, bool releaseContinuationPoint, const ByteString& continuationPoint
 ) noexcept;
 
 /**
  * Asynchronously request the next set of a @ref browse or @ref browseNext response.
  * @copydetails browseNext(T&, bool, const ByteString&)
- * @param token @completiontoken{void(Result<BrowseResult>&)}
- * @return @asyncresult{Result<BrowseResult>}
+ * @param token @completiontoken{void(BrowseResult&)}
+ * @return @asyncresult{BrowseResult}
  */
 template <typename CompletionToken = DefaultCompletionToken>
 auto browseNextAsync(
@@ -164,7 +164,7 @@ auto browseNextAsync(
         connection,
         detail::createBrowseNextRequest(releaseContinuationPoint, continuationPoint),
         [](UA_BrowseNextResponse& response) {
-            return detail::getSingleResult(response).transform(detail::Wrap<BrowseResult>{});
+            return detail::wrapSingleResultWithStatus<BrowseResult>(response);
         },
         std::forward<CompletionToken>(token)
     );

--- a/src/services_view.cpp
+++ b/src/services_view.cpp
@@ -15,14 +15,14 @@ BrowseResponse browse(Client& connection, const BrowseRequest& request) noexcept
 }
 
 template <>
-Result<BrowseResult> browse<Server>(
+BrowseResult browse<Server>(
     Server& connection, const BrowseDescription& bd, uint32_t maxReferences
 ) noexcept {
-    return {UA_Server_browse(connection.handle(), maxReferences, bd.handle())};
+    return UA_Server_browse(connection.handle(), maxReferences, bd.handle());
 }
 
 template <>
-Result<BrowseResult> browse<Client>(
+BrowseResult browse<Client>(
     Client& connection, const BrowseDescription& bd, uint32_t maxReferences
 ) noexcept {
     return browseAsync(connection, bd, maxReferences, detail::SyncOperation{});
@@ -33,16 +33,16 @@ BrowseNextResponse browseNext(Client& connection, const BrowseNextRequest& reque
 }
 
 template <>
-Result<BrowseResult> browseNext<Server>(
+BrowseResult browseNext<Server>(
     Server& connection, bool releaseContinuationPoint, const ByteString& continuationPoint
 ) noexcept {
-    return {UA_Server_browseNext(
+    return UA_Server_browseNext(
         connection.handle(), releaseContinuationPoint, continuationPoint.handle()
-    )};
+    );
 }
 
 template <>
-Result<BrowseResult> browseNext<Client>(
+BrowseResult browseNext<Client>(
     Client& connection, bool releaseContinuationPoint, const ByteString& continuationPoint
 ) noexcept {
     return browseNextAsync(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(
     services_monitoreditem.cpp
     services_nodemanagement.cpp
     services_subscription.cpp
+    services_view.cpp
     session.cpp
     span.cpp
     string_utils.cpp


### PR DESCRIPTION
Return `BrowseResult` instead of `Result<BrowseResult>` from `services::browse`/`services::browseNext` overloads.