### PR TITLE
feat!: return StatusCode instead of Result<void>

### DIFF
--- a/include/open62541pp/monitoreditem.hpp
+++ b/include/open62541pp/monitoreditem.hpp
@@ -67,10 +67,9 @@ public:
     /// @note Not implemented for Server.
     /// @see services::modifyMonitoredItem
     void setMonitoringParameters(const MonitoringParametersEx& parameters) {
-        const auto result = services::modifyMonitoredItem(
-            connection(), subscriptionId(), monitoredItemId(), parameters
-        );
-        result.getStatusCode().throwIfBad();
+        services::modifyMonitoredItem(connection(), subscriptionId(), monitoredItemId(), parameters)
+            .getStatusCode()
+            .throwIfBad();
     }
 
     /// Set the monitoring mode of this monitored item.
@@ -80,13 +79,14 @@ public:
         services::setMonitoringMode(
             connection(), subscriptionId(), monitoredItemId(), monitoringMode
         )
-            .value();
+            .throwIfBad();
     }
 
     /// Delete this monitored item.
     /// @see services::deleteMonitoredItem
     void deleteMonitoredItem() {
-        services::deleteMonitoredItem(connection(), subscriptionId(), monitoredItemId()).value();
+        services::deleteMonitoredItem(connection(), subscriptionId(), monitoredItemId())
+            .throwIfBad();
     }
 
 private:

--- a/include/open62541pp/node.hpp
+++ b/include/open62541pp/node.hpp
@@ -214,19 +214,19 @@ public:
 
     /// @wrapper{services::addReference}
     Node& addReference(const NodeId& targetId, const NodeId& referenceType, bool forward = true) {
-        services::addReference(connection(), id(), targetId, referenceType, forward).value();
+        services::addReference(connection(), id(), targetId, referenceType, forward).throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::addModellingRule}
     Node& addModellingRule(ModellingRule rule) {
-        services::addModellingRule(connection(), id(), rule).value();
+        services::addModellingRule(connection(), id(), rule).throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::deleteNode}
     void deleteNode(bool deleteReferences = true) {
-        services::deleteNode(connection(), id(), deleteReferences).value();
+        services::deleteNode(connection(), id(), deleteReferences).throwIfBad();
     }
 
     /// @wrapper{services::deleteReference}
@@ -239,7 +239,7 @@ public:
         services::deleteReference(
             connection(), id(), targetId, referenceType, isForward, deleteBidirectional
         )
-            .value();
+            .throwIfBad();
         return *this;
     }
 
@@ -469,67 +469,67 @@ public:
 
     /// @wrapper{services::writeDisplayName}
     Node& writeDisplayName(const LocalizedText& name) {
-        services::writeDisplayName(connection(), id(), name).value();
+        services::writeDisplayName(connection(), id(), name).throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeDescription}
     Node& writeDescription(const LocalizedText& desc) {
-        services::writeDescription(connection(), id(), desc).value();
+        services::writeDescription(connection(), id(), desc).throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeWriteMask}
     Node& writeWriteMask(Bitmask<WriteMask> mask) {
-        services::writeWriteMask(connection(), id(), mask).value();
+        services::writeWriteMask(connection(), id(), mask).throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeWriteMask}
     Node& writeUserWriteMask(Bitmask<WriteMask> mask) {
-        services::writeUserWriteMask(connection(), id(), mask).value();
+        services::writeUserWriteMask(connection(), id(), mask).throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeIsAbstract}
     Node& writeIsAbstract(bool isAbstract) {
-        services::writeIsAbstract(connection(), id(), isAbstract).value();
+        services::writeIsAbstract(connection(), id(), isAbstract).throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeSymmetric}
     Node& writeSymmetric(bool symmetric) {
-        services::writeSymmetric(connection(), id(), symmetric).value();
+        services::writeSymmetric(connection(), id(), symmetric).throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeInverseName}
     Node& writeInverseName(const LocalizedText& name) {
-        services::writeInverseName(connection(), id(), name).value();
+        services::writeInverseName(connection(), id(), name).throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeContainsNoLoops}
     Node& writeContainsNoLoops(bool containsNoLoops) {
-        services::writeContainsNoLoops(connection(), id(), containsNoLoops).value();
+        services::writeContainsNoLoops(connection(), id(), containsNoLoops).throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeEventNotifier}
     Node& writeEventNotifier(Bitmask<EventNotifier> mask) {
-        services::writeEventNotifier(connection(), id(), mask).value();
+        services::writeEventNotifier(connection(), id(), mask).throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeDataValue}
     Node& writeDataValue(const DataValue& value) {
-        services::writeDataValue(connection(), id(), value).value();
+        services::writeDataValue(connection(), id(), value).throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeValue}
     Node& writeValue(const Variant& value) {
-        services::writeValue(connection(), id(), value).value();
+        services::writeValue(connection(), id(), value).throwIfBad();
         return *this;
     }
 
@@ -559,7 +559,7 @@ public:
 
     /// @wrapper{services::writeDataType}
     Node& writeDataType(const NodeId& typeId) {
-        services::writeDataType(connection(), id(), typeId).value();
+        services::writeDataType(connection(), id(), typeId).throwIfBad();
         return *this;
     }
 
@@ -572,49 +572,49 @@ public:
 
     /// @wrapper{services::writeValueRank}
     Node& writeValueRank(ValueRank valueRank) {
-        services::writeValueRank(connection(), id(), valueRank).value();
+        services::writeValueRank(connection(), id(), valueRank).throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeArrayDimensions}
     Node& writeArrayDimensions(Span<const uint32_t> dimensions) {
-        services::writeArrayDimensions(connection(), id(), dimensions).value();
+        services::writeArrayDimensions(connection(), id(), dimensions).throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeAccessLevel}
     Node& writeAccessLevel(Bitmask<AccessLevel> mask) {
-        services::writeAccessLevel(connection(), id(), mask).value();
+        services::writeAccessLevel(connection(), id(), mask).throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeUserAccessLevel}
     Node& writeUserAccessLevel(Bitmask<AccessLevel> mask) {
-        services::writeUserAccessLevel(connection(), id(), mask).value();
+        services::writeUserAccessLevel(connection(), id(), mask).throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeMinimumSamplingInterval}
     Node& writeMinimumSamplingInterval(double milliseconds) {
-        services::writeMinimumSamplingInterval(connection(), id(), milliseconds).value();
+        services::writeMinimumSamplingInterval(connection(), id(), milliseconds).throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeHistorizing}
     Node& writeHistorizing(bool historizing) {
-        services::writeHistorizing(connection(), id(), historizing).value();
+        services::writeHistorizing(connection(), id(), historizing).throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeExecutable}
     Node& writeExecutable(bool executable) {
-        services::writeExecutable(connection(), id(), executable).value();
+        services::writeExecutable(connection(), id(), executable).throwIfBad();
         return *this;
     }
 
     /// @wrapper{services::writeUserExecutable}
     Node& writeUserExecutable(bool userExecutable) {
-        services::writeUserExecutable(connection(), id(), userExecutable).value();
+        services::writeUserExecutable(connection(), id(), userExecutable).throwIfBad();
         return *this;
     }
 

