### PR TITLE
feat!: remove crypto namespace

### DIFF
--- a/include/open62541pp/plugin/create_certificate.hpp
+++ b/include/open62541pp/plugin/create_certificate.hpp
@@ -6,7 +6,7 @@
 
 #if UAPP_HAS_CREATE_CERTIFICATE
 
-namespace opcua::crypto {
+namespace opcua {
 
 enum class CertificateFormat {
     DER,
@@ -43,6 +43,6 @@ CreateCertificateResult createCertificate(
     CertificateFormat certificateFormat = CertificateFormat::DER
 );
 
-}  // namespace opcua::crypto
+}  // namespace opcua
 
 #endif  // if UAPP_HAS_CREATE_CERTIFICATE

--- a/src/plugin/create_certificate.cpp
+++ b/src/plugin/create_certificate.cpp
@@ -11,7 +11,7 @@
 #include "open62541pp/exception.hpp"
 #include "open62541pp/plugin/log_default.hpp"
 
-namespace opcua::crypto {
+namespace opcua {
 
 static_assert(static_cast<int>(CertificateFormat::DER) == UA_CERTIFICATEFORMAT_DER);
 static_assert(static_cast<int>(CertificateFormat::PEM) == UA_CERTIFICATEFORMAT_PEM);
@@ -64,6 +64,6 @@ CreateCertificateResult createCertificate(
     return result;
 }
 
-}  // namespace opcua::crypto
+}  // namespace opcua
 
 #endif

--- a/tests/plugin_create_certificate.cpp
+++ b/tests/plugin_create_certificate.cpp
@@ -15,21 +15,21 @@ using namespace opcua;
 
 TEST_CASE("Create certificate") {
     SUBCASE("Empty subject / subjectAltName") {
-        CHECK_THROWS_AS(crypto::createCertificate({}, {}), CreateCertificateError);
+        CHECK_THROWS_AS(createCertificate({}, {}), CreateCertificateError);
     }
 
     SUBCASE("Invalid subject / subjectAltName") {
         CHECK_THROWS_AS(
-            crypto::createCertificate({String{"X=Y"}}, {String{"DNS:localhost"}}),
+            createCertificate({String{"X=Y"}}, {String{"DNS:localhost"}}),
             CreateCertificateError
         );
         CHECK_THROWS_AS(
-            crypto::createCertificate({String{"C=DE"}}, {String{"X:Y"}}), CreateCertificateError
+            createCertificate({String{"C=DE"}}, {String{"X:Y"}}), CreateCertificateError
         );
     }
 
     SUBCASE("Valid") {
-        const auto cert = crypto::createCertificate(
+        const auto cert = createCertificate(
             {
                 String{"C=DE"},
                 String{"O=open62541pp"},
@@ -50,7 +50,7 @@ TEST_CASE("Encrypted connection server/client") {
     const std::string clientApplicationUri = "urn:unconfigured:application";  // default
 
     // create server certificate
-    const auto certServer = crypto::createCertificate(
+    const auto certServer = createCertificate(
         {
             String{"C=DE"},
             String{"O=open62541pp"},
@@ -63,7 +63,7 @@ TEST_CASE("Encrypted connection server/client") {
     );
 
     // create client certificate
-    const auto certClient = crypto::createCertificate(
+    const auto certClient = createCertificate(
         {
             String{"C=DE"},
             String{"O=open62541pp"},


### PR DESCRIPTION
All types and functions are now available in namespace `opcua`.