### PR TITLE
feat!: return BrowsePathResult from translateBrowsePathToNodeIds/browseSimplifiedBrowsePath overloads

### DIFF
--- a/include/open62541pp/node.hpp
+++ b/include/open62541pp/node.hpp
@@ -299,7 +299,7 @@ public:
     /// The relative path is specified using browse names.
     /// @exception BadStatus (BadNoMatch) If path not found
     Node browseChild(Span<const QualifiedName> path) {
-        auto result = services::browseSimplifiedBrowsePath(connection(), id(), path).value();
+        auto result = services::browseSimplifiedBrowsePath(connection(), id(), path);
         for (auto&& target : result.getTargets()) {
             if (target.getTargetId().isLocal()) {
                 return {connection(), std::move(target.getTargetId().getNodeId())};
@@ -627,11 +627,10 @@ public:
 
 private:
     Node browseObjectProperty(const QualifiedName& propertyName) {
-        auto result =
-            services::translateBrowsePathToNodeIds(
-                connection(),
-                BrowsePath(id(), {{ReferenceTypeId::HasProperty, false, true, propertyName}})
-            ).value();
+        auto result = services::translateBrowsePathToNodeIds(
+            connection(),
+            BrowsePath(id(), {{ReferenceTypeId::HasProperty, false, true, propertyName}})
+        );
         result.getStatusCode().throwIfBad();
         for (auto&& target : result.getTargets()) {
             if (target.getTargetId().isLocal()) {

--- a/include/open62541pp/services/view.hpp
+++ b/include/open62541pp/services/view.hpp
@@ -217,15 +217,15 @@ auto translateBrowsePathsToNodeIdsAsync(
  * @param browsePath Browse path (starting node & relative path)
  */
 template <typename T>
-Result<BrowsePathResult> translateBrowsePathToNodeIds(
+BrowsePathResult translateBrowsePathToNodeIds(
     T& connection, const BrowsePath& browsePath
 ) noexcept;
 
 /**
  * Asynchronously translate a browse path to NodeIds.
  * @copydetails translateBrowsePathToNodeIds
- * @param token @completiontoken{void(Result<BrowsePathResult>&)}
- * @return @asyncresult{Result<BrowsePathResult>}
+ * @param token @completiontoken{void(BrowsePathResult&)}
+ * @return @asyncresult{BrowsePathResult}
  */
 template <typename CompletionToken = DefaultCompletionToken>
 auto translateBrowsePathToNodeIdsAsync(
@@ -239,7 +239,7 @@ auto translateBrowsePathToNodeIdsAsync(
         connection,
         detail::createTranslateBrowsePathsToNodeIdsRequest(browsePath),
         [](UA_TranslateBrowsePathsToNodeIdsResponse& response) {
-            return detail::getSingleResult(response).transform(detail::Wrap<BrowsePathResult>{});
+            return detail::wrapSingleResultWithStatus<BrowsePathResult>(response);
         },
         std::forward<CompletionToken>(token)
     );
@@ -257,7 +257,7 @@ auto translateBrowsePathToNodeIdsAsync(
  * @param browsePath Browse path as a list of browse names
  */
 template <typename T>
-inline Result<BrowsePathResult> browseSimplifiedBrowsePath(
+inline BrowsePathResult browseSimplifiedBrowsePath(
     T& connection, const NodeId& origin, Span<const QualifiedName> browsePath
 ) {
     return translateBrowsePathToNodeIds(connection, detail::createBrowsePath(origin, browsePath));
@@ -266,8 +266,8 @@ inline Result<BrowsePathResult> browseSimplifiedBrowsePath(
 /**
  * A simplified version of @ref translateBrowsePathToNodeIdsAsync.
  * @copydetails browseSimplifiedBrowsePath
- * @param token @completiontoken{void(Result<BrowsePathResult>&)}
- * @return @asyncresult{Result<BrowsePathResult>}
+ * @param token @completiontoken{void(BrowsePathResult&)}
+ * @return @asyncresult{BrowsePathResult}
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto browseSimplifiedBrowsePathAsync(

--- a/src/services_view.cpp
+++ b/src/services_view.cpp
@@ -57,14 +57,14 @@ TranslateBrowsePathsToNodeIdsResponse translateBrowsePathsToNodeIds(
 }
 
 template <>
-Result<BrowsePathResult> translateBrowsePathToNodeIds<Server>(
+BrowsePathResult translateBrowsePathToNodeIds<Server>(
     Server& connection, const BrowsePath& browsePath
 ) noexcept {
-    return {UA_Server_translateBrowsePathToNodeIds(connection.handle(), browsePath.handle())};
+    return UA_Server_translateBrowsePathToNodeIds(connection.handle(), browsePath.handle());
 }
 
 template <>
-Result<BrowsePathResult> translateBrowsePathToNodeIds<Client>(
+BrowsePathResult translateBrowsePathToNodeIds<Client>(
     Client& connection, const BrowsePath& browsePath
 ) noexcept {
     return translateBrowsePathToNodeIdsAsync(connection, browsePath, detail::SyncOperation{});

--- a/tests/services_view.cpp
+++ b/tests/services_view.cpp
@@ -116,7 +116,7 @@ TEST_CASE_TEMPLATE("View service set", T, Server, Client, Async<Client>) {
     }
 
     SUBCASE("browseSimplifiedBrowsePath") {
-        Result<BrowsePathResult> result;
+        BrowsePathResult result;
         if constexpr (isAsync<T>) {
             auto future = services::browseSimplifiedBrowsePathAsync(
                 connection, {0, UA_NS0ID_ROOTFOLDER}, {{0, "Objects"}, {1, "Variable"}}
@@ -128,13 +128,12 @@ TEST_CASE_TEMPLATE("View service set", T, Server, Client, Async<Client>) {
                 connection, {0, UA_NS0ID_ROOTFOLDER}, {{0, "Objects"}, {1, "Variable"}}
             );
         }
-        CHECK(result.value().getStatusCode().isGood());
-        const auto targets = result.value().getTargets();
-        CHECK(targets.size() == 1);
+        CHECK(result.getStatusCode().isGood());
+        CHECK(result.getTargets().size() == 1);
         // https://reference.opcfoundation.org/Core/Part4/v105/docs/5.8
         // value shall be equal to the maximum value of uint32 if all elements processed
-        CHECK(targets[0].getRemainingPathIndex() == 0xffffffff);
-        CHECK(targets[0].getTargetId().getNodeId() == id);
+        CHECK(result.getTargets()[0].getRemainingPathIndex() == 0xffffffff);
+        CHECK(result.getTargets()[0].getTargetId().getNodeId() == id);
     }
 
     SUBCASE("Register/unregister nodes") {


### PR DESCRIPTION
Return `BrowsePathResult` instead of `Result<BrowsePathResult>` from `services::translateBrowsePathToNodeIds`/`services::browseSimplifiedBrowsePath` overloads.