### PR TITLE
feat!: remove default arguments of functions in services namespace

### DIFF
--- a/doc/async_model.md
+++ b/doc/async_model.md
@@ -10,11 +10,11 @@ Open62541pp accepts completion tokens as the final argument of asynchronous oper
 
 ```cpp
 // Function signature of the completion handler: void(opcua::ReadResponse&)
-template <typename CompletionToken = opcua::DefaultCompletionToken>
+template <typename CompletionToken>
 auto opcua::services::readAsync(
     opcua::Client& connection,
     const opcua::ReadRequest& request,
-    CompletionToken&& token = DefaultCompletionToken()
+    CompletionToken&& token
 );
 ```
 
@@ -36,7 +36,7 @@ void(T&);  // for non-trivially copyable types
 ```
 
 ```cpp
-auto opcua::services::readAsync(
+opcua::services::readAsync(
     client,
     request,
     [](opcua::ReadResponse& response) {

--- a/doc/fragments/alias_completiontoken.dox
+++ b/doc/fragments/alias_completiontoken.dox
@@ -1,3 +1,3 @@
 The @ref async_model "completion token" that will be used to produce a completion handler, which will be called when the operation completes.
-Potential completion tokens include @ref useFuture (default), @ref useDeferred, @ref useDetached, or a function (object) with the correct completion signature.
+Potential completion tokens include @ref useFuture, @ref useDeferred, @ref useDetached, or a function (object) with the correct completion signature.
 The function signature of the completion handler must be:

--- a/examples/method/client_method_async.cpp
+++ b/examples/method/client_method_async.cpp
@@ -24,7 +24,7 @@ int main() {
             objectsNode.id(),
             greetMethodNode.id(),
             {opcua::Variant::fromScalar("Future World")},
-            opcua::useFuture  // default, can be omitted
+            opcua::useFuture
         );
 
         std::cout << "Waiting for asynchronous operation to complete\n";

--- a/examples/server_datasource.cpp
+++ b/examples/server_datasource.cpp
@@ -18,7 +18,9 @@ int main() {
         opcua::VariableAttributes{}
             .setAccessLevel(UA_ACCESSLEVELMASK_READ | UA_ACCESSLEVELMASK_WRITE)
             .setDataType<int>()
-            .setValueScalar(counter)
+            .setValueScalar(counter),
+        opcua::VariableTypeId::BaseDataVariableType,
+        opcua::ReferenceTypeId::HasComponent
     ).value();
 
     // Define data source with its read and write callbacks

--- a/include/open62541pp/services/attribute_highlevel.hpp
+++ b/include/open62541pp/services/attribute_highlevel.hpp
@@ -25,10 +25,8 @@ Result<NodeId> readNodeId(T& connection, const NodeId& id) noexcept {
  * @return @asyncresult{Result<NodeId>}
  * @ingroup Read
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto readNodeIdAsync(
-    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto readNodeIdAsync(Client& connection, const NodeId& id, CompletionToken&& token) {
     return detail::readAttributeAsyncImpl<AttributeId::NodeId>(
         connection, id, std::forward<CompletionToken>(token)
     );
@@ -51,10 +49,8 @@ Result<NodeClass> readNodeClass(T& connection, const NodeId& id) noexcept {
  * @return @asyncresult{Result<NodeClass>}
  * @ingroup Read
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto readNodeClassAsync(
-    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto readNodeClassAsync(Client& connection, const NodeId& id, CompletionToken&& token) {
     return detail::readAttributeAsyncImpl<AttributeId::NodeClass>(
         connection, id, std::forward<CompletionToken>(token)
     );
@@ -77,10 +73,8 @@ Result<QualifiedName> readBrowseName(T& connection, const NodeId& id) noexcept {
  * @return @asyncresult{Result<QualifiedName>}
  * @ingroup Read
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto readBrowseNameAsync(
-    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto readBrowseNameAsync(Client& connection, const NodeId& id, CompletionToken&& token) {
     return detail::readAttributeAsyncImpl<AttributeId::BrowseName>(
         connection, id, std::forward<CompletionToken>(token)
     );
@@ -106,12 +100,9 @@ StatusCode writeBrowseName(
  * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto writeBrowseNameAsync(
-    Client& connection,
-    const NodeId& id,
-    const QualifiedName& browseName,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, const QualifiedName& browseName, CompletionToken&& token
 ) {
     return detail::writeAttributeAsyncImpl<AttributeId::BrowseName>(
         connection, id, browseName, std::forward<CompletionToken>(token)
@@ -135,10 +126,8 @@ Result<LocalizedText> readDisplayName(T& connection, const NodeId& id) noexcept 
  * @return @asyncresult{Result<LocalizedText>}
  * @ingroup Read
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto readDisplayNameAsync(
-    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto readDisplayNameAsync(Client& connection, const NodeId& id, CompletionToken&& token) {
     return detail::readAttributeAsyncImpl<AttributeId::DisplayName>(
         connection, id, std::forward<CompletionToken>(token)
     );
@@ -164,12 +153,9 @@ StatusCode writeDisplayName(
  * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto writeDisplayNameAsync(
-    Client& connection,
-    const NodeId& id,
-    const LocalizedText& displayName,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, const LocalizedText& displayName, CompletionToken&& token
 ) {
     return detail::writeAttributeAsyncImpl<AttributeId::DisplayName>(
         connection, id, displayName, std::forward<CompletionToken>(token)
@@ -193,10 +179,8 @@ Result<LocalizedText> readDescription(T& connection, const NodeId& id) noexcept 
  * @return @asyncresult{Result<LocalizedText>}
  * @ingroup Read
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto readDescriptionAsync(
-    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto readDescriptionAsync(Client& connection, const NodeId& id, CompletionToken&& token) {
     return detail::readAttributeAsyncImpl<AttributeId::Description>(
         connection, id, std::forward<CompletionToken>(token)
     );
@@ -222,12 +206,9 @@ StatusCode writeDescription(
  * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto writeDescriptionAsync(
-    Client& connection,
-    const NodeId& id,
-    const LocalizedText& description,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, const LocalizedText& description, CompletionToken&& token
 ) {
     return detail::writeAttributeAsyncImpl<AttributeId::Description>(
         connection, id, description, std::forward<CompletionToken>(token)
@@ -251,10 +232,8 @@ Result<Bitmask<WriteMask>> readWriteMask(T& connection, const NodeId& id) noexce
  * @return @asyncresult{Result<Bitmask<WriteMask>>}
  * @ingroup Read
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto readWriteMaskAsync(
-    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto readWriteMaskAsync(Client& connection, const NodeId& id, CompletionToken&& token) {
     return detail::readAttributeAsyncImpl<AttributeId::WriteMask>(
         connection, id, std::forward<CompletionToken>(token)
     );
@@ -278,12 +257,9 @@ StatusCode writeWriteMask(T& connection, const NodeId& id, Bitmask<WriteMask> wr
  * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto writeWriteMaskAsync(
-    Client& connection,
-    const NodeId& id,
-    Bitmask<WriteMask> writeMask,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, Bitmask<WriteMask> writeMask, CompletionToken&& token
 ) {
     return detail::writeAttributeAsyncImpl<AttributeId::WriteMask>(
         connection, id, writeMask, std::forward<CompletionToken>(token)
@@ -307,10 +283,8 @@ Result<Bitmask<WriteMask>> readUserWriteMask(T& connection, const NodeId& id) no
  * @return @asyncresult{Result<Bitmask<WriteMask>>}
  * @ingroup Read
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto readUserWriteMaskAsync(
-    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto readUserWriteMaskAsync(Client& connection, const NodeId& id, CompletionToken&& token) {
     return detail::readAttributeAsyncImpl<AttributeId::UserWriteMask>(
         connection, id, std::forward<CompletionToken>(token)
     );
@@ -336,12 +310,9 @@ StatusCode writeUserWriteMask(
  * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto writeUserWriteMaskAsync(
-    Client& connection,
-    const NodeId& id,
-    Bitmask<WriteMask> userWriteMask,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, Bitmask<WriteMask> userWriteMask, CompletionToken&& token
 ) {
     return detail::writeAttributeAsyncImpl<AttributeId::UserWriteMask>(
         connection, id, userWriteMask, std::forward<CompletionToken>(token)
@@ -365,10 +336,8 @@ Result<bool> readIsAbstract(T& connection, const NodeId& id) noexcept {
  * @return @asyncresult{Result<bool>}
  * @ingroup Read
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto readIsAbstractAsync(
-    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto readIsAbstractAsync(Client& connection, const NodeId& id, CompletionToken&& token) {
     return detail::readAttributeAsyncImpl<AttributeId::IsAbstract>(
         connection, id, std::forward<CompletionToken>(token)
     );
@@ -392,12 +361,9 @@ StatusCode writeIsAbstract(T& connection, const NodeId& id, bool isAbstract) noe
  * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto writeIsAbstractAsync(
-    Client& connection,
-    const NodeId& id,
-    bool isAbstract,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, bool isAbstract, CompletionToken&& token
 ) {
     return detail::writeAttributeAsyncImpl<AttributeId::IsAbstract>(
         connection, id, isAbstract, std::forward<CompletionToken>(token)
@@ -421,10 +387,8 @@ Result<bool> readSymmetric(T& connection, const NodeId& id) noexcept {
  * @return @asyncresult{Result<bool>}
  * @ingroup Read
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto readSymmetricAsync(
-    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto readSymmetricAsync(Client& connection, const NodeId& id, CompletionToken&& token) {
     return detail::readAttributeAsyncImpl<AttributeId::Symmetric>(
         connection, id, std::forward<CompletionToken>(token)
     );
@@ -448,12 +412,9 @@ StatusCode writeSymmetric(T& connection, const NodeId& id, bool symmetric) noexc
  * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto writeSymmetricAsync(
-    Client& connection,
-    const NodeId& id,
-    bool symmetric,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, bool symmetric, CompletionToken&& token
 ) {
     return detail::writeAttributeAsyncImpl<AttributeId::Symmetric>(
         connection, id, symmetric, std::forward<CompletionToken>(token)
@@ -477,10 +438,8 @@ Result<LocalizedText> readInverseName(T& connection, const NodeId& id) noexcept 
  * @return @asyncresult{Result<LocalizedText>}
  * @ingroup Read
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto readInverseNameAsync(
-    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto readInverseNameAsync(Client& connection, const NodeId& id, CompletionToken&& token) {
     return detail::readAttributeAsyncImpl<AttributeId::InverseName>(
         connection, id, std::forward<CompletionToken>(token)
     );
@@ -506,12 +465,9 @@ StatusCode writeInverseName(
  * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto writeInverseNameAsync(
-    Client& connection,
-    const NodeId& id,
-    const LocalizedText& inverseName,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, const LocalizedText& inverseName, CompletionToken&& token
 ) {
     return detail::writeAttributeAsyncImpl<AttributeId::InverseName>(
         connection, id, inverseName, std::forward<CompletionToken>(token)
@@ -535,10 +491,8 @@ Result<bool> readContainsNoLoops(T& connection, const NodeId& id) noexcept {
  * @return @asyncresult{Result<bool>}
  * @ingroup Read
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto readContainsNoLoopsAsync(
-    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto readContainsNoLoopsAsync(Client& connection, const NodeId& id, CompletionToken&& token) {
     return detail::readAttributeAsyncImpl<AttributeId::ContainsNoLoops>(
         connection, id, std::forward<CompletionToken>(token)
     );
@@ -566,12 +520,9 @@ StatusCode writeContainsNoLoops(
  * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto writeContainsNoLoopsAsync(
-    Client& connection,
-    const NodeId& id,
-    const bool& containsNoLoops,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, const bool& containsNoLoops, CompletionToken&& token
 ) {
     return detail::writeAttributeAsyncImpl<AttributeId::ContainsNoLoops>(
         connection, id, containsNoLoops, std::forward<CompletionToken>(token)
@@ -595,10 +546,8 @@ Result<Bitmask<EventNotifier>> readEventNotifier(T& connection, const NodeId& id
  * @return @asyncresult{Result<Bitmask<EventNotifier>>}
  * @ingroup Read
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto readEventNotifierAsync(
-    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto readEventNotifierAsync(Client& connection, const NodeId& id, CompletionToken&& token) {
     return detail::readAttributeAsyncImpl<AttributeId::EventNotifier>(
         connection, id, std::forward<CompletionToken>(token)
     );
@@ -624,12 +573,12 @@ StatusCode writeEventNotifier(
  * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto writeEventNotifierAsync(
     Client& connection,
     const NodeId& id,
     Bitmask<EventNotifier> eventNotifier,
-    CompletionToken&& token = DefaultCompletionToken()
+    CompletionToken&& token
 ) {
     return detail::writeAttributeAsyncImpl<AttributeId::EventNotifier>(
         connection, id, eventNotifier, std::forward<CompletionToken>(token)
@@ -653,10 +602,8 @@ Result<Variant> readValue(T& connection, const NodeId& id) noexcept {
  * @return @asyncresult{Result<Variant>}
  * @ingroup Read
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto readValueAsync(
-    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto readValueAsync(Client& connection, const NodeId& id, CompletionToken&& token) {
     return detail::readAttributeAsyncImpl<AttributeId::Value>(
         connection, id, std::forward<CompletionToken>(token)
     );
@@ -680,12 +627,9 @@ StatusCode writeValue(T& connection, const NodeId& id, const Variant& value) noe
  * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto writeValueAsync(
-    Client& connection,
-    const NodeId& id,
-    const Variant& value,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, const Variant& value, CompletionToken&& token
 ) {
     return detail::writeAttributeAsyncImpl<AttributeId::Value>(
         connection, id, value, std::forward<CompletionToken>(token)
@@ -709,10 +653,8 @@ Result<NodeId> readDataType(T& connection, const NodeId& id) noexcept {
  * @return @asyncresult{Result<NodeId>}
  * @ingroup Read
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto readDataTypeAsync(
-    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto readDataTypeAsync(Client& connection, const NodeId& id, CompletionToken&& token) {
     return detail::readAttributeAsyncImpl<AttributeId::DataType>(
         connection, id, std::forward<CompletionToken>(token)
     );
@@ -736,12 +678,9 @@ StatusCode writeDataType(T& connection, const NodeId& id, const NodeId& dataType
  * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto writeDataTypeAsync(
-    Client& connection,
-    const NodeId& id,
-    const NodeId& dataType,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, const NodeId& dataType, CompletionToken&& token
 ) {
     return detail::writeAttributeAsyncImpl<AttributeId::DataType>(
         connection, id, dataType, std::forward<CompletionToken>(token)
@@ -765,10 +704,8 @@ Result<ValueRank> readValueRank(T& connection, const NodeId& id) noexcept {
  * @return @asyncresult{Result<ValueRank>}
  * @ingroup Read
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto readValueRankAsync(
-    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto readValueRankAsync(Client& connection, const NodeId& id, CompletionToken&& token) {
     return detail::readAttributeAsyncImpl<AttributeId::ValueRank>(
         connection, id, std::forward<CompletionToken>(token)
     );
@@ -792,12 +729,9 @@ StatusCode writeValueRank(T& connection, const NodeId& id, ValueRank valueRank) 
  * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto writeValueRankAsync(
-    Client& connection,
-    const NodeId& id,
-    ValueRank valueRank,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, ValueRank valueRank, CompletionToken&& token
 ) {
     return detail::writeAttributeAsyncImpl<AttributeId::ValueRank>(
         connection, id, valueRank, std::forward<CompletionToken>(token)
@@ -821,10 +755,8 @@ Result<std::vector<uint32_t>> readArrayDimensions(T& connection, const NodeId& i
  * @return @asyncresult{Result<std::vector<uint32_t>>}
  * @ingroup Read
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto readArrayDimensionsAsync(
-    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto readArrayDimensionsAsync(Client& connection, const NodeId& id, CompletionToken&& token) {
     return detail::readAttributeAsyncImpl<AttributeId::ArrayDimensions>(
         connection, id, std::forward<CompletionToken>(token)
     );
@@ -852,12 +784,12 @@ StatusCode writeArrayDimensions(
  * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto writeArrayDimensionsAsync(
     Client& connection,
     const NodeId& id,
     Span<const uint32_t> arrayDimensions,
-    CompletionToken&& token = DefaultCompletionToken()
+    CompletionToken&& token
 ) {
     return detail::writeAttributeAsyncImpl<AttributeId::ArrayDimensions>(
         connection, id, arrayDimensions, std::forward<CompletionToken>(token)
@@ -881,10 +813,8 @@ Result<Bitmask<AccessLevel>> readAccessLevel(T& connection, const NodeId& id) no
  * @return @asyncresult{Result<Bitmask<AccessLevel>>}
  * @ingroup Read
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto readAccessLevelAsync(
-    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto readAccessLevelAsync(Client& connection, const NodeId& id, CompletionToken&& token) {
     return detail::readAttributeAsyncImpl<AttributeId::AccessLevel>(
         connection, id, std::forward<CompletionToken>(token)
     );
@@ -910,12 +840,9 @@ StatusCode writeAccessLevel(
  * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto writeAccessLevelAsync(
-    Client& connection,
-    const NodeId& id,
-    Bitmask<AccessLevel> accessLevel,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, Bitmask<AccessLevel> accessLevel, CompletionToken&& token
 ) {
     return detail::writeAttributeAsyncImpl<AttributeId::AccessLevel>(
         connection, id, accessLevel, std::forward<CompletionToken>(token)
@@ -939,10 +866,8 @@ Result<Bitmask<AccessLevel>> readUserAccessLevel(T& connection, const NodeId& id
  * @return @asyncresult{Result<Bitmask<AccessLevel>>}
  * @ingroup Read
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto readUserAccessLevelAsync(
-    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto readUserAccessLevelAsync(Client& connection, const NodeId& id, CompletionToken&& token) {
     return detail::readAttributeAsyncImpl<AttributeId::UserAccessLevel>(
         connection, id, std::forward<CompletionToken>(token)
     );
@@ -970,12 +895,12 @@ StatusCode writeUserAccessLevel(
  * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto writeUserAccessLevelAsync(
     Client& connection,
     const NodeId& id,
     Bitmask<AccessLevel> userAccessLevel,
-    CompletionToken&& token = DefaultCompletionToken()
+    CompletionToken&& token
 ) {
     return detail::writeAttributeAsyncImpl<AttributeId::UserAccessLevel>(
         connection, id, userAccessLevel, std::forward<CompletionToken>(token)
@@ -999,9 +924,9 @@ Result<double> readMinimumSamplingInterval(T& connection, const NodeId& id) noex
  * @return @asyncresult{Result<double>}
  * @ingroup Read
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto readMinimumSamplingIntervalAsync(
-    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, CompletionToken&& token
 ) {
     return detail::readAttributeAsyncImpl<AttributeId::MinimumSamplingInterval>(
         connection, id, std::forward<CompletionToken>(token)
@@ -1030,12 +955,9 @@ StatusCode writeMinimumSamplingInterval(
  * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto writeMinimumSamplingIntervalAsync(
-    Client& connection,
-    const NodeId& id,
-    double minimumSamplingInterval,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, double minimumSamplingInterval, CompletionToken&& token
 ) {
     return detail::writeAttributeAsyncImpl<AttributeId::MinimumSamplingInterval>(
         connection, id, minimumSamplingInterval, std::forward<CompletionToken>(token)
@@ -1059,10 +981,8 @@ Result<bool> readHistorizing(T& connection, const NodeId& id) noexcept {
  * @return @asyncresult{Result<bool>}
  * @ingroup Read
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto readHistorizingAsync(
-    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto readHistorizingAsync(Client& connection, const NodeId& id, CompletionToken&& token) {
     return detail::readAttributeAsyncImpl<AttributeId::Historizing>(
         connection, id, std::forward<CompletionToken>(token)
     );
@@ -1086,12 +1006,9 @@ StatusCode writeHistorizing(T& connection, const NodeId& id, bool historizing) n
  * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto writeHistorizingAsync(
-    Client& connection,
-    const NodeId& id,
-    bool historizing,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, bool historizing, CompletionToken&& token
 ) {
     return detail::writeAttributeAsyncImpl<AttributeId::Historizing>(
         connection, id, historizing, std::forward<CompletionToken>(token)
@@ -1115,10 +1032,8 @@ Result<bool> readExecutable(T& connection, const NodeId& id) noexcept {
  * @return @asyncresult{Result<bool>}
  * @ingroup Read
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto readExecutableAsync(
-    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto readExecutableAsync(Client& connection, const NodeId& id, CompletionToken&& token) {
     return detail::readAttributeAsyncImpl<AttributeId::Executable>(
         connection, id, std::forward<CompletionToken>(token)
     );
@@ -1142,12 +1057,9 @@ StatusCode writeExecutable(T& connection, const NodeId& id, bool executable) noe
  * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto writeExecutableAsync(
-    Client& connection,
-    const NodeId& id,
-    bool executable,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, bool executable, CompletionToken&& token
 ) {
     return detail::writeAttributeAsyncImpl<AttributeId::Executable>(
         connection, id, executable, std::forward<CompletionToken>(token)
@@ -1171,10 +1083,8 @@ Result<bool> readUserExecutable(T& connection, const NodeId& id) noexcept {
  * @return @asyncresult{Result<bool>}
  * @ingroup Read
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto readUserExecutableAsync(
-    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto readUserExecutableAsync(Client& connection, const NodeId& id, CompletionToken&& token) {
     return detail::readAttributeAsyncImpl<AttributeId::UserExecutable>(
         connection, id, std::forward<CompletionToken>(token)
     );
@@ -1198,12 +1108,9 @@ StatusCode writeUserExecutable(T& connection, const NodeId& id, bool userExecuta
  * @return @asyncresult{StatusCode}
  * @ingroup Write
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto writeUserExecutableAsync(
-    Client& connection,
-    const NodeId& id,
-    bool userExecutable,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, bool userExecutable, CompletionToken&& token
 ) {
     return detail::writeAttributeAsyncImpl<AttributeId::UserExecutable>(
         connection, id, userExecutable, std::forward<CompletionToken>(token)
@@ -1228,10 +1135,8 @@ Result<Variant> readDataTypeDefinition(T& connection, const NodeId& id) noexcept
  * @return @asyncresult{Result<Variant>}
  * @ingroup Read
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto readDataTypeDefinitionAsync(
-    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto readDataTypeDefinitionAsync(Client& connection, const NodeId& id, CompletionToken&& token) {
     return detail::readAttributeAsyncImpl<AttributeId::DataTypeDefinition>(
         connection, id, std::forward<CompletionToken>(token)
     );

--- a/include/open62541pp/services/method.hpp
+++ b/include/open62541pp/services/method.hpp
@@ -45,12 +45,8 @@ CallResponse call(Client& connection, const CallRequest& request) noexcept;
  * @param token @completiontoken{void(CallResponse&)}
  * @return @asyncresult{CallResponse}
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto callAsync(
-    Client& connection,
-    const CallRequest& request,
-    CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto callAsync(Client& connection, const CallRequest& request, CompletionToken&& token) {
     return detail::sendRequestAsync<CallRequest, CallResponse>(
         connection, request, std::forward<CompletionToken>(token)
     );
@@ -78,13 +74,13 @@ CallMethodResult call(
  * @param token @completiontoken{void(CallMethodResult&)}
  * @return @asyncresult{CallMethodResult}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto callAsync(
     Client& connection,
     const NodeId& objectId,
     const NodeId& methodId,
     Span<const Variant> inputArguments,
-    CompletionToken&& token = DefaultCompletionToken()
+    CompletionToken&& token
 ) {
     auto item = detail::createCallMethodRequest(objectId, methodId, inputArguments);
     const auto request = detail::createCallRequest(item);

--- a/include/open62541pp/services/monitoreditem.hpp
+++ b/include/open62541pp/services/monitoreditem.hpp
@@ -147,7 +147,7 @@ void storeMonitoredItemContexts(
     Client& connection,
     const CreateMonitoredItemsRequest& request,
     DataChangeNotificationCallback dataChangeCallback,
-    DeleteMonitoredItemCallback deleteCallback = {}
+    DeleteMonitoredItemCallback deleteCallback
 );
 
 #if UAPP_OPEN62541_VER_GE(1, 1)
@@ -157,13 +157,13 @@ void storeMonitoredItemContexts(
  * @param token @completiontoken{void(CreateMonitoredItemsResponse&)}
  * @return @asyncresult{CreateMonitoredItemsResponse}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto createMonitoredItemsDataChangeAsync(
     Client& connection,
     const CreateMonitoredItemsRequest& request,
     DataChangeNotificationCallback dataChangeCallback,
-    DeleteMonitoredItemCallback deleteCallback = {},
-    CompletionToken&& token = DefaultCompletionToken()
+    DeleteMonitoredItemCallback deleteCallback,
+    CompletionToken&& token
 ) {
     auto contexts = detail::createMonitoredItemContexts(
         connection, request, std::move(dataChangeCallback), {}, std::move(deleteCallback)
@@ -222,7 +222,7 @@ template <typename T>
     MonitoringMode monitoringMode,
     const MonitoringParametersEx& parameters,
     DataChangeNotificationCallback dataChangeCallback,
-    DeleteMonitoredItemCallback deleteCallback = {}
+    DeleteMonitoredItemCallback deleteCallback
 );
 
 #if UAPP_OPEN62541_VER_GE(1, 1)
@@ -233,7 +233,7 @@ template <typename T>
  * @param token @completiontoken{void(MonitoredItemCreateResult&)}
  * @return @asyncresult{MonitoredItemCreateResult}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto createMonitoredItemDataChangeAsync(
     Client& connection,
     uint32_t subscriptionId,
@@ -241,8 +241,8 @@ auto createMonitoredItemDataChangeAsync(
     MonitoringMode monitoringMode,
     const MonitoringParametersEx& parameters,
     DataChangeNotificationCallback dataChangeCallback,
-    DeleteMonitoredItemCallback deleteCallback = {},
-    CompletionToken&& token = DefaultCompletionToken()
+    DeleteMonitoredItemCallback deleteCallback,
+    CompletionToken&& token
 ) {
     auto item = detail::createMonitoredItemCreateRequest(itemToMonitor, monitoringMode, parameters);
     const auto request = detail::createCreateMonitoredItemsRequest(
@@ -275,7 +275,7 @@ auto createMonitoredItemDataChangeAsync(
     Client& connection,
     const CreateMonitoredItemsRequest& request,
     EventNotificationCallback eventCallback,
-    DeleteMonitoredItemCallback deleteCallback = {}
+    DeleteMonitoredItemCallback deleteCallback
 );
 
 #if UAPP_OPEN62541_VER_GE(1, 1)
@@ -285,13 +285,13 @@ auto createMonitoredItemDataChangeAsync(
  * @param token @completiontoken{void(CreateMonitoredItemsResponse&)}
  * @return @asyncresult{CreateMonitoredItemsResponse}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto createMonitoredItemsEventAsync(
     Client& connection,
     const CreateMonitoredItemsRequest& request,
     EventNotificationCallback eventCallback,
-    DeleteMonitoredItemCallback deleteCallback = {},
-    CompletionToken&& token = DefaultCompletionToken()
+    DeleteMonitoredItemCallback deleteCallback,
+    CompletionToken&& token
 ) {
     auto contexts = detail::createMonitoredItemContexts(
         connection, request, {}, std::move(eventCallback), std::move(deleteCallback)
@@ -357,7 +357,7 @@ auto createMonitoredItemsEventAsync(
  * @param token @completiontoken{void(MonitoredItemCreateResult&)}
  * @return @asyncresult{MonitoredItemCreateResult}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto createMonitoredItemEventAsync(
     Client& connection,
     uint32_t subscriptionId,
@@ -365,8 +365,8 @@ auto createMonitoredItemEventAsync(
     MonitoringMode monitoringMode,
     const MonitoringParametersEx& parameters,
     EventNotificationCallback eventCallback,
-    DeleteMonitoredItemCallback deleteCallback = {},
-    CompletionToken&& token = DefaultCompletionToken()
+    DeleteMonitoredItemCallback deleteCallback,
+    CompletionToken&& token
 ) {
     auto item = detail::createMonitoredItemCreateRequest(itemToMonitor, monitoringMode, parameters);
     const auto request = detail::createCreateMonitoredItemsRequest(
@@ -410,11 +410,9 @@ ModifyMonitoredItemsResponse modifyMonitoredItems(
  * @param token @completiontoken{void(ModifyMonitoredItemsResponse&)}
  * @return @asyncresult{ModifyMonitoredItemsResponse}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto modifyMonitoredItemsAsync(
-    Client& connection,
-    const ModifyMonitoredItemsRequest& request,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const ModifyMonitoredItemsRequest& request, CompletionToken&& token
 ) {
     return detail::AsyncServiceAdapter<ModifyMonitoredItemsResponse>::initiate(
         connection,
@@ -456,13 +454,13 @@ inline MonitoredItemModifyResult modifyMonitoredItem(
  * @param token @completiontoken{void(MonitoredItemModifyResult&)}
  * @return @asyncresult{MonitoredItemModifyResult}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto modifyMonitoredItemAsync(
     Client& connection,
     uint32_t subscriptionId,
     uint32_t monitoredItemId,
     const MonitoringParametersEx& parameters,
-    CompletionToken&& token = DefaultCompletionToken()
+    CompletionToken&& token
 ) {
     auto item = detail::createMonitoredItemModifyRequest(monitoredItemId, parameters);
     auto request = detail::createModifyMonitoredItemsRequest(subscriptionId, parameters, item);
@@ -502,11 +500,9 @@ SetMonitoringModeResponse setMonitoringMode(
  * @param token @completiontoken{void(SetMonitoringModeResponse&)}
  * @return @asyncresult{SetMonitoringModeResponse}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto setMonitoringModeAsync(
-    Client& connection,
-    const SetMonitoringModeRequest& request,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const SetMonitoringModeRequest& request, CompletionToken&& token
 ) {
     return detail::sendRequestAsync<SetMonitoringModeRequest, SetMonitoringModeResponse>(
         connection, request, std::forward<CompletionToken>(token)
@@ -540,13 +536,13 @@ inline StatusCode setMonitoringMode(
  * @param token @completiontoken{void(StatusCode)}
  * @return @asyncresult{StatusCode}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto setMonitoringModeAsync(
     Client& connection,
     uint32_t subscriptionId,
     uint32_t monitoredItemId,
     MonitoringMode monitoringMode,
-    CompletionToken&& token = DefaultCompletionToken()
+    CompletionToken&& token
 ) {
     const auto request = detail::createSetMonitoringModeRequest(
         subscriptionId, {&monitoredItemId, 1}, monitoringMode
@@ -586,11 +582,9 @@ SetTriggeringResponse setTriggering(
  * @param token @completiontoken{void(SetTriggeringResponse&)}
  * @return @asyncresult{SetTriggeringResponse}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto setTriggeringAsync(
-    Client& connection,
-    const SetTriggeringRequest& request,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const SetTriggeringRequest& request, CompletionToken&& token
 ) {
     return detail::sendRequestAsync<SetTriggeringRequest, SetTriggeringResponse>(
         connection, request, std::forward<CompletionToken>(token)
@@ -621,11 +615,9 @@ DeleteMonitoredItemsResponse deleteMonitoredItems(
  * @param token @completiontoken{void(DeleteMonitoredItemsResponse&)}
  * @return @asyncresult{DeleteMonitoredItemsResponse}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto deleteMonitoredItemsAsync(
-    Client& connection,
-    const DeleteMonitoredItemsRequest& request,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const DeleteMonitoredItemsRequest& request, CompletionToken&& token
 ) {
     return detail::AsyncServiceAdapter<DeleteMonitoredItemsResponse>::initiate(
         connection,
@@ -656,12 +648,9 @@ StatusCode deleteMonitoredItem(T& connection, uint32_t subscriptionId, uint32_t 
  * @param token @completiontoken{void(StatusCode)}
  * @return @asyncresult{StatusCode}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto deleteMonitoredItemAsync(
-    Client& connection,
-    uint32_t subscriptionId,
-    uint32_t monitoredItemId,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, uint32_t subscriptionId, uint32_t monitoredItemId, CompletionToken&& token
 ) {
     const auto request = detail::createDeleteMonitoredItemsRequest(
         subscriptionId, {&monitoredItemId, 1}

--- a/include/open62541pp/services/nodemanagement.hpp
+++ b/include/open62541pp/services/nodemanagement.hpp
@@ -53,12 +53,8 @@ AddNodesResponse addNodes(Client& connection, const AddNodesRequest& request) no
  * @param token @completiontoken{void(AddNodesResponse&)}
  * @return @asyncresult{AddNodesResponse}
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto addNodesAsync(
-    Client& connection,
-    const AddNodesRequest& request,
-    CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto addNodesAsync(Client& connection, const AddNodesRequest& request, CompletionToken&& token) {
     return detail::sendRequestAsync<AddNodesRequest, AddNodesResponse>(
         connection, request, std::forward<CompletionToken>(token)
     );
@@ -92,7 +88,7 @@ Result<NodeId> addNode(
  * @param token @completiontoken{void(Result<NodeId>&)}
  * @return @asyncresult{Result<NodeId>}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto addNodeAsync(
     Client& connection,
     NodeClass nodeClass,
@@ -102,7 +98,7 @@ auto addNodeAsync(
     const ExtensionObject& nodeAttributes,
     const NodeId& typeDefinition,
     const NodeId& referenceType,
-    CompletionToken&& token = DefaultCompletionToken()
+    CompletionToken&& token
 ) {
     auto item = detail::createAddNodesItem(
         parentId, referenceType, id, browseName, nodeClass, nodeAttributes, typeDefinition
@@ -142,11 +138,9 @@ AddReferencesResponse addReferences(
  * @param token @completiontoken{void(AddReferencesResponse&)}
  * @return @asyncresult{AddReferencesReponse}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto addReferencesAsync(
-    Client& connection,
-    const AddReferencesRequest& request,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const AddReferencesRequest& request, CompletionToken&& token
 ) {
     return detail::sendRequestAsync<AddReferencesRequest, AddReferencesResponse>(
         connection, request, std::forward<CompletionToken>(token)
@@ -167,7 +161,7 @@ StatusCode addReference(
     const NodeId& sourceId,
     const NodeId& targetId,
     const NodeId& referenceType,
-    bool forward = true
+    bool forward
 ) noexcept;
 
 /**
@@ -175,14 +169,14 @@ StatusCode addReference(
  * @param token @completiontoken{void(StatusCode)}
  * @return @asyncresult{StatusCode}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto addReferenceAsync(
     Client& connection,
     const NodeId& sourceId,
     const NodeId& targetId,
     const NodeId& referenceType,
-    bool forward = true,
-    CompletionToken&& token = DefaultCompletionToken()
+    bool forward,
+    CompletionToken&& token
 ) {
     auto item = detail::createAddReferencesItem(sourceId, referenceType, forward, targetId);
     const auto request = detail::createAddReferencesRequest(item);
@@ -215,11 +209,9 @@ DeleteNodesResponse deleteNodes(Client& connection, const DeleteNodesRequest& re
  * @param token @completiontoken{void(DeleteNodesResponse&)}
  * @return @asyncresult{DeleteNodesResponse}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto deleteNodesAsync(
-    Client& connection,
-    const DeleteNodesRequest& request,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const DeleteNodesRequest& request, CompletionToken&& token
 ) {
     return detail::sendRequestAsync<DeleteNodesRequest, DeleteNodesResponse>(
         connection, request, std::forward<CompletionToken>(token)
@@ -233,19 +225,16 @@ auto deleteNodesAsync(
  * @param deleteReferences Delete references in target nodes that reference the node to delete
  */
 template <typename T>
-StatusCode deleteNode(T& connection, const NodeId& id, bool deleteReferences = true) noexcept;
+StatusCode deleteNode(T& connection, const NodeId& id, bool deleteReferences) noexcept;
 
 /**
  * @copydoc deleteNode
  * @param token @completiontoken{void(StatusCode)}
  * @return @asyncresult{StatusCode}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto deleteNodeAsync(
-    Client& connection,
-    const NodeId& id,
-    bool deleteReferences = true,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, bool deleteReferences, CompletionToken&& token
 ) {
     auto item = detail::createDeleteNodesItem(id, deleteReferences);
     const auto request = detail::createDeleteNodesRequest(item);
@@ -280,11 +269,9 @@ DeleteReferencesResponse deleteReferences(
  * @param token @completiontoken{void(DeleteReferencesResponse&)}
  * @return @asyncresult{DeleteReferencesResponse}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto deleteReferencesAsync(
-    Client& connection,
-    const DeleteReferencesRequest& request,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const DeleteReferencesRequest& request, CompletionToken&& token
 ) {
     return detail::sendRequestAsync<DeleteReferencesRequest, DeleteReferencesResponse>(
         connection, request, std::forward<CompletionToken>(token)
@@ -315,7 +302,7 @@ StatusCode deleteReference(
  * @param token @completiontoken{void(StatusCode)}
  * @return @asyncresult{StatusCode}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto deleteReferenceAsync(
     Client& connection,
     const NodeId& sourceId,
@@ -323,7 +310,7 @@ auto deleteReferenceAsync(
     const NodeId& referenceType,
     bool isForward,
     bool deleteBidirectional,
-    CompletionToken&& token = DefaultCompletionToken()
+    CompletionToken&& token
 ) {
     auto item = detail::createDeleteReferencesItem(
         sourceId, referenceType, isForward, targetId, deleteBidirectional
@@ -356,8 +343,9 @@ auto deleteReferenceAsync(
  * @param id Requested NodeId of the object node to add
  * @param browseName Browse name
  * @param attributes Object attributes
- * @param objectType NodeId of the object type
- * @param referenceType Hierarchical reference type from the parent node to the new node
+ * @param objectType NodeId of the object type, e.g. ObjectTypeId::BaseObjectType
+ * @param referenceType Hierarchical reference type from the parent node to the new node, e.g.
+ *                      ReferenceTypeId::HasComponent
  */
 template <typename T>
 Result<NodeId> addObject(
@@ -365,9 +353,9 @@ Result<NodeId> addObject(
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
-    const ObjectAttributes& attributes = {},
-    const NodeId& objectType = ObjectTypeId::BaseObjectType,
-    const NodeId& referenceType = ReferenceTypeId::HasComponent
+    const ObjectAttributes& attributes,
+    const NodeId& objectType,
+    const NodeId& referenceType
 ) noexcept {
     return addNode(
         connection,
@@ -386,16 +374,16 @@ Result<NodeId> addObject(
  * @param token @completiontoken{void(Result<NodeId>&)}
  * @return @asyncresult{Result<NodeId>}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto addObjectAsync(
     Client& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
-    const ObjectAttributes& attributes = {},
-    const NodeId& objectType = ObjectTypeId::BaseObjectType,
-    const NodeId& referenceType = ReferenceTypeId::HasComponent,
-    CompletionToken&& token = DefaultCompletionToken()
+    const ObjectAttributes& attributes,
+    const NodeId& objectType,
+    const NodeId& referenceType,
+    CompletionToken&& token
 ) {
     return addNodeAsync(
         connection,
@@ -417,7 +405,8 @@ auto addObjectAsync(
  * @param id Requested NodeId of the node to add
  * @param browseName Browse name
  * @param attributes Object attributes
- * @param referenceType Hierarchical reference type from the parent node to the new node
+ * @param referenceType Hierarchical reference type from the parent node to the new node, e.g.
+ *                      ReferenceTypeId::HasComponent
  */
 template <typename T>
 Result<NodeId> addFolder(
@@ -425,8 +414,8 @@ Result<NodeId> addFolder(
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
-    const ObjectAttributes& attributes = {},
-    const NodeId& referenceType = ReferenceTypeId::HasComponent
+    const ObjectAttributes& attributes,
+    const NodeId& referenceType
 ) noexcept {
     return addObject(
         connection, parentId, id, browseName, attributes, ObjectTypeId::FolderType, referenceType
@@ -438,15 +427,15 @@ Result<NodeId> addFolder(
  * @param token @completiontoken{void(Result<NodeId>&)}
  * @return @asyncresult{Result<NodeId>}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto addFolderAsync(
     Client& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
-    const ObjectAttributes& attributes = {},
-    const NodeId& referenceType = ReferenceTypeId::HasComponent,
-    CompletionToken&& token = DefaultCompletionToken()
+    const ObjectAttributes& attributes,
+    const NodeId& referenceType,
+    CompletionToken&& token
 ) {
     return addObjectAsync(
         connection,
@@ -467,8 +456,9 @@ auto addFolderAsync(
  * @param id Requested NodeId of the node to add
  * @param browseName Browse name
  * @param attributes Variable attributes
- * @param variableType NodeId of the variable type
- * @param referenceType Hierarchical reference type from the parent node to the new node
+ * @param variableType NodeId of the variable type, e.g. VariableTypeId::BaseDataVariableType
+ * @param referenceType Hierarchical reference type from the parent node to the new node, e.g.
+ *                      ReferenceTypeId::HasComponent
  */
 template <typename T>
 Result<NodeId> addVariable(
@@ -476,9 +466,9 @@ Result<NodeId> addVariable(
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
-    const VariableAttributes& attributes = {},
-    const NodeId& variableType = VariableTypeId::BaseDataVariableType,
-    const NodeId& referenceType = ReferenceTypeId::HasComponent
+    const VariableAttributes& attributes,
+    const NodeId& variableType,
+    const NodeId& referenceType
 ) noexcept {
     return addNode(
         connection,
@@ -497,16 +487,16 @@ Result<NodeId> addVariable(
  * @param token @completiontoken{void(Result<NodeId>&)}
  * @return @asyncresult{Result<NodeId>}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto addVariableAsync(
     Client& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
-    const VariableAttributes& attributes = {},
-    const NodeId& variableType = VariableTypeId::BaseDataVariableType,
-    const NodeId& referenceType = ReferenceTypeId::HasComponent,
-    CompletionToken&& token = DefaultCompletionToken()
+    const VariableAttributes& attributes,
+    const NodeId& variableType,
+    const NodeId& referenceType,
+    CompletionToken&& token
 ) {
     return addNodeAsync(
         connection,
@@ -535,7 +525,7 @@ Result<NodeId> addProperty(
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
-    const VariableAttributes& attributes = {}
+    const VariableAttributes& attributes
 ) noexcept {
     return addVariable(
         connection,
@@ -553,14 +543,14 @@ Result<NodeId> addProperty(
  * @param token @completiontoken{void(Result<NodeId>&)}
  * @return @asyncresult{Result<NodeId>}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto addPropertyAsync(
     Client& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
-    const VariableAttributes& attributes = {},
-    CompletionToken&& token = DefaultCompletionToken()
+    const VariableAttributes& attributes,
+    CompletionToken&& token
 ) {
     return addVariableAsync(
         connection,
@@ -593,7 +583,8 @@ using MethodCallback = std::function<void(Span<const Variant> input, Span<Varian
  * @param inputArguments Input arguments
  * @param outputArguments Output arguments
  * @param attributes Method attributes
- * @param referenceType Hierarchical reference type from the parent node to the new node
+ * @param referenceType Hierarchical reference type from the parent node to the new node, e.g.
+ *                      ReferenceTypeId::HasComponent
  */
 template <typename T>
 Result<NodeId> addMethod(
@@ -604,8 +595,8 @@ Result<NodeId> addMethod(
     MethodCallback callback,
     Span<const Argument> inputArguments,
     Span<const Argument> outputArguments,
-    const MethodAttributes& attributes = {},
-    const NodeId& referenceType = ReferenceTypeId::HasComponent
+    const MethodAttributes& attributes,
+    const NodeId& referenceType
 ) noexcept;
 
 /**
@@ -613,7 +604,7 @@ Result<NodeId> addMethod(
  * @param token @completiontoken{void(Result<NodeId>&)}
  * @return @asyncresult{Result<NodeId>}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto addMethodAsync(
     Client& connection,
     const NodeId& parentId,
@@ -622,9 +613,9 @@ auto addMethodAsync(
     [[maybe_unused]] MethodCallback callback,  // NOLINT
     [[maybe_unused]] Span<const Argument> inputArguments,
     [[maybe_unused]] Span<const Argument> outputArguments,
-    const MethodAttributes& attributes = {},
-    const NodeId& referenceType = ReferenceTypeId::HasComponent,
-    CompletionToken&& token = DefaultCompletionToken()
+    const MethodAttributes& attributes,
+    const NodeId& referenceType,
+    CompletionToken&& token
 ) {
     return addNodeAsync(
         connection,
@@ -647,7 +638,8 @@ auto addMethodAsync(
  * @param id Requested NodeId of the node to add
  * @param browseName Browse name
  * @param attributes Object type attributes
- * @param referenceType Hierarchical reference type from the parent node to the new node
+ * @param referenceType Hierarchical reference type from the parent node to the new node, e.g.
+ *                      ReferenceTypeId::HasSubtype
  */
 template <typename T>
 Result<NodeId> addObjectType(
@@ -655,8 +647,8 @@ Result<NodeId> addObjectType(
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
-    const ObjectTypeAttributes& attributes = {},
-    const NodeId& referenceType = ReferenceTypeId::HasSubtype
+    const ObjectTypeAttributes& attributes,
+    const NodeId& referenceType
 ) noexcept {
     return addNode(
         connection,
@@ -675,15 +667,15 @@ Result<NodeId> addObjectType(
  * @param token @completiontoken{void(Result<NodeId>&)}
  * @return @asyncresult{Result<NodeId>}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto addObjectTypeAsync(
     Client& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
-    const ObjectTypeAttributes& attributes = {},
-    const NodeId& referenceType = ReferenceTypeId::HasSubtype,
-    CompletionToken&& token = DefaultCompletionToken()
+    const ObjectTypeAttributes& attributes,
+    const NodeId& referenceType,
+    CompletionToken&& token
 ) {
     return addNodeAsync(
         connection,
@@ -705,8 +697,9 @@ auto addObjectTypeAsync(
  * @param id Requested NodeId of the node to add
  * @param browseName Browse name
  * @param attributes Variable type attributes
- * @param variableType NodeId of the variable type
- * @param referenceType Hierarchical reference type from the parent node to the new node
+ * @param variableType NodeId of the variable type, e.g. VariableTypeId::BaseDataVariableType
+ * @param referenceType Hierarchical reference type from the parent node to the new node, e.g.
+ *                      ReferenceTypeId::HasSubtype
  */
 template <typename T>
 Result<NodeId> addVariableType(
@@ -714,9 +707,9 @@ Result<NodeId> addVariableType(
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
-    const VariableTypeAttributes& attributes = {},
-    const NodeId& variableType = VariableTypeId::BaseDataVariableType,
-    const NodeId& referenceType = ReferenceTypeId::HasSubtype
+    const VariableTypeAttributes& attributes,
+    const NodeId& variableType,
+    const NodeId& referenceType
 ) noexcept {
     return addNode(
         connection,
@@ -735,16 +728,16 @@ Result<NodeId> addVariableType(
  * @param token @completiontoken{void(Result<NodeId>&)}
  * @return @asyncresult{Result<NodeId>}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto addVariableTypeAsync(
     Client& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
-    const VariableTypeAttributes& attributes = {},
-    const NodeId& variableType = VariableTypeId::BaseDataVariableType,
-    const NodeId& referenceType = ReferenceTypeId::HasSubtype,
-    CompletionToken&& token = DefaultCompletionToken()
+    const VariableTypeAttributes& attributes,
+    const NodeId& variableType,
+    const NodeId& referenceType,
+    CompletionToken&& token
 ) {
     return addNodeAsync(
         connection,
@@ -766,7 +759,8 @@ auto addVariableTypeAsync(
  * @param id Requested NodeId of the node to add
  * @param browseName Browse name
  * @param attributes Reference type attributes
- * @param referenceType Hierarchical reference type from the parent node to the new node
+ * @param referenceType Hierarchical reference type from the parent node to the new node, e.g.
+ *                      ReferenceTypeId::HasSubtype
  */
 template <typename T>
 Result<NodeId> addReferenceType(
@@ -774,8 +768,8 @@ Result<NodeId> addReferenceType(
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
-    const ReferenceTypeAttributes& attributes = {},
-    const NodeId& referenceType = ReferenceTypeId::HasSubtype
+    const ReferenceTypeAttributes& attributes,
+    const NodeId& referenceType
 ) noexcept {
     return addNode(
         connection,
@@ -794,15 +788,15 @@ Result<NodeId> addReferenceType(
  * @param token @completiontoken{void(Result<NodeId>&)}
  * @return @asyncresult{Result<NodeId>}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto addReferenceTypeAsync(
     Client& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
-    const ReferenceTypeAttributes& attributes = {},
-    const NodeId& referenceType = ReferenceTypeId::HasSubtype,
-    CompletionToken&& token = DefaultCompletionToken()
+    const ReferenceTypeAttributes& attributes,
+    const NodeId& referenceType,
+    CompletionToken&& token
 ) {
     return addNodeAsync(
         connection,
@@ -824,7 +818,8 @@ auto addReferenceTypeAsync(
  * @param id Requested NodeId of the node to add
  * @param browseName Browse name
  * @param attributes Data type attributes
- * @param referenceType Hierarchical reference type from the parent node to the new node
+ * @param referenceType Hierarchical reference type from the parent node to the new node, e.g.
+ *                      ReferenceTypeId::HasSubtype
  */
 template <typename T>
 Result<NodeId> addDataType(
@@ -832,8 +827,8 @@ Result<NodeId> addDataType(
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
-    const DataTypeAttributes& attributes = {},
-    const NodeId& referenceType = ReferenceTypeId::HasSubtype
+    const DataTypeAttributes& attributes,
+    const NodeId& referenceType
 ) noexcept {
     return addNode(
         connection,
@@ -852,15 +847,15 @@ Result<NodeId> addDataType(
  * @param token @completiontoken{void(Result<NodeId>&)}
  * @return @asyncresult{Result<NodeId>}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto addDataTypeAsync(
     Client& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
-    const DataTypeAttributes& attributes = {},
-    const NodeId& referenceType = ReferenceTypeId::HasSubtype,
-    CompletionToken&& token = DefaultCompletionToken()
+    const DataTypeAttributes& attributes,
+    const NodeId& referenceType,
+    CompletionToken&& token
 ) {
     return addNodeAsync(
         connection,
@@ -882,7 +877,8 @@ auto addDataTypeAsync(
  * @param id Requested NodeId of the node to add
  * @param browseName Browse name
  * @param attributes View attributes
- * @param referenceType Hierarchical reference type from the parent node to the new node
+ * @param referenceType Hierarchical reference type from the parent node to the new node, e.g.
+ *                      ReferenceTypeId::Organizes
  */
 template <typename T>
 Result<NodeId> addView(
@@ -890,8 +886,8 @@ Result<NodeId> addView(
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
-    const ViewAttributes& attributes = {},
-    const NodeId& referenceType = ReferenceTypeId::Organizes
+    const ViewAttributes& attributes,
+    const NodeId& referenceType
 ) noexcept {
     return addNode(
         connection,
@@ -910,15 +906,15 @@ Result<NodeId> addView(
  * @param token @completiontoken{void(Result<NodeId>&)}
  * @return @asyncresult{Result<NodeId>}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto addViewAsync(
     Client& connection,
     const NodeId& parentId,
     const NodeId& id,
     std::string_view browseName,
-    const ViewAttributes& attributes = {},
-    const NodeId& referenceType = ReferenceTypeId::Organizes,
-    CompletionToken&& token = DefaultCompletionToken()
+    const ViewAttributes& attributes,
+    const NodeId& referenceType,
+    CompletionToken&& token
 ) {
     return addNodeAsync(
         connection,
@@ -958,12 +954,9 @@ StatusCode addModellingRule(T& connection, const NodeId& id, ModellingRule rule)
  * @param token @completiontoken{void(StatusCode)}
  * @return @asyncresult{StatusCode}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto addModellingRuleAsync(
-    Client& connection,
-    const NodeId& id,
-    ModellingRule rule,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const NodeId& id, ModellingRule rule, CompletionToken&& token
 ) {
     return addReferenceAsync(
         connection,

--- a/include/open62541pp/services/subscription.hpp
+++ b/include/open62541pp/services/subscription.hpp
@@ -100,17 +100,17 @@ void storeSubscriptionContext(
 [[nodiscard]] CreateSubscriptionResponse createSubscription(
     Client& connection,
     const CreateSubscriptionRequest& request,
-    StatusChangeNotificationCallback statusChangeCallback = {},
-    DeleteSubscriptionCallback deleteCallback = {}
+    StatusChangeNotificationCallback statusChangeCallback,
+    DeleteSubscriptionCallback deleteCallback
 );
 
 /// @overload
 [[nodiscard]] CreateSubscriptionResponse createSubscription(
     Client& connection,
     const SubscriptionParameters& parameters,
-    bool publishingEnabled = true,
-    StatusChangeNotificationCallback statusChangeCallback = {},
-    DeleteSubscriptionCallback deleteCallback = {}
+    bool publishingEnabled,
+    StatusChangeNotificationCallback statusChangeCallback,
+    DeleteSubscriptionCallback deleteCallback
 ) noexcept;
 
 #if UAPP_OPEN62541_VER_GE(1, 1)
@@ -120,13 +120,13 @@ void storeSubscriptionContext(
  * @param token @completiontoken{void(CreateSubscriptionResponse&)}
  * @return @asyncresult{CreateSubscriptionResponse}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto createSubscriptionAsync(
     Client& connection,
     const CreateSubscriptionRequest& request,
-    StatusChangeNotificationCallback statusChangeCallback = {},
-    DeleteSubscriptionCallback deleteCallback = {},
-    CompletionToken&& token = DefaultCompletionToken()
+    StatusChangeNotificationCallback statusChangeCallback,
+    DeleteSubscriptionCallback deleteCallback,
+    CompletionToken&& token
 ) {
     auto context = detail::createSubscriptionContext(
         connection, std::move(statusChangeCallback), std::move(deleteCallback)
@@ -159,14 +159,14 @@ auto createSubscriptionAsync(
 }
 
 /// @overload
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto createSubscriptionAsync(
     Client& connection,
     const SubscriptionParameters& parameters,
-    bool publishingEnabled = true,
-    StatusChangeNotificationCallback statusChangeCallback = {},
-    DeleteSubscriptionCallback deleteCallback = {},
-    CompletionToken&& token = DefaultCompletionToken()
+    bool publishingEnabled,
+    StatusChangeNotificationCallback statusChangeCallback,
+    DeleteSubscriptionCallback deleteCallback,
+    CompletionToken&& token
 ) {
     const auto request = detail::createCreateSubscriptionRequest(parameters, publishingEnabled);
     return createSubscriptionAsync(
@@ -210,11 +210,9 @@ inline ModifySubscriptionResponse modifySubscription(
  * @param token @completiontoken{void(ModifySubscriptionResponse&)}
  * @return @asyncresult{ModifySubscriptionResponse}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto modifySubscriptionAsync(
-    Client& connection,
-    const ModifySubscriptionRequest& request,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const ModifySubscriptionRequest& request, CompletionToken&& token
 ) {
     return detail::AsyncServiceAdapter<ModifySubscriptionResponse>::initiate(
         connection,
@@ -228,12 +226,12 @@ auto modifySubscriptionAsync(
 }
 
 /// @overload
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto modifySubscriptionAsync(
     Client& connection,
     uint32_t subscriptionId,
     const SubscriptionParameters& parameters,
-    CompletionToken&& token = DefaultCompletionToken()
+    CompletionToken&& token
 ) {
     const auto request = detail::createModifySubscriptionRequest(subscriptionId, parameters);
     return modifySubscriptionAsync(
@@ -268,11 +266,9 @@ SetPublishingModeResponse setPublishingMode(
  * @param token @completiontoken{void(SetPublishingModeResponse&)}
  * @return @asyncresult{SetPublishingModeResponse}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto setPublishingModeAsync(
-    Client& connection,
-    const SetPublishingModeRequest& request,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const SetPublishingModeRequest& request, CompletionToken&& token
 ) {
     return detail::sendRequestAsync<SetPublishingModeRequest, SetPublishingModeResponse>(
         connection, request, std::forward<CompletionToken>(token)
@@ -299,12 +295,9 @@ inline StatusCode setPublishingMode(
  * @param token @completiontoken{void(StatusCode)}
  * @return @asyncresult{StatusCode}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto setPublishingModeAsync(
-    Client& connection,
-    uint32_t subscriptionId,
-    bool publishing,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, uint32_t subscriptionId, bool publishing, CompletionToken&& token
 ) {
     const auto request = detail::createSetPublishingModeRequest(publishing, {&subscriptionId, 1});
     return setPublishingModeAsync(
@@ -340,11 +333,9 @@ DeleteSubscriptionsResponse deleteSubscriptions(
  * @param token @completiontoken{void(DeleteSubscriptionsResponse&)}
  * @return @asyncresult{DeleteSubscriptionsResponse}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto deleteSubscriptionsAsync(
-    Client& connection,
-    const DeleteSubscriptionsRequest& request,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const DeleteSubscriptionsRequest& request, CompletionToken&& token
 ) {
     return detail::AsyncServiceAdapter<DeleteSubscriptionsResponse>::initiate(
         connection,
@@ -376,10 +367,8 @@ inline StatusCode deleteSubscription(Client& connection, uint32_t subscriptionId
  * @param token @completiontoken{void(StatusCode)}
  * @return @asyncresult{StatusCode}
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto deleteSubscriptionAsync(
-    Client& connection, uint32_t subscriptionId, CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto deleteSubscriptionAsync(Client& connection, uint32_t subscriptionId, CompletionToken&& token) {
     const auto request = detail::createDeleteSubscriptionsRequest(subscriptionId);
     return deleteSubscriptionsAsync(
         connection,

--- a/include/open62541pp/services/view.hpp
+++ b/include/open62541pp/services/view.hpp
@@ -50,12 +50,8 @@ BrowseResponse browse(Client& connection, const BrowseRequest& request) noexcept
  * @param token @completiontoken{void(BrowseResponse&)}
  * @return @asyncresult{BrowseResponse}
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto browseAsync(
-    Client& connection,
-    const BrowseRequest& request,
-    CompletionToken&& token = DefaultCompletionToken()
-) {
+template <typename CompletionToken>
+auto browseAsync(Client& connection, const BrowseRequest& request, CompletionToken&& token) {
     return detail::sendRequestAsync<BrowseRequest, BrowseResponse>(
         connection, request, std::forward<CompletionToken>(token)
     );
@@ -69,21 +65,16 @@ auto browseAsync(
  * @param maxReferences The maximum number of references to return (0 if no limit)
  */
 template <typename T>
-BrowseResult browse(
-    T& connection, const BrowseDescription& bd, uint32_t maxReferences = 0
-) noexcept;
+BrowseResult browse(T& connection, const BrowseDescription& bd, uint32_t maxReferences) noexcept;
 
 /**
  * @copydoc browse(T&, const BrowseDescription&, uint32_t)
  * @param token @completiontoken{void(BrowseResult&)}
  * @return @asyncresult{BrowseResult}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto browseAsync(
-    Client& connection,
-    const BrowseDescription& bd,
-    uint32_t maxReferences = 0,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const BrowseDescription& bd, uint32_t maxReferences, CompletionToken&& token
 ) {
     const auto request = detail::createBrowseRequest(bd, maxReferences);
     return browseAsync(
@@ -118,11 +109,9 @@ BrowseNextResponse browseNext(Client& connection, const BrowseNextRequest& reque
  * @param token @completiontoken{void(BrowseNextResponse&)}
  * @return @asyncresult{BrowseNextResponse}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto browseNextAsync(
-    Client& connection,
-    const BrowseNextRequest& request,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const BrowseNextRequest& request, CompletionToken&& token
 ) {
     return detail::sendRequestAsync<BrowseNextRequest, BrowseNextResponse>(
         connection, request, std::forward<CompletionToken>(token)
@@ -147,12 +136,12 @@ BrowseResult browseNext(
  * @param token @completiontoken{void(BrowseResult&)}
  * @return @asyncresult{BrowseResult}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto browseNextAsync(
     Client& connection,
     bool releaseContinuationPoint,
     const ByteString& continuationPoint,
-    CompletionToken&& token = DefaultCompletionToken()
+    CompletionToken&& token
 ) {
     const auto request = detail::createBrowseNextRequest(
         releaseContinuationPoint, continuationPoint
@@ -190,11 +179,9 @@ TranslateBrowsePathsToNodeIdsResponse translateBrowsePathsToNodeIds(
  * @param token @completiontoken{void(TranslateBrowsePathsToNodeIdsResponse&)}
  * @return @asyncresult{TranslateBrowsePathsToNodeIdsResponse}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto translateBrowsePathsToNodeIdsAsync(
-    Client& connection,
-    const TranslateBrowsePathsToNodeIdsRequest& request,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const TranslateBrowsePathsToNodeIdsRequest& request, CompletionToken&& token
 ) {
     return detail::sendRequestAsync<
         TranslateBrowsePathsToNodeIdsRequest,
@@ -217,11 +204,9 @@ BrowsePathResult translateBrowsePathToNodeIds(T& connection, const BrowsePath& b
  * @param token @completiontoken{void(BrowsePathResult&)}
  * @return @asyncresult{BrowsePathResult}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto translateBrowsePathToNodeIdsAsync(
-    Client& connection,
-    const BrowsePath& browsePath,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const BrowsePath& browsePath, CompletionToken&& token
 ) {
     const auto request = detail::createTranslateBrowsePathsToNodeIdsRequest(browsePath);
     return translateBrowsePathsToNodeIdsAsync(
@@ -259,12 +244,12 @@ BrowsePathResult browseSimplifiedBrowsePath(
  * @param token @completiontoken{void(BrowsePathResult&)}
  * @return @asyncresult{BrowsePathResult}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto browseSimplifiedBrowsePathAsync(
     Client& connection,
     const NodeId& origin,
     Span<const QualifiedName> browsePath,
-    CompletionToken&& token = DefaultCompletionToken()
+    CompletionToken&& token
 ) {
     return translateBrowsePathToNodeIdsAsync(
         connection,
@@ -296,11 +281,9 @@ RegisterNodesResponse registerNodes(
  * @param token @completiontoken{void(RegisterNodesResponse&)}
  * @return @asyncresult{RegisterNodesResponse}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto registerNodesAsync(
-    Client& connection,
-    const RegisterNodesRequest& request,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const RegisterNodesRequest& request, CompletionToken&& token
 ) {
     return detail::sendRequestAsync<RegisterNodesRequest, RegisterNodesResponse>(
         connection, request, std::forward<CompletionToken>(token)
@@ -330,11 +313,9 @@ UnregisterNodesResponse unregisterNodes(
  * @param token @completiontoken{void(UnregisterNodesResponse&)}
  * @return @asyncresult{UnregisterNodesResponse}
  */
-template <typename CompletionToken = DefaultCompletionToken>
+template <typename CompletionToken>
 auto unregisterNodesAsync(
-    Client& connection,
-    const UnregisterNodesRequest& request,
-    CompletionToken&& token = DefaultCompletionToken()
+    Client& connection, const UnregisterNodesRequest& request, CompletionToken&& token
 ) {
     return detail::sendRequestAsync<UnregisterNodesRequest, UnregisterNodesResponse>(
         connection, request, std::forward<CompletionToken>(token)

--- a/include/open62541pp/subscription.hpp
+++ b/include/open62541pp/subscription.hpp
@@ -97,7 +97,8 @@ public:
             {id, attribute},
             monitoringMode,
             parameters,
-            std::move(onDataChange)
+            std::move(onDataChange),
+            {}
         );
         result.getStatusCode().throwIfBad();
         return {connection(), subscriptionId(), result.getMonitoredItemId()};

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -427,7 +427,7 @@ Subscription<Client> Client::createSubscription() {
 }
 
 Subscription<Client> Client::createSubscription(const SubscriptionParameters& parameters) {
-    const auto response = services::createSubscription(*this, parameters, true);
+    const auto response = services::createSubscription(*this, parameters, true, {}, {});
     response.getResponseHeader().getServiceResult().throwIfBad();
     return {*this, response.getSubscriptionId()};
 }

--- a/tests/client_service.cpp
+++ b/tests/client_service.cpp
@@ -19,15 +19,12 @@ TEST_CASE("AsyncServiceAdapter") {
         bool throwInCompletionHandler = false;
         detail::ExceptionCatcher catcher;
 
-        auto callbackAndContext = Adapter::createCallbackAndContext(
-            catcher,
-            [&](Response res) {
-                result = res;
-                if (throwInCompletionHandler) {
-                    throw std::runtime_error("CompletionHandler");
-                }
+        auto callbackAndContext = Adapter::createCallbackAndContext(catcher, [&](Response res) {
+            result = res;
+            if (throwInCompletionHandler) {
+                throw std::runtime_error("CompletionHandler");
             }
-        );
+        });
 
         const auto invokeCallback = [&](int* response) {
             callbackAndContext.callback(
@@ -108,9 +105,7 @@ TEST_CASE("sendRequestAsync") {
         request.nodesToReadSize = 1;
         request.nodesToRead = &item;
         return services::detail::sendRequestAsync<UA_ReadRequest, ReadResponse>(
-            client,
-            request,
-            std::forward<decltype(token)>(token)
+            client, request, std::forward<decltype(token)>(token)
         );
     };
 

--- a/tests/node.cpp
+++ b/tests/node.cpp
@@ -15,7 +15,16 @@ TEST_CASE_TEMPLATE("Node", T, Server, Client) {
     auto& connection = setup.getInstance<T>();
 
     const NodeId varId{1, 1};
-    services::addVariable(setup.server, {0, UA_NS0ID_OBJECTSFOLDER}, varId, "variable").value();
+    services::addVariable(
+        setup.server,
+        {0, UA_NS0ID_OBJECTSFOLDER},
+        varId,
+        "variable",
+        {},
+        VariableTypeId::BaseDataVariableType,
+        ReferenceTypeId::HasComponent
+    )
+        .value();
     // set all bits to 1 -> allow all
     services::writeAccessLevel(setup.server, varId, 0xFF).throwIfBad();
     services::writeWriteMask(setup.server, varId, 0xFFFFFFFF).throwIfBad();

--- a/tests/services_helper.cpp
+++ b/tests/services_helper.cpp
@@ -74,13 +74,17 @@ TEST_CASE("Response handling") {
 
     SUBCASE("wrapSingleResultWithStatus") {
         CHECK_EQ(
-            services::detail::wrapSingleResultWithStatus<AddNodesResult>(response).getStatusCode().get(),
+            services::detail::wrapSingleResultWithStatus<AddNodesResult>(response)
+                .getStatusCode()
+                .get(),
             UA_STATUSCODE_GOOD
         );
 
         response.responseHeader.serviceResult = UA_STATUSCODE_BADINTERNALERROR;
         CHECK_EQ(
-            services::detail::wrapSingleResultWithStatus<AddNodesResult>(response).getStatusCode().get(),
+            services::detail::wrapSingleResultWithStatus<AddNodesResult>(response)
+                .getStatusCode()
+                .get(),
             UA_STATUSCODE_BADINTERNALERROR
         );
     }

--- a/tests/services_method.cpp
+++ b/tests/services_method.cpp
@@ -45,11 +45,11 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
 
     auto call = [&](auto&&... args) {
         if constexpr (isAsync<T>) {
-            auto future = services::callAsync(std::forward<decltype(args)>(args)..., useFuture);
+            auto future = services::callAsync(args..., useFuture);
             setup.client.runIterate();
             return future.get();
         } else {
-            return services::call(std::forward<decltype(args)>(args)...);
+            return services::call(args...);
         }
     };
 

--- a/tests/services_method.cpp
+++ b/tests/services_method.cpp
@@ -37,13 +37,15 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
         },
         {
             Argument("sum", {"en-US", "sum of both numbers"}, DataTypeId::Int32, ValueRank::Scalar),
-        }
+        },
+        MethodAttributes{},
+        ReferenceTypeId::HasComponent
     )
         .value();
 
     auto call = [&](auto&&... args) {
         if constexpr (isAsync<T>) {
-            auto future = services::callAsync(std::forward<decltype(args)>(args)...);
+            auto future = services::callAsync(std::forward<decltype(args)>(args)..., useFuture);
             setup.client.runIterate();
             return future.get();
         } else {

--- a/tests/services_nodemanagement.cpp
+++ b/tests/services_nodemanagement.cpp
@@ -20,11 +20,28 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
     SUBCASE("addObject") {
         Result<NodeId> result;
         if constexpr (isAsync<T>) {
-            auto future = services::addObjectAsync(connection, objectsId, newId, "Object");
+            auto future = services::addObjectAsync(
+                connection,
+                objectsId,
+                newId,
+                "Object",
+                ObjectAttributes{},
+                ObjectTypeId::BaseObjectType,
+                ReferenceTypeId::HasComponent,
+                useFuture
+            );
             setup.client.runIterate();
             result = future.get();
         } else {
-            result = services::addObject(connection, objectsId, newId, "Object");
+            result = services::addObject(
+                connection,
+                objectsId,
+                newId,
+                "Object",
+                ObjectAttributes{},
+                ObjectTypeId::BaseObjectType,
+                ReferenceTypeId::HasComponent
+            );
         }
         CHECK_EQ(result.value(), newId);
         CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::Object);
@@ -33,11 +50,15 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
     SUBCASE("addFolder") {
         Result<NodeId> result;
         if constexpr (isAsync<T>) {
-            auto future = services::addFolderAsync(connection, objectsId, newId, "Folder");
+            auto future = services::addFolderAsync(
+                connection, objectsId, newId, "Folder", {}, ReferenceTypeId::HasComponent, useFuture
+            );
             setup.client.runIterate();
             result = future.get();
         } else {
-            result = services::addFolder(connection, objectsId, newId, "Folder");
+            result = services::addFolder(
+                connection, objectsId, newId, "Folder", {}, ReferenceTypeId::HasComponent
+            );
         }
         CHECK_EQ(result.value(), newId);
         CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::Object);
@@ -46,11 +67,28 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
     SUBCASE("addVariable") {
         Result<NodeId> result;
         if constexpr (isAsync<T>) {
-            auto future = services::addVariableAsync(connection, objectsId, newId, "Variable");
+            auto future = services::addVariableAsync(
+                connection,
+                objectsId,
+                newId,
+                "Variable",
+                VariableAttributes{},
+                VariableTypeId::BaseDataVariableType,
+                ReferenceTypeId::HasComponent,
+                useFuture
+            );
             setup.client.runIterate();
             result = future.get();
         } else {
-            result = services::addVariable(connection, objectsId, newId, "Variable");
+            result = services::addVariable(
+                connection,
+                objectsId,
+                newId,
+                "Variable",
+                VariableAttributes{},
+                VariableTypeId::BaseDataVariableType,
+                ReferenceTypeId::HasComponent
+            );
         }
         CHECK_EQ(result.value(), newId);
         CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::Variable);
@@ -59,11 +97,13 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
     SUBCASE("addProperty") {
         Result<NodeId> result;
         if constexpr (isAsync<T>) {
-            auto future = services::addPropertyAsync(connection, objectsId, newId, "Property");
+            auto future = services::addPropertyAsync(
+                connection, objectsId, newId, "Property", {}, useFuture
+            );
             setup.client.runIterate();
             result = future.get();
         } else {
-            result = services::addProperty(connection, objectsId, newId, "Property");
+            result = services::addProperty(connection, objectsId, newId, "Property", {});
         }
         CHECK_EQ(result.value(), newId);
         CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::Variable);
@@ -74,12 +114,31 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
         Result<NodeId> result;
         if constexpr (isAsync<T>) {
             auto future = services::addMethodAsync(
-                connection, objectsId, newId, "Method", {}, {}, {}
+                connection,
+                objectsId,
+                newId,
+                "Method",
+                {},  // callback
+                {},  // input arguments
+                {},  // output arguments
+                MethodAttributes{},
+                ReferenceTypeId::HasComponent,
+                useFuture
             );
             setup.client.runIterate();
             result = future.get();
         } else {
-            result = services::addMethod(connection, objectsId, newId, "Method", {}, {}, {});
+            result = services::addMethod(
+                connection,
+                objectsId,
+                newId,
+                "Method",
+                {},  // callback
+                {},  // input arguments
+                {},  // output arguments
+                MethodAttributes{},
+                ReferenceTypeId::HasComponent
+            );
         }
         CHECK_EQ(result.value(), newId);
         CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::Method);
@@ -90,13 +149,24 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
         Result<NodeId> result;
         if constexpr (isAsync<T>) {
             auto future = services::addObjectTypeAsync(
-                connection, {0, UA_NS0ID_BASEOBJECTTYPE}, newId, "ObjectType"
+                connection,
+                {0, UA_NS0ID_BASEOBJECTTYPE},
+                newId,
+                "ObjectType",
+                ObjectTypeAttributes{},
+                ReferenceTypeId::HasSubtype,
+                useFuture
             );
             setup.client.runIterate();
             result = future.get();
         } else {
             result = services::addObjectType(
-                connection, {0, UA_NS0ID_BASEOBJECTTYPE}, newId, "ObjectType"
+                connection,
+                {0, UA_NS0ID_BASEOBJECTTYPE},
+                newId,
+                "ObjectType",
+                ObjectTypeAttributes{},
+                ReferenceTypeId::HasSubtype
             );
         }
         CHECK_EQ(result.value(), newId);
@@ -107,13 +177,26 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
         Result<NodeId> result;
         if constexpr (isAsync<T>) {
             auto future = services::addVariableTypeAsync(
-                connection, {0, UA_NS0ID_BASEVARIABLETYPE}, newId, "VariableType"
+                connection,
+                {0, UA_NS0ID_BASEVARIABLETYPE},
+                newId,
+                "VariableType",
+                VariableTypeAttributes{},
+                VariableTypeId::BaseDataVariableType,
+                ReferenceTypeId::HasSubtype,
+                useFuture
             );
             setup.client.runIterate();
             result = future.get();
         } else {
             result = services::addVariableType(
-                connection, {0, UA_NS0ID_BASEVARIABLETYPE}, newId, "VariableType"
+                connection,
+                {0, UA_NS0ID_BASEVARIABLETYPE},
+                newId,
+                "VariableType",
+                VariableTypeAttributes{},
+                VariableTypeId::BaseDataVariableType,
+                ReferenceTypeId::HasSubtype
             );
         }
         CHECK_EQ(result.value(), newId);
@@ -124,13 +207,24 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
         Result<NodeId> result;
         if constexpr (isAsync<T>) {
             auto future = services::addReferenceTypeAsync(
-                connection, {0, UA_NS0ID_ORGANIZES}, newId, "ReferenceType"
+                connection,
+                {0, UA_NS0ID_ORGANIZES},
+                newId,
+                "ReferenceType",
+                ReferenceTypeAttributes{},
+                ReferenceTypeId::HasSubtype,
+                useFuture
             );
             setup.client.runIterate();
             result = future.get();
         } else {
             result = services::addReferenceType(
-                connection, {0, UA_NS0ID_ORGANIZES}, newId, "ReferenceType"
+                connection,
+                {0, UA_NS0ID_ORGANIZES},
+                newId,
+                "ReferenceType",
+                ReferenceTypeAttributes{},
+                ReferenceTypeId::HasSubtype
             );
         }
         CHECK_EQ(result.value(), newId);
@@ -141,12 +235,25 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
         Result<NodeId> result;
         if constexpr (isAsync<T>) {
             auto future = services::addDataTypeAsync(
-                connection, {0, UA_NS0ID_STRUCTURE}, newId, "DataType"
+                connection,
+                {0, UA_NS0ID_STRUCTURE},
+                newId,
+                "DataType",
+                DataTypeAttributes{},
+                ReferenceTypeId::HasSubtype,
+                useFuture
             );
             setup.client.runIterate();
             result = future.get();
         } else {
-            result = services::addDataType(connection, {0, UA_NS0ID_STRUCTURE}, newId, "DataType");
+            result = services::addDataType(
+                connection,
+                {0, UA_NS0ID_STRUCTURE},
+                newId,
+                "DataType",
+                DataTypeAttributes{},
+                ReferenceTypeId::HasSubtype
+            );
         }
         CHECK_EQ(result.value(), newId);
         CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::DataType);
@@ -156,31 +263,56 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
         Result<NodeId> result;
         if constexpr (isAsync<T>) {
             auto future = services::addViewAsync(
-                connection, {0, UA_NS0ID_VIEWSFOLDER}, newId, "View"
+                connection,
+                {0, UA_NS0ID_VIEWSFOLDER},
+                newId,
+                "View",
+                ViewAttributes{},
+                ReferenceTypeId::Organizes,
+                useFuture
             );
             setup.client.runIterate();
             result = future.get();
         } else {
-            result = services::addView(connection, {0, UA_NS0ID_VIEWSFOLDER}, newId, "View");
+            result = services::addView(
+                connection,
+                {0, UA_NS0ID_VIEWSFOLDER},
+                newId,
+                "View",
+                ViewAttributes{},
+                ReferenceTypeId::Organizes
+            );
         }
         CHECK_EQ(result.value(), newId);
         CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::View);
     }
 
     SUBCASE("Add/delete reference") {
-        services::addFolder(connection, objectsId, {1, 1000}, "Folder").value();
-        services::addObject(connection, objectsId, {1, 1001}, "Object").value();
+        services::addFolder(
+            connection, objectsId, {1, 1000}, "Folder", {}, ReferenceTypeId::HasComponent
+        )
+            .value();
+        services::addObject(
+            connection,
+            objectsId,
+            {1, 1001},
+            "Object",
+            {},
+            ObjectTypeId::BaseObjectType,
+            ReferenceTypeId::HasComponent
+        )
+            .value();
 
         auto addReference = [&] {
             if constexpr (isAsync<T>) {
                 auto future = services::addReferenceAsync(
-                    connection, {1, 1000}, {1, 1001}, ReferenceTypeId::Organizes
+                    connection, {1, 1000}, {1, 1001}, ReferenceTypeId::Organizes, true, useFuture
                 );
                 setup.client.runIterate();
                 return future.get();
             } else {
                 return services::addReference(
-                    connection, {1, 1000}, {1, 1001}, ReferenceTypeId::Organizes
+                    connection, {1, 1000}, {1, 1001}, ReferenceTypeId::Organizes, true
                 );
             }
         };
@@ -190,7 +322,13 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
         auto deleteReference = [&] {
             if constexpr (isAsync<T>) {
                 auto future = services::deleteReferenceAsync(
-                    connection, {1, 1000}, {1, 1001}, ReferenceTypeId::Organizes, true, true
+                    connection,
+                    {1, 1000},
+                    {1, 1001},
+                    ReferenceTypeId::Organizes,
+                    true,
+                    true,
+                    useFuture
                 );
                 setup.client.runIterate();
                 return future.get();
@@ -204,15 +342,24 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
     }
 
     SUBCASE("Delete node") {
-        services::addObject(connection, objectsId, {1, 1000}, "Object").value();
+        services::addObject(
+            connection,
+            objectsId,
+            {1, 1000},
+            "Object",
+            {},
+            ObjectTypeId::BaseObjectType,
+            ReferenceTypeId::HasComponent
+        )
+            .value();
 
         auto deleteNode = [&] {
             if constexpr (isAsync<T>) {
-                auto future = services::deleteNodeAsync(connection, {1, 1000});
+                auto future = services::deleteNodeAsync(connection, {1, 1000}, true, useFuture);
                 setup.client.runIterate();
                 return future.get();
             } else {
-                return services::deleteNode(connection, {1, 1000});
+                return services::deleteNode(connection, {1, 1000}, true);
             }
         };
         CHECK(deleteNode().isGood());
@@ -221,7 +368,17 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
 
     SUBCASE("Random node id") {
         // https://www.open62541.org/doc/1.3/server.html#node-addition-and-deletion
-        const auto id = services::addObject(connection, objectsId, {1, 0}, "Random").value();
+        const auto id =
+            services::addObject(
+                connection,
+                objectsId,
+                {1, 0},
+                "Random",
+                {},
+                ObjectTypeId::BaseObjectType,
+                ReferenceTypeId::HasComponent
+            )
+                .value();
         CHECK(id != NodeId(1, 0));
         CHECK(id.getNamespaceIndex() == 1);
     }

--- a/tests/services_nodemanagement.cpp
+++ b/tests/services_nodemanagement.cpp
@@ -18,271 +18,224 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
     const NodeId newId{1, 1000};
 
     SUBCASE("addObject") {
-        Result<NodeId> result;
-        if constexpr (isAsync<T>) {
-            auto future = services::addObjectAsync(
-                connection,
-                objectsId,
-                newId,
-                "Object",
-                ObjectAttributes{},
-                ObjectTypeId::BaseObjectType,
-                ReferenceTypeId::HasComponent,
-                useFuture
-            );
-            setup.client.runIterate();
-            result = future.get();
-        } else {
-            result = services::addObject(
-                connection,
-                objectsId,
-                newId,
-                "Object",
-                ObjectAttributes{},
-                ObjectTypeId::BaseObjectType,
-                ReferenceTypeId::HasComponent
-            );
-        }
+        const auto addObject = [&](auto&&... args) {
+            if constexpr (isAsync<T>) {
+                auto future = services::addObjectAsync(args..., useFuture);
+                setup.client.runIterate();
+                return future.get();
+            } else {
+                return services::addObject(args...);
+            }
+        };
+        const Result<NodeId> result = addObject(
+            connection,
+            objectsId,
+            newId,
+            "Object",
+            ObjectAttributes{},
+            ObjectTypeId::BaseObjectType,
+            ReferenceTypeId::HasComponent
+        );
         CHECK_EQ(result.value(), newId);
         CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::Object);
     }
 
     SUBCASE("addFolder") {
-        Result<NodeId> result;
-        if constexpr (isAsync<T>) {
-            auto future = services::addFolderAsync(
-                connection, objectsId, newId, "Folder", {}, ReferenceTypeId::HasComponent, useFuture
-            );
-            setup.client.runIterate();
-            result = future.get();
-        } else {
-            result = services::addFolder(
-                connection, objectsId, newId, "Folder", {}, ReferenceTypeId::HasComponent
-            );
-        }
+        const auto addFolder = [&](auto&&... args) {
+            if constexpr (isAsync<T>) {
+                auto future = services::addFolderAsync(args..., useFuture);
+                setup.client.runIterate();
+                return future.get();
+            } else {
+                return services::addFolder(args...);
+            }
+        };
+        const Result<NodeId> result = addFolder(
+            connection,
+            objectsId,
+            newId,
+            "Folder",
+            ObjectAttributes{},
+            ReferenceTypeId::HasComponent
+        );
         CHECK_EQ(result.value(), newId);
         CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::Object);
     }
 
     SUBCASE("addVariable") {
-        Result<NodeId> result;
-        if constexpr (isAsync<T>) {
-            auto future = services::addVariableAsync(
-                connection,
-                objectsId,
-                newId,
-                "Variable",
-                VariableAttributes{},
-                VariableTypeId::BaseDataVariableType,
-                ReferenceTypeId::HasComponent,
-                useFuture
-            );
-            setup.client.runIterate();
-            result = future.get();
-        } else {
-            result = services::addVariable(
-                connection,
-                objectsId,
-                newId,
-                "Variable",
-                VariableAttributes{},
-                VariableTypeId::BaseDataVariableType,
-                ReferenceTypeId::HasComponent
-            );
-        }
+        const auto addVariable = [&](auto&&... args) {
+            if constexpr (isAsync<T>) {
+                auto future = services::addVariableAsync(args..., useFuture);
+                setup.client.runIterate();
+                return future.get();
+            } else {
+                return services::addVariable(args...);
+            }
+        };
+        const Result<NodeId> result = addVariable(
+            connection,
+            objectsId,
+            newId,
+            "Variable",
+            VariableAttributes{},
+            VariableTypeId::BaseDataVariableType,
+            ReferenceTypeId::HasComponent
+        );
         CHECK_EQ(result.value(), newId);
         CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::Variable);
     }
 
     SUBCASE("addProperty") {
-        Result<NodeId> result;
-        if constexpr (isAsync<T>) {
-            auto future = services::addPropertyAsync(
-                connection, objectsId, newId, "Property", {}, useFuture
-            );
-            setup.client.runIterate();
-            result = future.get();
-        } else {
-            result = services::addProperty(connection, objectsId, newId, "Property", {});
-        }
+        const auto addProperty = [&](auto&&... args) {
+            if constexpr (isAsync<T>) {
+                auto future = services::addPropertyAsync(args..., useFuture);
+                setup.client.runIterate();
+                return future.get();
+            } else {
+                return services::addProperty(args...);
+            }
+        };
+        const Result<NodeId> result = addProperty(
+            connection, objectsId, newId, "Property", VariableAttributes{}
+        );
         CHECK_EQ(result.value(), newId);
         CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::Variable);
     }
 
 #ifdef UA_ENABLE_METHODCALLS
     SUBCASE("addMethod") {
-        Result<NodeId> result;
-        if constexpr (isAsync<T>) {
-            auto future = services::addMethodAsync(
-                connection,
-                objectsId,
-                newId,
-                "Method",
-                {},  // callback
-                {},  // input arguments
-                {},  // output arguments
-                MethodAttributes{},
-                ReferenceTypeId::HasComponent,
-                useFuture
-            );
-            setup.client.runIterate();
-            result = future.get();
-        } else {
-            result = services::addMethod(
-                connection,
-                objectsId,
-                newId,
-                "Method",
-                {},  // callback
-                {},  // input arguments
-                {},  // output arguments
-                MethodAttributes{},
-                ReferenceTypeId::HasComponent
-            );
-        }
+        const auto addMethod = [&](auto&&... args) {
+            if constexpr (isAsync<T>) {
+                auto future = services::addMethodAsync(args..., useFuture);
+                setup.client.runIterate();
+                return future.get();
+            } else {
+                return services::addMethod(args...);
+            }
+        };
+        const Result<NodeId> result = addMethod(
+            connection,
+            objectsId,
+            newId,
+            "Method",
+            nullptr,  // callback
+            opcua::Span<const opcua::Argument>{},  // input
+            opcua::Span<const opcua::Argument>{},  // output
+            MethodAttributes{},
+            ReferenceTypeId::HasComponent
+        );
         CHECK_EQ(result.value(), newId);
         CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::Method);
     }
 #endif
 
     SUBCASE("addObjectType") {
-        Result<NodeId> result;
-        if constexpr (isAsync<T>) {
-            auto future = services::addObjectTypeAsync(
-                connection,
-                {0, UA_NS0ID_BASEOBJECTTYPE},
-                newId,
-                "ObjectType",
-                ObjectTypeAttributes{},
-                ReferenceTypeId::HasSubtype,
-                useFuture
-            );
-            setup.client.runIterate();
-            result = future.get();
-        } else {
-            result = services::addObjectType(
-                connection,
-                {0, UA_NS0ID_BASEOBJECTTYPE},
-                newId,
-                "ObjectType",
-                ObjectTypeAttributes{},
-                ReferenceTypeId::HasSubtype
-            );
-        }
+        const auto addObjectType = [&](auto&&... args) {
+            if constexpr (isAsync<T>) {
+                auto future = services::addObjectTypeAsync(args..., useFuture);
+                setup.client.runIterate();
+                return future.get();
+            } else {
+                return services::addObjectType(args...);
+            }
+        };
+        const Result<NodeId> result = addObjectType(
+            connection,
+            opcua::ObjectTypeId::BaseObjectType,
+            newId,
+            "ObjectType",
+            ObjectTypeAttributes{},
+            ReferenceTypeId::HasSubtype
+        );
         CHECK_EQ(result.value(), newId);
         CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::ObjectType);
     }
 
     SUBCASE("addVariableType") {
-        Result<NodeId> result;
-        if constexpr (isAsync<T>) {
-            auto future = services::addVariableTypeAsync(
-                connection,
-                {0, UA_NS0ID_BASEVARIABLETYPE},
-                newId,
-                "VariableType",
-                VariableTypeAttributes{},
-                VariableTypeId::BaseDataVariableType,
-                ReferenceTypeId::HasSubtype,
-                useFuture
-            );
-            setup.client.runIterate();
-            result = future.get();
-        } else {
-            result = services::addVariableType(
-                connection,
-                {0, UA_NS0ID_BASEVARIABLETYPE},
-                newId,
-                "VariableType",
-                VariableTypeAttributes{},
-                VariableTypeId::BaseDataVariableType,
-                ReferenceTypeId::HasSubtype
-            );
-        }
+        const auto addVariableType = [&](auto&&... args) {
+            if constexpr (isAsync<T>) {
+                auto future = services::addVariableTypeAsync(args..., useFuture);
+                setup.client.runIterate();
+                return future.get();
+            } else {
+                return services::addVariableType(args...);
+            }
+        };
+        const Result<NodeId> result = addVariableType(
+            connection,
+            VariableTypeId::BaseVariableType,
+            newId,
+            "VariableType",
+            VariableTypeAttributes{},
+            VariableTypeId::BaseDataVariableType,
+            ReferenceTypeId::HasSubtype
+        );
         CHECK_EQ(result.value(), newId);
         CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::VariableType);
     }
 
     SUBCASE("addReferenceType") {
-        Result<NodeId> result;
-        if constexpr (isAsync<T>) {
-            auto future = services::addReferenceTypeAsync(
-                connection,
-                {0, UA_NS0ID_ORGANIZES},
-                newId,
-                "ReferenceType",
-                ReferenceTypeAttributes{},
-                ReferenceTypeId::HasSubtype,
-                useFuture
-            );
-            setup.client.runIterate();
-            result = future.get();
-        } else {
-            result = services::addReferenceType(
-                connection,
-                {0, UA_NS0ID_ORGANIZES},
-                newId,
-                "ReferenceType",
-                ReferenceTypeAttributes{},
-                ReferenceTypeId::HasSubtype
-            );
-        }
+        const auto addReferenceType = [&](auto&&... args) {
+            if constexpr (isAsync<T>) {
+                auto future = services::addReferenceTypeAsync(args..., useFuture);
+                setup.client.runIterate();
+                return future.get();
+            } else {
+                return services::addReferenceType(args...);
+            }
+        };
+        const Result<NodeId> result = addReferenceType(
+            connection,
+            ReferenceTypeId::Organizes,
+            newId,
+            "ReferenceType",
+            ReferenceTypeAttributes{},
+            ReferenceTypeId::HasSubtype
+        );
         CHECK_EQ(result.value(), newId);
         CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::ReferenceType);
     }
 
     SUBCASE("addDataType") {
-        Result<NodeId> result;
-        if constexpr (isAsync<T>) {
-            auto future = services::addDataTypeAsync(
-                connection,
-                {0, UA_NS0ID_STRUCTURE},
-                newId,
-                "DataType",
-                DataTypeAttributes{},
-                ReferenceTypeId::HasSubtype,
-                useFuture
-            );
-            setup.client.runIterate();
-            result = future.get();
-        } else {
-            result = services::addDataType(
-                connection,
-                {0, UA_NS0ID_STRUCTURE},
-                newId,
-                "DataType",
-                DataTypeAttributes{},
-                ReferenceTypeId::HasSubtype
-            );
-        }
+        const auto addDataType = [&](auto&&... args) {
+            if constexpr (isAsync<T>) {
+                auto future = services::addDataTypeAsync(args..., useFuture);
+                setup.client.runIterate();
+                return future.get();
+            } else {
+                return services::addDataType(args...);
+            }
+        };
+        const Result<NodeId> result = addDataType(
+            connection,
+            DataTypeId::Structure,
+            newId,
+            "DataType",
+            DataTypeAttributes{},
+            ReferenceTypeId::HasSubtype
+        );
         CHECK_EQ(result.value(), newId);
         CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::DataType);
     }
 
     SUBCASE("addView") {
-        Result<NodeId> result;
-        if constexpr (isAsync<T>) {
-            auto future = services::addViewAsync(
-                connection,
-                {0, UA_NS0ID_VIEWSFOLDER},
-                newId,
-                "View",
-                ViewAttributes{},
-                ReferenceTypeId::Organizes,
-                useFuture
-            );
-            setup.client.runIterate();
-            result = future.get();
-        } else {
-            result = services::addView(
-                connection,
-                {0, UA_NS0ID_VIEWSFOLDER},
-                newId,
-                "View",
-                ViewAttributes{},
-                ReferenceTypeId::Organizes
-            );
-        }
+        const auto addView = [&](auto&&... args) {
+            if constexpr (isAsync<T>) {
+                auto future = services::addViewAsync(args..., useFuture);
+                setup.client.runIterate();
+                return future.get();
+            } else {
+                return services::addView(args...);
+            }
+        };
+        const Result<NodeId> result = addView(
+            connection,
+            ObjectId::ViewsFolder,
+            newId,
+            "View",
+            ViewAttributes{},
+            ReferenceTypeId::Organizes
+        );
         CHECK_EQ(result.value(), newId);
         CHECK_EQ(services::readNodeClass(server, newId).value(), NodeClass::View);
     }
@@ -290,8 +243,7 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
     SUBCASE("Add/delete reference") {
         services::addFolder(
             connection, objectsId, {1, 1000}, "Folder", {}, ReferenceTypeId::HasComponent
-        )
-            .value();
+        );
         services::addObject(
             connection,
             objectsId,
@@ -300,45 +252,45 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
             {},
             ObjectTypeId::BaseObjectType,
             ReferenceTypeId::HasComponent
-        )
-            .value();
+        );
 
-        auto addReference = [&] {
+        const auto addReference = [&](auto&&... args) {
             if constexpr (isAsync<T>) {
-                auto future = services::addReferenceAsync(
-                    connection, {1, 1000}, {1, 1001}, ReferenceTypeId::Organizes, true, useFuture
-                );
+                auto future = services::addReferenceAsync(args..., useFuture);
                 setup.client.runIterate();
                 return future.get();
             } else {
-                return services::addReference(
-                    connection, {1, 1000}, {1, 1001}, ReferenceTypeId::Organizes, true
-                );
+                return services::addReference(args...);
             }
         };
-        CHECK(addReference().isGood());
-        CHECK(addReference() == UA_STATUSCODE_BADDUPLICATEREFERENCENOTALLOWED);
+        CHECK_EQ(
+            addReference(
+                connection, NodeId(1, 1000), NodeId(1, 1001), ReferenceTypeId::Organizes, true
+            ),
+            UA_STATUSCODE_GOOD
+        );
+        CHECK_EQ(
+            addReference(
+                connection, NodeId(1, 1000), NodeId(1, 1001), ReferenceTypeId::Organizes, true
+            ),
+            UA_STATUSCODE_BADDUPLICATEREFERENCENOTALLOWED
+        );
 
-        auto deleteReference = [&] {
+        const auto deleteReference = [&](auto&&... args) {
             if constexpr (isAsync<T>) {
-                auto future = services::deleteReferenceAsync(
-                    connection,
-                    {1, 1000},
-                    {1, 1001},
-                    ReferenceTypeId::Organizes,
-                    true,
-                    true,
-                    useFuture
-                );
+                auto future = services::deleteReferenceAsync(args..., useFuture);
                 setup.client.runIterate();
                 return future.get();
             } else {
-                return services::deleteReference(
-                    connection, {1, 1000}, {1, 1001}, ReferenceTypeId::Organizes, true, true
-                );
+                return services::deleteReference(args...);
             }
         };
-        CHECK(deleteReference().isGood());
+        CHECK_EQ(
+            deleteReference(
+                connection, NodeId(1, 1000), NodeId(1, 1001), ReferenceTypeId::Organizes, true, true
+            ),
+            UA_STATUSCODE_GOOD
+        );
     }
 
     SUBCASE("Delete node") {
@@ -350,20 +302,19 @@ TEST_CASE_TEMPLATE("NodeManagement service set", T, Server, Client, Async<Client
             {},
             ObjectTypeId::BaseObjectType,
             ReferenceTypeId::HasComponent
-        )
-            .value();
+        );
 
-        auto deleteNode = [&] {
+        const auto deleteNode = [&](auto&&... args) {
             if constexpr (isAsync<T>) {
-                auto future = services::deleteNodeAsync(connection, {1, 1000}, true, useFuture);
+                auto future = services::deleteNodeAsync(args..., useFuture);
                 setup.client.runIterate();
                 return future.get();
             } else {
-                return services::deleteNode(connection, {1, 1000}, true);
+                return services::deleteNode(args...);
             }
         };
-        CHECK(deleteNode().isGood());
-        CHECK(deleteNode() == UA_STATUSCODE_BADNODEIDUNKNOWN);
+        CHECK(deleteNode(connection, NodeId(1, 1000), true) == UA_STATUSCODE_GOOD);
+        CHECK(deleteNode(connection, NodeId(1, 1000), true) == UA_STATUSCODE_BADNODEIDUNKNOWN);
     }
 
     SUBCASE("Random node id") {

--- a/tools/gen_attribute_highlevel.py
+++ b/tools/gen_attribute_highlevel.py
@@ -80,10 +80,8 @@ Result<{type}> read{attr}(T& connection, const NodeId& id) noexcept {{
  * @return @asyncresult{{Result<{type}>}}
  * @ingroup Read
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto read{attr}Async(
-    Client& connection, const NodeId& id, CompletionToken&& token = DefaultCompletionToken()
-) {{
+template <typename CompletionToken>
+auto read{attr}Async(Client& connection, const NodeId& id, CompletionToken&& token) {{
     return detail::readAttributeAsyncImpl<AttributeId::{attr}>(
         connection, id, std::forward<CompletionToken>(token)
     );
@@ -110,13 +108,8 @@ StatusCode write{attr}(T& connection, const NodeId& id, {param_type} {param_name
  * @return @asyncresult{{StatusCode}}
  * @ingroup Write
  */
-template <typename CompletionToken = DefaultCompletionToken>
-auto write{attr}Async(
-    Client& connection,
-    const NodeId& id,
-    {param_type} {param_name},
-    CompletionToken&& token = DefaultCompletionToken()
-) {{
+template <typename CompletionToken>
+auto write{attr}Async(Client& connection, const NodeId& id, {param_type} {param_name}, CompletionToken&& token) {{
     return detail::writeAttributeAsyncImpl<AttributeId::{attr}>(
         connection, id, {param_name}, std::forward<CompletionToken>(token)
     );


### PR DESCRIPTION
Remove all default arguments of functions in the `opcua::services` namespace. The previous default arguments are mentioned in the function documentation.

Why? The completion token of async functions is always the last function parameter. So all function arguments, even the default ones, have to be provided for async function calls. This makes it hard to switch between sync and async behavior.