--- a/include/open62541pp/services/attribute_highlevel.hpp
+++ b/include/open62541pp/services/attribute_highlevel.hpp
@@ -97,7 +97,7 @@ inline auto readBrowseNameAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeBrowseName(
+inline StatusCode writeBrowseName(
     T& connection, const NodeId& id, const QualifiedName& browseName
 ) noexcept {
     return detail::writeAttributeImpl<AttributeId::BrowseName>(connection, id, browseName);
@@ -106,8 +106,8 @@ inline Result<void> writeBrowseName(
 /**
  * Asynchronously write the AttributeId::BrowseName attribute of a node.
  * @copydetails writeBrowseName
- * @param token @completiontoken{void(Result<void>)}
- * @return @asyncresult{Result<void>}
+ * @param token @completiontoken{void(StatusCode)}
+ * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
 template <typename CompletionToken = DefaultCompletionToken>
@@ -157,7 +157,7 @@ inline auto readDisplayNameAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeDisplayName(
+inline StatusCode writeDisplayName(
     T& connection, const NodeId& id, const LocalizedText& displayName
 ) noexcept {
     return detail::writeAttributeImpl<AttributeId::DisplayName>(connection, id, displayName);
@@ -166,8 +166,8 @@ inline Result<void> writeDisplayName(
 /**
  * Asynchronously write the AttributeId::DisplayName attribute of a node.
  * @copydetails writeDisplayName
- * @param token @completiontoken{void(Result<void>)}
- * @return @asyncresult{Result<void>}
+ * @param token @completiontoken{void(StatusCode)}
+ * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
 template <typename CompletionToken = DefaultCompletionToken>
@@ -217,7 +217,7 @@ inline auto readDescriptionAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeDescription(
+inline StatusCode writeDescription(
     T& connection, const NodeId& id, const LocalizedText& description
 ) noexcept {
     return detail::writeAttributeImpl<AttributeId::Description>(connection, id, description);
@@ -226,8 +226,8 @@ inline Result<void> writeDescription(
 /**
  * Asynchronously write the AttributeId::Description attribute of a node.
  * @copydetails writeDescription
- * @param token @completiontoken{void(Result<void>)}
- * @return @asyncresult{Result<void>}
+ * @param token @completiontoken{void(StatusCode)}
+ * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
 template <typename CompletionToken = DefaultCompletionToken>
@@ -277,7 +277,7 @@ inline auto readWriteMaskAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeWriteMask(
+inline StatusCode writeWriteMask(
     T& connection, const NodeId& id, Bitmask<WriteMask> writeMask
 ) noexcept {
     return detail::writeAttributeImpl<AttributeId::WriteMask>(connection, id, writeMask);
@@ -286,8 +286,8 @@ inline Result<void> writeWriteMask(
 /**
  * Asynchronously write the AttributeId::WriteMask attribute of a node.
  * @copydetails writeWriteMask
- * @param token @completiontoken{void(Result<void>)}
- * @return @asyncresult{Result<void>}
+ * @param token @completiontoken{void(StatusCode)}
+ * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
 template <typename CompletionToken = DefaultCompletionToken>
@@ -337,7 +337,7 @@ inline auto readUserWriteMaskAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeUserWriteMask(
+inline StatusCode writeUserWriteMask(
     T& connection, const NodeId& id, Bitmask<WriteMask> userWriteMask
 ) noexcept {
     return detail::writeAttributeImpl<AttributeId::UserWriteMask>(connection, id, userWriteMask);
@@ -346,8 +346,8 @@ inline Result<void> writeUserWriteMask(
 /**
  * Asynchronously write the AttributeId::UserWriteMask attribute of a node.
  * @copydetails writeUserWriteMask
- * @param token @completiontoken{void(Result<void>)}
- * @return @asyncresult{Result<void>}
+ * @param token @completiontoken{void(StatusCode)}
+ * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
 template <typename CompletionToken = DefaultCompletionToken>
@@ -397,15 +397,15 @@ inline auto readIsAbstractAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeIsAbstract(T& connection, const NodeId& id, bool isAbstract) noexcept {
+inline StatusCode writeIsAbstract(T& connection, const NodeId& id, bool isAbstract) noexcept {
     return detail::writeAttributeImpl<AttributeId::IsAbstract>(connection, id, isAbstract);
 }
 
 /**
  * Asynchronously write the AttributeId::IsAbstract attribute of a node.
  * @copydetails writeIsAbstract
- * @param token @completiontoken{void(Result<void>)}
- * @return @asyncresult{Result<void>}
+ * @param token @completiontoken{void(StatusCode)}
+ * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
 template <typename CompletionToken = DefaultCompletionToken>
@@ -455,15 +455,15 @@ inline auto readSymmetricAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeSymmetric(T& connection, const NodeId& id, bool symmetric) noexcept {
+inline StatusCode writeSymmetric(T& connection, const NodeId& id, bool symmetric) noexcept {
     return detail::writeAttributeImpl<AttributeId::Symmetric>(connection, id, symmetric);
 }
 
 /**
  * Asynchronously write the AttributeId::Symmetric attribute of a node.
  * @copydetails writeSymmetric
- * @param token @completiontoken{void(Result<void>)}
- * @return @asyncresult{Result<void>}
+ * @param token @completiontoken{void(StatusCode)}
+ * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
 template <typename CompletionToken = DefaultCompletionToken>
@@ -513,7 +513,7 @@ inline auto readInverseNameAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeInverseName(
+inline StatusCode writeInverseName(
     T& connection, const NodeId& id, const LocalizedText& inverseName
 ) noexcept {
     return detail::writeAttributeImpl<AttributeId::InverseName>(connection, id, inverseName);
@@ -522,8 +522,8 @@ inline Result<void> writeInverseName(
 /**
  * Asynchronously write the AttributeId::InverseName attribute of a node.
  * @copydetails writeInverseName
- * @param token @completiontoken{void(Result<void>)}
- * @return @asyncresult{Result<void>}
+ * @param token @completiontoken{void(StatusCode)}
+ * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
 template <typename CompletionToken = DefaultCompletionToken>
@@ -573,7 +573,7 @@ inline auto readContainsNoLoopsAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeContainsNoLoops(
+inline StatusCode writeContainsNoLoops(
     T& connection, const NodeId& id, const bool& containsNoLoops
 ) noexcept {
     return detail::writeAttributeImpl<AttributeId::ContainsNoLoops>(
@@ -584,8 +584,8 @@ inline Result<void> writeContainsNoLoops(
 /**
  * Asynchronously write the AttributeId::ContainsNoLoops attribute of a node.
  * @copydetails writeContainsNoLoops
- * @param token @completiontoken{void(Result<void>)}
- * @return @asyncresult{Result<void>}
+ * @param token @completiontoken{void(StatusCode)}
+ * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
 template <typename CompletionToken = DefaultCompletionToken>
@@ -635,7 +635,7 @@ inline auto readEventNotifierAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeEventNotifier(
+inline StatusCode writeEventNotifier(
     T& connection, const NodeId& id, Bitmask<EventNotifier> eventNotifier
 ) noexcept {
     return detail::writeAttributeImpl<AttributeId::EventNotifier>(connection, id, eventNotifier);
@@ -644,8 +644,8 @@ inline Result<void> writeEventNotifier(
 /**
  * Asynchronously write the AttributeId::EventNotifier attribute of a node.
  * @copydetails writeEventNotifier
- * @param token @completiontoken{void(Result<void>)}
- * @return @asyncresult{Result<void>}
+ * @param token @completiontoken{void(StatusCode)}
+ * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
 template <typename CompletionToken = DefaultCompletionToken>
@@ -695,15 +695,15 @@ inline auto readValueAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeValue(T& connection, const NodeId& id, const Variant& value) noexcept {
+inline StatusCode writeValue(T& connection, const NodeId& id, const Variant& value) noexcept {
     return detail::writeAttributeImpl<AttributeId::Value>(connection, id, value);
 }
 
 /**
  * Asynchronously write the AttributeId::Value attribute of a node.
  * @copydetails writeValue
- * @param token @completiontoken{void(Result<void>)}
- * @return @asyncresult{Result<void>}
+ * @param token @completiontoken{void(StatusCode)}
+ * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
 template <typename CompletionToken = DefaultCompletionToken>
@@ -753,17 +753,15 @@ inline auto readDataTypeAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeDataType(
-    T& connection, const NodeId& id, const NodeId& dataType
-) noexcept {
+inline StatusCode writeDataType(T& connection, const NodeId& id, const NodeId& dataType) noexcept {
     return detail::writeAttributeImpl<AttributeId::DataType>(connection, id, dataType);
 }
 
 /**
  * Asynchronously write the AttributeId::DataType attribute of a node.
  * @copydetails writeDataType
- * @param token @completiontoken{void(Result<void>)}
- * @return @asyncresult{Result<void>}
+ * @param token @completiontoken{void(StatusCode)}
+ * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
 template <typename CompletionToken = DefaultCompletionToken>
@@ -813,15 +811,15 @@ inline auto readValueRankAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeValueRank(T& connection, const NodeId& id, ValueRank valueRank) noexcept {
+inline StatusCode writeValueRank(T& connection, const NodeId& id, ValueRank valueRank) noexcept {
     return detail::writeAttributeImpl<AttributeId::ValueRank>(connection, id, valueRank);
 }
 
 /**
  * Asynchronously write the AttributeId::ValueRank attribute of a node.
  * @copydetails writeValueRank
- * @param token @completiontoken{void(Result<void>)}
- * @return @asyncresult{Result<void>}
+ * @param token @completiontoken{void(StatusCode)}
+ * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
 template <typename CompletionToken = DefaultCompletionToken>
@@ -871,7 +869,7 @@ inline auto readArrayDimensionsAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeArrayDimensions(
+inline StatusCode writeArrayDimensions(
     T& connection, const NodeId& id, Span<const uint32_t> arrayDimensions
 ) noexcept {
     return detail::writeAttributeImpl<AttributeId::ArrayDimensions>(
@@ -882,8 +880,8 @@ inline Result<void> writeArrayDimensions(
 /**
  * Asynchronously write the AttributeId::ArrayDimensions attribute of a node.
  * @copydetails writeArrayDimensions
- * @param token @completiontoken{void(Result<void>)}
- * @return @asyncresult{Result<void>}
+ * @param token @completiontoken{void(StatusCode)}
+ * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
 template <typename CompletionToken = DefaultCompletionToken>
@@ -933,7 +931,7 @@ inline auto readAccessLevelAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeAccessLevel(
+inline StatusCode writeAccessLevel(
     T& connection, const NodeId& id, Bitmask<AccessLevel> accessLevel
 ) noexcept {
     return detail::writeAttributeImpl<AttributeId::AccessLevel>(connection, id, accessLevel);
@@ -942,8 +940,8 @@ inline Result<void> writeAccessLevel(
 /**
  * Asynchronously write the AttributeId::AccessLevel attribute of a node.
  * @copydetails writeAccessLevel
- * @param token @completiontoken{void(Result<void>)}
- * @return @asyncresult{Result<void>}
+ * @param token @completiontoken{void(StatusCode)}
+ * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
 template <typename CompletionToken = DefaultCompletionToken>
@@ -993,7 +991,7 @@ inline auto readUserAccessLevelAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeUserAccessLevel(
+inline StatusCode writeUserAccessLevel(
     T& connection, const NodeId& id, Bitmask<AccessLevel> userAccessLevel
 ) noexcept {
     return detail::writeAttributeImpl<AttributeId::UserAccessLevel>(
@@ -1004,8 +1002,8 @@ inline Result<void> writeUserAccessLevel(
 /**
  * Asynchronously write the AttributeId::UserAccessLevel attribute of a node.
  * @copydetails writeUserAccessLevel
- * @param token @completiontoken{void(Result<void>)}
- * @return @asyncresult{Result<void>}
+ * @param token @completiontoken{void(StatusCode)}
+ * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
 template <typename CompletionToken = DefaultCompletionToken>
@@ -1055,7 +1053,7 @@ inline auto readMinimumSamplingIntervalAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeMinimumSamplingInterval(
+inline StatusCode writeMinimumSamplingInterval(
     T& connection, const NodeId& id, double minimumSamplingInterval
 ) noexcept {
     return detail::writeAttributeImpl<AttributeId::MinimumSamplingInterval>(
@@ -1066,8 +1064,8 @@ inline Result<void> writeMinimumSamplingInterval(
 /**
  * Asynchronously write the AttributeId::MinimumSamplingInterval attribute of a node.
  * @copydetails writeMinimumSamplingInterval
- * @param token @completiontoken{void(Result<void>)}
- * @return @asyncresult{Result<void>}
+ * @param token @completiontoken{void(StatusCode)}
+ * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
 template <typename CompletionToken = DefaultCompletionToken>
@@ -1117,15 +1115,15 @@ inline auto readHistorizingAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeHistorizing(T& connection, const NodeId& id, bool historizing) noexcept {
+inline StatusCode writeHistorizing(T& connection, const NodeId& id, bool historizing) noexcept {
     return detail::writeAttributeImpl<AttributeId::Historizing>(connection, id, historizing);
 }
 
 /**
  * Asynchronously write the AttributeId::Historizing attribute of a node.
  * @copydetails writeHistorizing
- * @param token @completiontoken{void(Result<void>)}
- * @return @asyncresult{Result<void>}
+ * @param token @completiontoken{void(StatusCode)}
+ * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
 template <typename CompletionToken = DefaultCompletionToken>
@@ -1175,15 +1173,15 @@ inline auto readExecutableAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeExecutable(T& connection, const NodeId& id, bool executable) noexcept {
+inline StatusCode writeExecutable(T& connection, const NodeId& id, bool executable) noexcept {
     return detail::writeAttributeImpl<AttributeId::Executable>(connection, id, executable);
 }
 
 /**
  * Asynchronously write the AttributeId::Executable attribute of a node.
  * @copydetails writeExecutable
- * @param token @completiontoken{void(Result<void>)}
- * @return @asyncresult{Result<void>}
+ * @param token @completiontoken{void(StatusCode)}
+ * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
 template <typename CompletionToken = DefaultCompletionToken>
@@ -1233,7 +1231,7 @@ inline auto readUserExecutableAsync(
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> writeUserExecutable(
+inline StatusCode writeUserExecutable(
     T& connection, const NodeId& id, bool userExecutable
 ) noexcept {
     return detail::writeAttributeImpl<AttributeId::UserExecutable>(connection, id, userExecutable);
@@ -1242,8 +1240,8 @@ inline Result<void> writeUserExecutable(
 /**
  * Asynchronously write the AttributeId::UserExecutable attribute of a node.
  * @copydetails writeUserExecutable
- * @param token @completiontoken{void(Result<void>)}
- * @return @asyncresult{Result<void>}
+ * @param token @completiontoken{void(StatusCode)}
+ * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
 template <typename CompletionToken = DefaultCompletionToken>

--- a/include/open62541pp/services/detail/response_handling.hpp
+++ b/include/open62541pp/services/detail/response_handling.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>  // ref
 #include <type_traits>
 #include <utility>  // exchange
 
@@ -31,21 +32,21 @@ struct Wrap {
 };
 
 template <typename Response>
-inline const UA_ResponseHeader& getResponseHeader(const Response& response) noexcept {
+const UA_ResponseHeader& getResponseHeader(const Response& response) noexcept {
     if constexpr (opcua::detail::isWrapper<Response>) {
-        return response->responseHeader;
+        return asNative(response).responseHeader;
     } else {
         return response.responseHeader;
     }
 }
 
 template <typename Response>
-inline StatusCode getServiceResult(const Response& response) noexcept {
+StatusCode getServiceResult(const Response& response) noexcept {
     return getResponseHeader(response).serviceResult;
 }
 
 template <typename Response>
-auto getSingleResult(Response& response) noexcept -> Result<decltype(std::ref(*response.results))> {
+auto getSingleResultRef(Response& response) noexcept -> Result<decltype(std::ref(*response.results))> {
     if (const StatusCode serviceResult = getServiceResult(response); serviceResult.isBad()) {
         return BadResult(serviceResult);
     }
@@ -55,31 +56,34 @@ auto getSingleResult(Response& response) noexcept -> Result<decltype(std::ref(*r
     return std::ref(*response.results);
 }
 
+template <typename Response>
+StatusCode getSingleStatus(const Response& response) noexcept {
+    return getSingleResultRef(response)
+        .andThen([](UA_StatusCode code) -> Result<void> { return {code}; })
+        .code();
+}
+
+template <typename WrapperType, typename Response>
+Result<WrapperType> wrapSingleResult(Response& response) noexcept {
+    return getSingleResultRef(response).transform(Wrap<WrapperType>{});
+}
+
 // Get single result from response and save response status code in result type's statusCode member.
 template <typename WrapperType, typename Response>
-[[nodiscard]] auto wrapSingleResultWithStatus(Response& response) noexcept {
-    return getSingleResult(response)
-        .transform(Wrap<WrapperType>{})
-        .orElse([](UA_StatusCode& code) {
+WrapperType wrapSingleResultWithStatus(Response& response) noexcept {
+    return *wrapSingleResult<WrapperType>(response)
+        .orElse([](StatusCode code) {
             Result<WrapperType> result;
             result->handle()->statusCode = code;
             return result;
-        })
-        .value();
-}
-
-inline Result<void> toResult(UA_StatusCode code) noexcept {
-    if (opcua::detail::isBad(code)) {
-        return BadResult(code);
-    }
-    return {code};
+        });
 }
 
 inline Result<NodeId> getAddedNodeId(UA_AddNodesResult& result) noexcept {
     if (const StatusCode code = result.statusCode; code.isBad()) {
         return BadResult(code);
     }
-    return {std::exchange(result.addedNodeId, {})};
+    return Wrap<NodeId>{}(result.addedNodeId);
 }
 
 }  // namespace opcua::services::detail

--- a/include/open62541pp/services/detail/response_handling.hpp
+++ b/include/open62541pp/services/detail/response_handling.hpp
@@ -58,9 +58,8 @@ auto getSingleResultRef(Response& response) noexcept -> Result<decltype(std::ref
 
 template <typename Response>
 StatusCode getSingleStatus(const Response& response) noexcept {
-    return getSingleResultRef(response)
-        .andThen([](UA_StatusCode code) -> Result<void> { return {code}; })
-        .code();
+    auto result = getSingleResultRef(response);
+    return result ? asWrapper<StatusCode>(result->get()) : result.code();
 }
 
 template <typename WrapperType, typename Response>

--- a/include/open62541pp/services/monitoreditem.hpp
+++ b/include/open62541pp/services/monitoreditem.hpp
@@ -5,7 +5,6 @@
 
 #include "open62541pp/common.hpp"  // TimestampsToReturn, MonitoringMode
 #include "open62541pp/config.hpp"
-#include "open62541pp/result.hpp"
 #include "open62541pp/span.hpp"
 #include "open62541pp/types.hpp"
 #include "open62541pp/types_composed.hpp"
@@ -239,7 +238,7 @@ SetMonitoringModeResponse setMonitoringMode(
  * @param monitoredItemId Identifier of the monitored item
  * @param monitoringMode Monitoring mode
  */
-Result<void> setMonitoringMode(
+StatusCode setMonitoringMode(
     Client& connection,
     uint32_t subscriptionId,
     uint32_t monitoredItemId,
@@ -294,7 +293,7 @@ DeleteMonitoredItemsResponse deleteMonitoredItems(
  * @param monitoredItemId Identifier of the monitored item
  */
 template <typename T>
-Result<void> deleteMonitoredItem(T& connection, uint32_t subscriptionId, uint32_t monitoredItemId);
+StatusCode deleteMonitoredItem(T& connection, uint32_t subscriptionId, uint32_t monitoredItemId);
 
 /**
  * @}

--- a/include/open62541pp/services/nodemanagement.hpp
+++ b/include/open62541pp/services/nodemanagement.hpp
@@ -123,7 +123,7 @@ auto addNodeAsync(
         connection,
         request,
         [](UA_AddNodesResponse& response) {
-            return detail::getSingleResult(response).andThen(detail::getAddedNodeId);
+            return detail::getSingleResultRef(response).andThen(detail::getAddedNodeId);
         },
         std::forward<CompletionToken>(token)
     );
@@ -175,7 +175,7 @@ auto addReferencesAsync(
  * @param forward Create a forward reference if `true` or a inverse reference if `false`
  */
 template <typename T>
-Result<void> addReference(
+StatusCode addReference(
     T& connection,
     const NodeId& sourceId,
     const NodeId& targetId,
@@ -186,8 +186,8 @@ Result<void> addReference(
 /**
  * Asynchronously add reference.
  * @copydetails addReference
- * @param token @completiontoken{void(Result<void>)}
- * @return @asyncresult{Result<void>}
+ * @param token @completiontoken{void(StatusCode)}
+ * @return @asyncresult{StatusCode}
  */
 template <typename CompletionToken = DefaultCompletionToken>
 auto addReferenceAsync(
@@ -210,9 +210,7 @@ auto addReferenceAsync(
     return detail::sendRequest<UA_AddReferencesRequest, UA_AddReferencesResponse>(
         connection,
         request,
-        [](UA_AddReferencesResponse& response) {
-            return detail::getSingleResult(response).andThen(detail::toResult);
-        },
+        [](UA_AddReferencesResponse& response) { return detail::getSingleStatus(response); },
         std::forward<CompletionToken>(token)
     );
 }
@@ -259,13 +257,13 @@ auto deleteNodesAsync(
  * @param deleteReferences Delete references in target nodes that reference the node to delete
  */
 template <typename T>
-Result<void> deleteNode(T& connection, const NodeId& id, bool deleteReferences = true) noexcept;
+StatusCode deleteNode(T& connection, const NodeId& id, bool deleteReferences = true) noexcept;
 
 /**
  * Asynchronously delete node.
  * @copydetails deleteNode
- * @param token @completiontoken{void(Result<void>)}
- * @return @asyncresult{Result<void>}
+ * @param token @completiontoken{void(StatusCode)}
+ * @return @asyncresult{StatusCode}
  */
 template <typename CompletionToken = DefaultCompletionToken>
 auto deleteNodeAsync(
@@ -283,9 +281,7 @@ auto deleteNodeAsync(
     return detail::sendRequest<UA_DeleteNodesRequest, UA_DeleteNodesResponse>(
         connection,
         request,
-        [](UA_DeleteNodesResponse& response) {
-            return detail::getSingleResult(response).andThen(detail::toResult);
-        },
+        [](UA_DeleteNodesResponse& response) { return detail::getSingleStatus(response); },
         std::forward<CompletionToken>(token)
     );
 }
@@ -337,7 +333,7 @@ auto deleteReferencesAsync(
  * @param deleteBidirectional Delete the specified and opposite reference from the target node
  */
 template <typename T>
-Result<void> deleteReference(
+StatusCode deleteReference(
     T& connection,
     const NodeId& sourceId,
     const NodeId& targetId,
@@ -349,8 +345,8 @@ Result<void> deleteReference(
 /**
  * Asynchronously delete reference.
  * @copydetails deleteReference
- * @param token @completiontoken{void(Result<void>)}
- * @return @asyncresult{Result<void>}
+ * @param token @completiontoken{void(StatusCode)}
+ * @return @asyncresult{StatusCode}
  */
 template <typename CompletionToken = DefaultCompletionToken>
 auto deleteReferenceAsync(
@@ -374,9 +370,7 @@ auto deleteReferenceAsync(
     return detail::sendRequest<UA_DeleteReferencesRequest, UA_DeleteReferencesResponse>(
         connection,
         request,
-        [](UA_DeleteReferencesResponse& response) {
-            return detail::getSingleResult(response).andThen(detail::toResult);
-        },
+        [](UA_DeleteReferencesResponse& response) { return detail::getSingleStatus(response); },
         std::forward<CompletionToken>(token)
     );
 }
@@ -1010,7 +1004,7 @@ inline auto addViewAsync(
  * @see https://reference.opcfoundation.org/Core/Part3/v105/docs/6.4.4
  */
 template <typename T>
-inline Result<void> addModellingRule(T& connection, const NodeId& id, ModellingRule rule) noexcept {
+inline StatusCode addModellingRule(T& connection, const NodeId& id, ModellingRule rule) noexcept {
     return addReference(
         connection, id, {0, static_cast<uint32_t>(rule)}, ReferenceTypeId::HasModellingRule, true
     );
@@ -1019,8 +1013,8 @@ inline Result<void> addModellingRule(T& connection, const NodeId& id, ModellingR
 /**
  * Asynchronously add modelling rule.
  * @copydetails addModellingRule
- * @param token @completiontoken{void(Result<void>)}
- * @return @asyncresult{Result<void>}
+ * @param token @completiontoken{void(StatusCode)}
+ * @return @asyncresult{StatusCode}
  */
 template <typename CompletionToken = DefaultCompletionToken>
 inline auto addModellingRuleAsync(

--- a/include/open62541pp/services/subscription.hpp
+++ b/include/open62541pp/services/subscription.hpp
@@ -4,7 +4,6 @@
 #include <functional>
 
 #include "open62541pp/config.hpp"
-#include "open62541pp/result.hpp"
 #include "open62541pp/types_composed.hpp"  // StatusChangeNotification
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
@@ -141,9 +140,7 @@ SetPublishingModeResponse setPublishingMode(
  * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
  * @param publishing Enable/disable publishing
  */
-Result<void> setPublishingMode(
-    Client& connection, uint32_t subscriptionId, bool publishing
-) noexcept;
+StatusCode setPublishingMode(Client& connection, uint32_t subscriptionId, bool publishing) noexcept;
 
 /**
  * @}
@@ -167,7 +164,7 @@ DeleteSubscriptionsResponse deleteSubscriptions(
  * @param connection Instance of type Client
  * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
  */
-Result<void> deleteSubscription(Client& connection, uint32_t subscriptionId) noexcept;
+StatusCode deleteSubscription(Client& connection, uint32_t subscriptionId) noexcept;
 
 /**
  * @}

--- a/include/open62541pp/services/view.hpp
+++ b/include/open62541pp/services/view.hpp
@@ -382,18 +382,18 @@ Result<std::vector<ReferenceDescription>> browseAll(
             std::make_move_iterator(refsNew.end())
         );
     };
-    BrowseResult result = browse(connection, bd, maxReferences);
-    if (result.getStatusCode().isBad()) {
-        return BadResult(result.getStatusCode());
+    Result<BrowseResult> result = browse(connection, bd, maxReferences);
+    if (!result) {
+        return BadResult(result.code());
     }
-    append(result.getReferences());
-    while (!result.getContinuationPoint().empty()) {
+    append(result->getReferences());
+    while (!result.value().getContinuationPoint().empty()) {
         const bool release = (refs.size() >= maxReferences);
-        result = browseNext(connection, release, result.getContinuationPoint());
-        if (result.getStatusCode().isBad()) {
-            return BadResult(result.getStatusCode());
+        result = browseNext(connection, release, result->getContinuationPoint());
+        if (!result) {
+            return BadResult(result.code());
         }
-        append(result.getReferences());
+        append(result->getReferences());
     }
     if ((maxReferences > 0) && (refs.size() > maxReferences)) {
         refs.resize(maxReferences);

--- a/include/open62541pp/subscription.hpp
+++ b/include/open62541pp/subscription.hpp
@@ -80,7 +80,7 @@ public:
     /// @note Not implemented for Server.
     /// @see services::setPublishingMode
     void setPublishingMode(bool publishing) {
-        services::setPublishingMode(connection(), subscriptionId(), publishing).value();
+        services::setPublishingMode(connection(), subscriptionId(), publishing).throwIfBad();
     }
 
     /// Create a monitored item for data change notifications.
@@ -150,7 +150,7 @@ public:
     /// Delete this subscription.
     /// @note Not implemented for Server.
     void deleteSubscription() {
-        services::deleteSubscription(connection(), subscriptionId()).value();
+        services::deleteSubscription(connection(), subscriptionId()).throwIfBad();
     }
 
 private:

--- a/src/services_attribute.cpp
+++ b/src/services_attribute.cpp
@@ -32,15 +32,15 @@ WriteResponse write(Client& connection, const WriteRequest& request) noexcept {
 }
 
 template <>
-Result<void> writeAttribute<Server>(
+StatusCode writeAttribute<Server>(
     Server& connection, const NodeId& id, AttributeId attributeId, const DataValue& value
 ) noexcept {
     const auto item = detail::createWriteValue(id, attributeId, value);
-    return detail::toResult(UA_Server_write(connection.handle(), &item));
+    return UA_Server_write(connection.handle(), &item);
 }
 
 template <>
-Result<void> writeAttribute<Client>(
+StatusCode writeAttribute<Client>(
     Client& connection, const NodeId& id, AttributeId attributeId, const DataValue& value
 ) noexcept {
     return writeAttributeAsync(connection, id, attributeId, value, detail::SyncOperation{});

--- a/src/services_nodemanagement.cpp
+++ b/src/services_nodemanagement.cpp
@@ -132,7 +132,7 @@ Result<NodeId> addMethod(
         auto* nodeContext = opcua::detail::getContext(connection).nodeContexts[id];
         nodeContext->methodCallback = std::move(callback);
         NodeId outputNodeId;
-        const auto status = UA_Server_addMethodNode(
+        throwIfBad(UA_Server_addMethodNode(
             connection.handle(),
             id,
             parentId,
@@ -146,8 +146,7 @@ Result<NodeId> addMethod(
             asNative(outputArguments.data()),
             nodeContext,
             outputNodeId.handle()  // outNewNodeId
-        );
-        throwIfBad(status);
+        ));
         return outputNodeId;
     });
 }
@@ -180,24 +179,24 @@ Result<NodeId> addMethod(
 #endif
 
 template <>
-Result<void> addReference<Server>(
+StatusCode addReference<Server>(
     Server& connection,
     const NodeId& sourceId,
     const NodeId& targetId,
     const NodeId& referenceType,
     bool forward
 ) noexcept {
-    return detail::toResult(UA_Server_addReference(
+    return UA_Server_addReference(
         connection.handle(),
         sourceId,
         referenceType,
         {targetId, {}, 0},
         forward  // isForward
-    ));
+    );
 }
 
 template <>
-Result<void> addReference<Client>(
+StatusCode addReference<Client>(
     Client& connection,
     const NodeId& sourceId,
     const NodeId& targetId,
@@ -210,21 +209,21 @@ Result<void> addReference<Client>(
 }
 
 template <>
-Result<void> deleteNode<Server>(
+StatusCode deleteNode<Server>(
     Server& connection, const NodeId& id, bool deleteReferences
 ) noexcept {
-    return detail::toResult(UA_Server_deleteNode(connection.handle(), id, deleteReferences));
+    return UA_Server_deleteNode(connection.handle(), id, deleteReferences);
 }
 
 template <>
-Result<void> deleteNode<Client>(
+StatusCode deleteNode<Client>(
     Client& connection, const NodeId& id, bool deleteReferences
 ) noexcept {
     return deleteNodeAsync(connection, id, deleteReferences, detail::SyncOperation{});
 }
 
 template <>
-Result<void> deleteReference<Server>(
+StatusCode deleteReference<Server>(
     Server& connection,
     const NodeId& sourceId,
     const NodeId& targetId,
@@ -232,18 +231,18 @@ Result<void> deleteReference<Server>(
     bool isForward,
     bool deleteBidirectional
 ) noexcept {
-    return detail::toResult(UA_Server_deleteReference(
+    return UA_Server_deleteReference(
         connection.handle(),
         sourceId,
         referenceType,
         isForward,
         {targetId, {}, 0},
         deleteBidirectional
-    ));
+    );
 }
 
 template <>
-Result<void> deleteReference<Client>(
+StatusCode deleteReference<Client>(
     Client& connection,
     const NodeId& sourceId,
     const NodeId& targetId,

--- a/src/services_subscription.cpp
+++ b/src/services_subscription.cpp
@@ -91,7 +91,7 @@ SetPublishingModeResponse setPublishingMode(
     );
 }
 
-Result<void> setPublishingMode(
+StatusCode setPublishingMode(
     Client& connection, uint32_t subscriptionId, bool publishing
 ) noexcept {
     UA_SetPublishingModeRequest request{};
@@ -101,9 +101,7 @@ Result<void> setPublishingMode(
     return detail::sendRequest<UA_SetPublishingModeRequest, UA_SetPublishingModeResponse>(
         connection,
         request,
-        [](UA_SetPublishingModeResponse& response) {
-            return detail::getSingleResult(response).andThen(detail::toResult);
-        },
+        [](UA_SetPublishingModeResponse& response) { return detail::getSingleStatus(response); },
         detail::SyncOperation{}
     );
 }
@@ -114,14 +112,14 @@ DeleteSubscriptionsResponse deleteSubscriptions(
     return UA_Client_Subscriptions_delete(connection.handle(), request);
 }
 
-Result<void> deleteSubscription(Client& connection, uint32_t subscriptionId) noexcept {
+StatusCode deleteSubscription(Client& connection, uint32_t subscriptionId) noexcept {
     UA_DeleteSubscriptionsRequest request{};
     request.subscriptionIdsSize = 1;
     request.subscriptionIds = &subscriptionId;
     const DeleteSubscriptionsResponse response = UA_Client_Subscriptions_delete(
         connection.handle(), request
     );
-    return detail::getSingleResult(asNative(response)).andThen(detail::toResult);
+    return detail::getSingleStatus(asNative(response));
 }
 
 }  // namespace opcua::services

--- a/tests/node.cpp
+++ b/tests/node.cpp
@@ -17,8 +17,8 @@ TEST_CASE_TEMPLATE("Node", T, Server, Client) {
     const NodeId varId{1, 1};
     services::addVariable(setup.server, {0, UA_NS0ID_OBJECTSFOLDER}, varId, "variable").value();
     // set all bits to 1 -> allow all
-    services::writeAccessLevel(setup.server, varId, 0xFF).value();
-    services::writeWriteMask(setup.server, varId, 0xFFFFFFFF).value();
+    services::writeAccessLevel(setup.server, varId, 0xFF).throwIfBad();
+    services::writeWriteMask(setup.server, varId, 0xFFFFFFFF).throwIfBad();
 
     Node rootNode(connection, ObjectId::RootFolder);
     Node objNode(connection, ObjectId::ObjectsFolder);

--- a/tests/services_attribute.cpp
+++ b/tests/services_attribute.cpp
@@ -62,7 +62,7 @@ TEST_CASE("Attribute service set (highlevel)") {
 
         // write new attributes
         const auto eventNotifier = EventNotifier::HistoryRead | EventNotifier::HistoryWrite;
-        CHECK(services::writeEventNotifier(server, id, eventNotifier));
+        CHECK(services::writeEventNotifier(server, id, eventNotifier).isGood());
 
         // read new attributes
         CHECK(services::readEventNotifier(server, id).value().allOf(eventNotifier));
@@ -73,16 +73,16 @@ TEST_CASE("Attribute service set (highlevel)") {
         services::addVariable(server, objectsId, id, "TestAttributes").value();
 
         // write new attributes
-        CHECK(services::writeDisplayName(server, id, {{}, "NewDisplayName"}));
-        CHECK(services::writeDescription(server, id, {{}, "NewDescription"}));
-        CHECK(services::writeWriteMask(server, id, WriteMask::Executable));
-        CHECK(services::writeDataType(server, id, NodeId{0, 2}));
-        CHECK(services::writeValueRank(server, id, ValueRank::TwoDimensions));
-        CHECK(services::writeArrayDimensions(server, id, {3, 2}));
+        CHECK(services::writeDisplayName(server, id, {{}, "NewDisplayName"}).isGood());
+        CHECK(services::writeDescription(server, id, {{}, "NewDescription"}).isGood());
+        CHECK(services::writeWriteMask(server, id, WriteMask::Executable).isGood());
+        CHECK(services::writeDataType(server, id, NodeId{0, 2}).isGood());
+        CHECK(services::writeValueRank(server, id, ValueRank::TwoDimensions).isGood());
+        CHECK(services::writeArrayDimensions(server, id, {3, 2}).isGood());
         const auto newAccessLevel = AccessLevel::CurrentRead | AccessLevel::CurrentWrite;
-        CHECK(services::writeAccessLevel(server, id, newAccessLevel));
-        CHECK(services::writeMinimumSamplingInterval(server, id, 10.0));
-        CHECK(services::writeHistorizing(server, id, true));
+        CHECK(services::writeAccessLevel(server, id, newAccessLevel).isGood());
+        CHECK(services::writeMinimumSamplingInterval(server, id, 10.0).isGood());
+        CHECK(services::writeHistorizing(server, id, true).isGood());
 
         // read new attributes
         // https://github.com/open62541/open62541/issues/6723
@@ -105,7 +105,7 @@ TEST_CASE("Attribute service set (highlevel)") {
         services::addMethod(server, objectsId, id, "TestMethod", nullptr, {}, {}).value();
 
         // write new attributes
-        CHECK(services::writeExecutable(server, id, true));
+        CHECK(services::writeExecutable(server, id, true).isGood());
 
         // read new attributes
         CHECK(services::readExecutable(server, id));
@@ -124,9 +124,9 @@ TEST_CASE("Attribute service set (highlevel)") {
         CHECK(services::readInverseName(server, id).value() == LocalizedText({}, {}));
 
         // write new attributes
-        CHECK(services::writeIsAbstract(server, id, true));
-        CHECK(services::writeSymmetric(server, id, false));
-        CHECK(services::writeInverseName(server, id, LocalizedText({}, "InverseName")));
+        CHECK(services::writeIsAbstract(server, id, true).isGood());
+        CHECK(services::writeSymmetric(server, id, false).isGood());
+        CHECK(services::writeInverseName(server, id, LocalizedText({}, "InverseName")).isGood());
 
         // read new attributes
         CHECK(services::readIsAbstract(server, id).value() == true);
@@ -147,36 +147,36 @@ TEST_CASE("Attribute service set (highlevel)") {
             };
             for (auto valueRank : valueRanks) {
                 CAPTURE(valueRank);
-                CHECK(services::writeValueRank(server, id, valueRank));
-                CHECK(services::writeArrayDimensions(server, id, {}));
-                CHECK_FALSE(services::writeArrayDimensions(server, id, {1}));
-                CHECK_FALSE(services::writeArrayDimensions(server, id, {1, 2}));
-                CHECK_FALSE(services::writeArrayDimensions(server, id, {1, 2, 3}));
+                CHECK(services::writeValueRank(server, id, valueRank).isGood());
+                CHECK(services::writeArrayDimensions(server, id, {}).isGood());
+                CHECK_FALSE(services::writeArrayDimensions(server, id, {1}).isGood());
+                CHECK_FALSE(services::writeArrayDimensions(server, id, {1, 2}).isGood());
+                CHECK_FALSE(services::writeArrayDimensions(server, id, {1, 2, 3}).isGood());
             }
         }
 
         SUBCASE("OneDimension") {
-            CHECK(services::writeValueRank(server, id, ValueRank::OneDimension));
-            CHECK(services::writeArrayDimensions(server, id, {1}));
-            CHECK_FALSE(services::writeArrayDimensions(server, id, {}));
-            CHECK_FALSE(services::writeArrayDimensions(server, id, {1, 2}));
-            CHECK_FALSE(services::writeArrayDimensions(server, id, {1, 2, 3}));
+            CHECK(services::writeValueRank(server, id, ValueRank::OneDimension).isGood());
+            CHECK(services::writeArrayDimensions(server, id, {1}).isGood());
+            CHECK_FALSE(services::writeArrayDimensions(server, id, {}).isGood());
+            CHECK_FALSE(services::writeArrayDimensions(server, id, {1, 2}).isGood());
+            CHECK_FALSE(services::writeArrayDimensions(server, id, {1, 2, 3}).isGood());
         }
 
         SUBCASE("TwoDimensions") {
-            CHECK(services::writeValueRank(server, id, ValueRank::TwoDimensions));
-            CHECK(services::writeArrayDimensions(server, id, {1, 2}));
-            CHECK_FALSE(services::writeArrayDimensions(server, id, {}));
-            CHECK_FALSE(services::writeArrayDimensions(server, id, {1}));
-            CHECK_FALSE(services::writeArrayDimensions(server, id, {1, 2, 3}));
+            CHECK(services::writeValueRank(server, id, ValueRank::TwoDimensions).isGood());
+            CHECK(services::writeArrayDimensions(server, id, {1, 2}).isGood());
+            CHECK_FALSE(services::writeArrayDimensions(server, id, {}).isGood());
+            CHECK_FALSE(services::writeArrayDimensions(server, id, {1}).isGood());
+            CHECK_FALSE(services::writeArrayDimensions(server, id, {1, 2, 3}).isGood());
         }
 
         SUBCASE("ThreeDimensions") {
-            CHECK(services::writeValueRank(server, id, ValueRank::ThreeDimensions));
-            CHECK(services::writeArrayDimensions(server, id, {1, 2, 3}));
-            CHECK_FALSE(services::writeArrayDimensions(server, id, {}));
-            CHECK_FALSE(services::writeArrayDimensions(server, id, {1}));
-            CHECK_FALSE(services::writeArrayDimensions(server, id, {1, 2}));
+            CHECK(services::writeValueRank(server, id, ValueRank::ThreeDimensions).isGood());
+            CHECK(services::writeArrayDimensions(server, id, {1, 2, 3}).isGood());
+            CHECK_FALSE(services::writeArrayDimensions(server, id, {}).isGood());
+            CHECK_FALSE(services::writeArrayDimensions(server, id, {1}).isGood());
+            CHECK_FALSE(services::writeArrayDimensions(server, id, {1, 2}).isGood());
         }
     }
 
@@ -186,7 +186,7 @@ TEST_CASE("Attribute service set (highlevel)") {
 
         Variant variantWrite;
         variantWrite.setScalarCopy(11.11);
-        services::writeValue(server, id, variantWrite).value();
+        services::writeValue(server, id, variantWrite).throwIfBad();
 
         Variant variantRead = services::readValue(server, id).value();
         CHECK(variantRead.getScalar<double>() == 11.11);
@@ -199,7 +199,7 @@ TEST_CASE("Attribute service set (highlevel)") {
         Variant variant;
         variant.setScalarCopy<int>(11);
         DataValue valueWrite(variant, {}, DateTime::now(), {}, uint16_t{1}, UA_STATUSCODE_GOOD);
-        services::writeDataValue(server, id, valueWrite).value();
+        services::writeDataValue(server, id, valueWrite).throwIfBad();
 
         DataValue valueRead = services::readDataValue(server, id).value();
 
@@ -270,7 +270,7 @@ TEST_CASE("Attribute service set (highlevel, async)") {
             auto variant = Variant::fromScalar(11.11);
             auto future = services::writeValueAsync(client, id, variant);
             client.runIterate();
-            future.get().value();
+            future.get().throwIfBad();
         }
 
         // read
@@ -310,10 +310,10 @@ TEST_CASE_TEMPLATE("Attribute service set write/read", T, Server, Client, Async<
             connection, id, AttributeId::Value, DataValue::fromScalar(value)
         );
         client.runIterate();
-        future.get().value();
+        future.get().throwIfBad();
     } else {
         services::writeAttribute(connection, id, AttributeId::Value, DataValue::fromScalar(value))
-            .value();
+            .throwIfBad();
     }
 
     // read

--- a/tests/services_monitoreditem.cpp
+++ b/tests/services_monitoreditem.cpp
@@ -82,7 +82,7 @@ TEST_CASE("MonitoredItem service set (client)") {
             CAPTURE(result.getMonitoredItemId());
         }
 
-        services::writeValue(server, id, Variant::fromScalar(11.11)).value();
+        services::writeValue(server, id, Variant::fromScalar(11.11)).throwIfBad();
         client.runIterate();
         CHECK(notificationCount > 0);
         CHECK(changedValue.getValue().getScalar<double>() == 11.11);
@@ -178,7 +178,7 @@ TEST_CASE("MonitoredItem service set (client)") {
             )
                 .getMonitoredItemId();
         CAPTURE(monId);
-        CHECK(services::setMonitoringMode(client, subId, monId, MonitoringMode::Disabled));
+        CHECK(services::setMonitoringMode(client, subId, monId, MonitoringMode::Disabled).isGood());
     }
 
 #if UAPP_OPEN62541_VER_GE(1, 2)
@@ -238,7 +238,7 @@ TEST_CASE("MonitoredItem service set (client)") {
 
     SUBCASE("deleteMonitoredItem") {
         CHECK(
-            services::deleteMonitoredItem(client, subId, 11U).code() ==
+            services::deleteMonitoredItem(client, subId, 11U) ==
             UA_STATUSCODE_BADMONITOREDITEMIDINVALID
         );
 
@@ -254,7 +254,7 @@ TEST_CASE("MonitoredItem service set (client)") {
                 [&](uint32_t, uint32_t) { deleted = true; }
             ).getMonitoredItemId();
 
-        CHECK(services::deleteMonitoredItem(client, subId, monId));
+        CHECK(services::deleteMonitoredItem(client, subId, monId).isGood());
         client.runIterate();
         CHECK(deleted == true);
     }
@@ -281,14 +281,14 @@ TEST_CASE("MonitoredItem service set (server)") {
             ).getMonitoredItemId();
         CAPTURE(monId);
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
-        services::writeValue(server, id, Variant::fromScalar(11.11)).value();
+        services::writeValue(server, id, Variant::fromScalar(11.11)).throwIfBad();
         server.runIterate();
         CHECK(notificationCount > 0);
     }
 
     SUBCASE("deleteMonitoredItem") {
         CHECK(
-            services::deleteMonitoredItem(server, 0U, 11U).code() ==
+            services::deleteMonitoredItem(server, 0U, 11U) ==
             UA_STATUSCODE_BADMONITOREDITEMIDINVALID
         );
 
@@ -303,7 +303,7 @@ TEST_CASE("MonitoredItem service set (server)") {
             )
                 .getMonitoredItemId();
         CAPTURE(monId);
-        CHECK(services::deleteMonitoredItem(server, 0U, monId));
+        CHECK(services::deleteMonitoredItem(server, 0U, monId).isGood());
     }
 }
 #endif

--- a/tests/services_nodemanagement.cpp
+++ b/tests/services_nodemanagement.cpp
@@ -184,8 +184,8 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
                 );
             }
         };
-        CHECK(addReference());
-        CHECK(addReference().code() == UA_STATUSCODE_BADDUPLICATEREFERENCENOTALLOWED);
+        CHECK(addReference().isGood());
+        CHECK(addReference() == UA_STATUSCODE_BADDUPLICATEREFERENCENOTALLOWED);
 
         auto deleteReference = [&] {
             if constexpr (isAsync<T>) {
@@ -200,7 +200,7 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
                 );
             }
         };
-        CHECK(deleteReference());
+        CHECK(deleteReference().isGood());
     }
 
     SUBCASE("Delete node") {
@@ -215,8 +215,8 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
                 return services::deleteNode(connection, {1, 1000});
             }
         };
-        CHECK(deleteNode());
-        CHECK(deleteNode().code() == UA_STATUSCODE_BADNODEIDUNKNOWN);
+        CHECK(deleteNode().isGood());
+        CHECK(deleteNode() == UA_STATUSCODE_BADNODEIDUNKNOWN);
     }
 
     SUBCASE("Random node id") {

--- a/tests/services_subscription.cpp
+++ b/tests/services_subscription.cpp
@@ -40,14 +40,14 @@ TEST_CASE("Subscription service set (client)") {
 
     SUBCASE("setPublishingMode") {
         const auto subId = services::createSubscription(client, parameters).getSubscriptionId();
-        CHECK(services::setPublishingMode(client, subId, false));
+        CHECK(services::setPublishingMode(client, subId, false).isGood());
     }
 
     SUBCASE("deleteSubscription") {
         const auto subId = services::createSubscription(client, parameters).getSubscriptionId();
-        CHECK(services::deleteSubscription(client, subId));
+        CHECK(services::deleteSubscription(client, subId).isGood());
         CHECK(
-            services::deleteSubscription(client, subId + 1).code() ==
+            services::deleteSubscription(client, subId + 1) ==
             UA_STATUSCODE_BADSUBSCRIPTIONIDINVALID
         );
     }
@@ -59,7 +59,7 @@ TEST_CASE("Subscription service set (client)") {
             services::createSubscription(client, parameters, true, {}, deleteCallback)
                 .getSubscriptionId();
 
-        CHECK(services::deleteSubscription(client, subId));
+        CHECK(services::deleteSubscription(client, subId).isGood());
         CHECK(deleted == true);
     }
 }

--- a/tools/gen_attribute_highlevel.py
+++ b/tools/gen_attribute_highlevel.py
@@ -101,15 +101,15 @@ TEMPLATE_WRITE = """
  * @ingroup Write
  */
 template <typename T>
-inline Result<void> write{attr}(T& connection, const NodeId& id, {param_type} {param_name}) noexcept {{
+inline StatusCode write{attr}(T& connection, const NodeId& id, {param_type} {param_name}) noexcept {{
     return detail::writeAttributeImpl<AttributeId::{attr}>(connection, id, {param_name});
 }}
 
 /**
  * Asynchronously write the AttributeId::{attr} attribute of a node.
  * @copydetails write{attr}
- * @param token @completiontoken{{void(Result<void>)}}
- * @return @asyncresult{{Result<void>}}
+ * @param token @completiontoken{{void(StatusCode)}}
+ * @return @asyncresult{{StatusCode}}
  * @ingroup Write
  */
 template <typename CompletionToken = DefaultCompletionToken>


### PR DESCRIPTION
Just return a `StatusCode` instead of `Result<void>` if possible. `Result<void>` as a return type just wraps a returned `StatusCode`.
The `Result<T>` type shines in scenarios, where a result and a `StatusCode` have to be returned simultaneously - let's only use it there. 