### PR TITLE
style: refine format rules

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,6 @@
 ﻿---
 # Documentation: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
-# LLVM defaults: https://github.com/llvm/llvm-project/blob/main/clang/lib/Format/Format.cpp#L1248
+# LLVM defaults: https://github.com/llvm/llvm-project/blob/release/19.x/clang/lib/Format/Format.cpp#L1412-L1630
 BasedOnStyle: LLVM
 
 AccessModifierOffset: -4
@@ -8,6 +8,7 @@ AlignAfterOpenBracket: BlockIndent # version >= 14 required
 # AlignConsecutiveAssignments: true
 # AlignConsecutiveDeclarations: true
 AlignOperands: DontAlign
+AllowBreakBeforeNoexceptSpecifier: Never
 AllowShortFunctionsOnASingleLine: Empty
 AlignTrailingComments: false
 AlwaysBreakTemplateDeclarations: Yes
@@ -18,13 +19,15 @@ ColumnLimit: 100
 FixNamespaceComments: true
 IndentWidth: 4
 InsertBraces: true
+InsertNewlineAtEOF: true
 InsertTrailingCommas: Wrapped # currently only available for JavaScript
 Language: Cpp
 PackConstructorInitializers: Never
 PointerAlignment: Left
-QualifierAlignment: Left
+QualifierAlignment: Custom # v14
+QualifierOrder: [friend, inline, static, constexpr, const, volatile, type] # v14
 ReferenceAlignment: Left
-SeparateDefinitionBlocks: Always # version >= 14 required
+SeparateDefinitionBlocks: Always # v14
 SpacesBeforeTrailingComments: 2
 
 # Adjust penalties to prefer break after open bracket
@@ -33,6 +36,7 @@ PenaltyBreakBeforeFirstCallParameter: 0 # default: 19
 PenaltyBreakComment: 300 # default: 300
 PenaltyBreakFirstLessLess: 0 # default: 120
 PenaltyBreakOpenParenthesis: 0 # default: 0
+PenaltyBreakScopeResolution: 1000 # default: 500; v18
 PenaltyBreakString: 1000 # default: 1000
 PenaltyBreakTemplateDeclaration: 0 # default: ?
 PenaltyExcessCharacter: 1000000 # default: 1000000

--- a/include/open62541pp/services/monitoreditem.hpp
+++ b/include/open62541pp/services/monitoreditem.hpp
@@ -254,8 +254,9 @@ auto createMonitoredItemDataChangeAsync(
         std::move(dataChangeCallback),
         std::move(deleteCallback),
         detail::TransformToken(
-            detail::
-                wrapSingleResultWithStatus<MonitoredItemCreateResult, CreateMonitoredItemsResponse>,
+            detail::wrapSingleResultWithStatus<
+                MonitoredItemCreateResult,
+                CreateMonitoredItemsResponse>,
             std::forward<CompletionToken>(token)
         )
     );
@@ -378,8 +379,9 @@ auto createMonitoredItemEventAsync(
         std::move(eventCallback),
         std::move(deleteCallback),
         detail::TransformToken(
-            detail::
-                wrapSingleResultWithStatus<MonitoredItemCreateResult, CreateMonitoredItemsResponse>,
+            detail::wrapSingleResultWithStatus<
+                MonitoredItemCreateResult,
+                CreateMonitoredItemsResponse>,
             std::forward<CompletionToken>(token)
         )
     );

--- a/include/open62541pp/typewrapper.hpp
+++ b/include/open62541pp/typewrapper.hpp
@@ -6,8 +6,8 @@
 #include "open62541pp/common.hpp"  // TypeIndex
 #include "open62541pp/detail/open62541/common.h"
 #include "open62541pp/detail/types_handling.hpp"
-#include "open62541pp/wrapper.hpp"
 #include "open62541pp/typeregistry.hpp"
+#include "open62541pp/wrapper.hpp"
 
 namespace opcua {
 


### PR DESCRIPTION
Adapt and apply clang-format config options for version 14 and later.