### PR TITLE
feat: IntegerId alias (uint32_t)

### DIFF
--- a/examples/client_async.cpp
+++ b/examples/client_async.cpp
@@ -44,7 +44,9 @@ int main() {
             opcua::SubscriptionParameters{},  // default subscription parameters
             true,  // publishingEnabled
             {},  // statusChangeCallback
-            [](uint32_t subId) { std::cout << "Subscription deleted: " << subId << std::endl; },
+            [](opcua::IntegerId subId) {
+                std::cout << "Subscription deleted: " << subId << std::endl;
+            },
             [&](opcua::CreateSubscriptionResponse& response) {
                 std::cout
                     << "Subscription created:\n"
@@ -61,7 +63,7 @@ int main() {
                     ),
                     opcua::MonitoringMode::Reporting,
                     opcua::MonitoringParametersEx{},  // default monitoring parameters
-                    [](uint32_t subId, uint32_t monId, const opcua::DataValue& dv) {
+                    [](opcua::IntegerId subId, opcua::IntegerId monId, const opcua::DataValue& dv) {
                         std::cout
                             << "Data change notification:\n"
                             << "- subscription id: " << subId << "\n"

--- a/examples/client_subscription.cpp
+++ b/examples/client_subscription.cpp
@@ -25,7 +25,7 @@ int main() {
         auto mon = sub.subscribeDataChange(
             opcua::VariableId::Server_ServerStatus_CurrentTime,  // monitored node id
             opcua::AttributeId::Value,  // monitored attribute
-            [&](uint32_t subId, uint32_t monId, const opcua::DataValue& value) {
+            [&](opcua::IntegerId subId, opcua::IntegerId monId, const opcua::DataValue& value) {
                 opcua::MonitoredItem item(client, subId, monId);
                 std::cout
                     << "Data change notification:\n"

--- a/examples/events/client_eventfilter.cpp
+++ b/examples/events/client_eventfilter.cpp
@@ -46,7 +46,9 @@ int main() {
     sub.subscribeEvent(
         opcua::ObjectId::Server,
         eventFilter,
-        [&](uint32_t subId, uint32_t monId, opcua::Span<const opcua::Variant> eventFields) {
+        [&](opcua::IntegerId subId,
+            opcua::IntegerId monId,
+            opcua::Span<const opcua::Variant> eventFields) {
             opcua::MonitoredItem item(client, subId, monId);
             std::cout
                 << "Event notification:\n"

--- a/include/open62541pp/common.hpp
+++ b/include/open62541pp/common.hpp
@@ -7,6 +7,10 @@
 
 namespace opcua {
 
+/// Integer id used as an identifier.
+/// @see https://reference.opcfoundation.org/Core/Part4/v105/docs/7.19
+using IntegerId = uint32_t;
+
 /// Namespace index.
 /// @see https://reference.opcfoundation.org/Core/Part3/v105/docs/8.2.2
 using NamespaceIndex = uint16_t;

--- a/include/open62541pp/common.hpp
+++ b/include/open62541pp/common.hpp
@@ -7,10 +7,6 @@
 
 namespace opcua {
 
-/// Integer id used as an identifier.
-/// @see https://reference.opcfoundation.org/Core/Part4/v105/docs/7.19
-using IntegerId = uint32_t;
-
 /// Namespace index.
 /// @see https://reference.opcfoundation.org/Core/Part3/v105/docs/8.2.2
 using NamespaceIndex = uint16_t;

--- a/include/open62541pp/detail/client_context.hpp
+++ b/include/open62541pp/detail/client_context.hpp
@@ -8,7 +8,6 @@
 #include <utility>  // pair
 #include <vector>
 
-#include "open62541pp/common.hpp"  // IntegerId
 #include "open62541pp/config.hpp"
 #include "open62541pp/datatype.hpp"
 #include "open62541pp/detail/contextmap.hpp"
@@ -16,6 +15,7 @@
 #include "open62541pp/detail/open62541/client.h"  // UA_SessionState, UA_SecureChannelState
 #include "open62541pp/services/detail/monitoreditem_context.hpp"
 #include "open62541pp/services/detail/subscription_context.hpp"
+#include "open62541pp/types_composed.hpp"  // IntegerId
 
 namespace opcua::detail {
 

--- a/include/open62541pp/detail/client_context.hpp
+++ b/include/open62541pp/detail/client_context.hpp
@@ -8,6 +8,7 @@
 #include <utility>  // pair
 #include <vector>
 
+#include "open62541pp/common.hpp"  // IntegerId
 #include "open62541pp/config.hpp"
 #include "open62541pp/datatype.hpp"
 #include "open62541pp/detail/contextmap.hpp"
@@ -37,9 +38,9 @@ struct ClientContext {
     std::unique_ptr<UA_DataTypeArray> dataTypeArray;
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
-    using SubId = uint32_t;
-    using MonId = uint32_t;
-    using SubMonId = std::pair<uint32_t, uint32_t>;
+    using SubId = IntegerId;
+    using MonId = IntegerId;
+    using SubMonId = std::pair<SubId, MonId>;
     ContextMap<SubId, services::detail::SubscriptionContext> subscriptions;
     ContextMap<SubMonId, services::detail::MonitoredItemContext> monitoredItems;
 #endif

--- a/include/open62541pp/detail/server_context.hpp
+++ b/include/open62541pp/detail/server_context.hpp
@@ -7,7 +7,6 @@
 #include <utility>  // pair
 #include <vector>
 
-#include "open62541pp/common.hpp"  // IntegerId
 #include "open62541pp/config.hpp"
 #include "open62541pp/datatype.hpp"
 #include "open62541pp/detail/contextmap.hpp"
@@ -16,6 +15,7 @@
 #include "open62541pp/plugin/nodestore.hpp"
 #include "open62541pp/services/detail/monitoreditem_context.hpp"
 #include "open62541pp/types.hpp"  // NodeId, Variant
+#include "open62541pp/types_composed.hpp"  // IntegerId
 
 namespace opcua::detail {
 

--- a/include/open62541pp/detail/server_context.hpp
+++ b/include/open62541pp/detail/server_context.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -8,6 +7,7 @@
 #include <utility>  // pair
 #include <vector>
 
+#include "open62541pp/common.hpp"  // IntegerId
 #include "open62541pp/config.hpp"
 #include "open62541pp/datatype.hpp"
 #include "open62541pp/detail/contextmap.hpp"
@@ -46,9 +46,9 @@ struct ServerContext {
     std::unique_ptr<UA_DataTypeArray> dataTypeArray;
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
-    using SubId = uint32_t;  // always 0
-    using MonId = uint32_t;
-    using SubMonId = std::pair<uint32_t, uint32_t>;
+    using SubId = IntegerId;  // always 0
+    using MonId = IntegerId;
+    using SubMonId = std::pair<SubId, MonId>;
     ContextMap<SubMonId, services::detail::MonitoredItemContext> monitoredItems;
 #endif
 

--- a/include/open62541pp/monitoreditem.hpp
+++ b/include/open62541pp/monitoreditem.hpp
@@ -2,10 +2,11 @@
 
 #include <type_traits>
 
-#include "open62541pp/common.hpp"  // AttributeId, IntegerId
+#include "open62541pp/common.hpp"  // AttributeId
 #include "open62541pp/config.hpp"
 #include "open62541pp/services/monitoreditem.hpp"
 #include "open62541pp/types.hpp"
+#include "open62541pp/types_composed.hpp"  // IntegerId
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
 

--- a/include/open62541pp/monitoreditem.hpp
+++ b/include/open62541pp/monitoreditem.hpp
@@ -1,9 +1,8 @@
 #pragma once
 
-#include <cstdint>
 #include <type_traits>
 
-#include "open62541pp/common.hpp"  // AttributeId
+#include "open62541pp/common.hpp"  // AttributeId, IntegerId
 #include "open62541pp/config.hpp"
 #include "open62541pp/services/monitoreditem.hpp"
 #include "open62541pp/types.hpp"
@@ -31,7 +30,7 @@ public:
     /// Wrap an existing monitored item.
     /// The `subscriptionId` is ignored and set to `0U` for servers.
     MonitoredItem(
-        Connection& connection, uint32_t subscriptionId, uint32_t monitoredItemId
+        Connection& connection, IntegerId subscriptionId, IntegerId monitoredItemId
     ) noexcept
         : connection_(&connection),
           subscriptionId_(std::is_same_v<Connection, Server> ? 0U : subscriptionId),
@@ -48,12 +47,12 @@ public:
     }
 
     /// Get the server-assigned identifier of the underlying subscription.
-    uint32_t subscriptionId() const noexcept {
+    IntegerId subscriptionId() const noexcept {
         return subscriptionId_;
     }
 
     /// Get the server-assigned identifier of this monitored item.
-    uint32_t monitoredItemId() const noexcept {
+    IntegerId monitoredItemId() const noexcept {
         return monitoredItemId_;
     }
 
@@ -91,8 +90,8 @@ public:
 
 private:
     Connection* connection_;
-    uint32_t subscriptionId_{0U};
-    uint32_t monitoredItemId_{0U};
+    IntegerId subscriptionId_{0U};
+    IntegerId monitoredItemId_{0U};
 };
 
 /* ---------------------------------------------------------------------------------------------- */

--- a/include/open62541pp/services/detail/monitoreditem_context.hpp
+++ b/include/open62541pp/services/detail/monitoreditem_context.hpp
@@ -3,10 +3,9 @@
 #include <cstdint>
 #include <functional>
 
-#include "open62541pp/common.hpp"
 #include "open62541pp/services/detail/callbackadapter.hpp"
 #include "open62541pp/span.hpp"
-#include "open62541pp/types_composed.hpp"  // DataValue, Variant
+#include "open62541pp/types_composed.hpp"  // DataValue, IntegerId, Variant
 #include "open62541pp/wrapper.hpp"  // asWrapper
 
 struct UA_Client;

--- a/include/open62541pp/services/detail/monitoreditem_context.hpp
+++ b/include/open62541pp/services/detail/monitoreditem_context.hpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <functional>
 
+#include "open62541pp/common.hpp"
 #include "open62541pp/services/detail/callbackadapter.hpp"
 #include "open62541pp/span.hpp"
 #include "open62541pp/types_composed.hpp"  // DataValue, Variant
@@ -17,13 +18,13 @@ struct MonitoredItemContext : CallbackAdapter {
     bool stale{false};
     bool inserted{false};
     ReadValueId itemToMonitor;
-    std::function<void(uint32_t subId, uint32_t monId, const DataValue&)> dataChangeCallback;
-    std::function<void(uint32_t subId, uint32_t monId, Span<const Variant>)> eventCallback;
-    std::function<void(uint32_t subId, uint32_t monId)> deleteCallback;
+    std::function<void(IntegerId subId, IntegerId monId, const DataValue&)> dataChangeCallback;
+    std::function<void(IntegerId subId, IntegerId monId, Span<const Variant>)> eventCallback;
+    std::function<void(IntegerId subId, IntegerId monId)> deleteCallback;
 
     static void dataChangeCallbackNativeServer(
         [[maybe_unused]] UA_Server* server,
-        uint32_t monId,
+        IntegerId monId,
         void* monContext,
         [[maybe_unused]] const UA_NodeId* nodeId,
         [[maybe_unused]] void* nodeContext,
@@ -41,9 +42,9 @@ struct MonitoredItemContext : CallbackAdapter {
 
     static void dataChangeCallbackNativeClient(
         [[maybe_unused]] UA_Client* client,
-        uint32_t subId,
+        IntegerId subId,
         [[maybe_unused]] void* subContext,
-        uint32_t monId,
+        IntegerId monId,
         void* monContext,
         UA_DataValue* value
     ) noexcept {
@@ -58,9 +59,9 @@ struct MonitoredItemContext : CallbackAdapter {
 
     static void eventCallbackNative(
         [[maybe_unused]] UA_Client* client,
-        uint32_t subId,
+        IntegerId subId,
         [[maybe_unused]] void* subContext,
-        uint32_t monId,
+        IntegerId monId,
         void* monContext,
         size_t nEventFields,
         UA_Variant* eventFields
@@ -81,9 +82,9 @@ struct MonitoredItemContext : CallbackAdapter {
 
     static void deleteCallbackNative(
         [[maybe_unused]] UA_Client* client,
-        uint32_t subId,
+        IntegerId subId,
         [[maybe_unused]] void* subContext,
-        uint32_t monId,
+        IntegerId monId,
         void* monContext
     ) noexcept {
         if (monContext != nullptr) {

--- a/include/open62541pp/services/detail/request_handling.hpp
+++ b/include/open62541pp/services/detail/request_handling.hpp
@@ -260,7 +260,7 @@ UA_CreateSubscriptionRequest createCreateSubscriptionRequest(
 
 template <typename SubscriptionParameters>
 UA_ModifySubscriptionRequest createModifySubscriptionRequest(
-    uint32_t subscriptionId, const SubscriptionParameters& parameters
+    IntegerId subscriptionId, const SubscriptionParameters& parameters
 ) noexcept {
     UA_ModifySubscriptionRequest request{};
     request.subscriptionId = subscriptionId;
@@ -273,7 +273,7 @@ UA_ModifySubscriptionRequest createModifySubscriptionRequest(
 }
 
 inline UA_SetPublishingModeRequest createSetPublishingModeRequest(
-    bool publishing, Span<const uint32_t> subscriptionIds
+    bool publishing, Span<const IntegerId> subscriptionIds
 ) noexcept {
     UA_SetPublishingModeRequest request{};
     request.publishingEnabled = publishing;
@@ -282,7 +282,7 @@ inline UA_SetPublishingModeRequest createSetPublishingModeRequest(
     return request;
 }
 
-inline UA_DeleteSubscriptionsRequest createDeleteSubscriptionsRequest(uint32_t& subscriptionId
+inline UA_DeleteSubscriptionsRequest createDeleteSubscriptionsRequest(IntegerId& subscriptionId
 ) noexcept {
     UA_DeleteSubscriptionsRequest request{};
     request.subscriptionIdsSize = 1;
@@ -314,7 +314,7 @@ UA_MonitoredItemCreateRequest createMonitoredItemCreateRequest(
 }
 
 inline UA_CreateMonitoredItemsRequest createCreateMonitoredItemsRequest(
-    uint32_t subscriptionId,
+    IntegerId subscriptionId,
     TimestampsToReturn timestampsToReturn,
     Span<const UA_MonitoredItemCreateRequest> itemsToCreate
 ) noexcept {
@@ -328,7 +328,7 @@ inline UA_CreateMonitoredItemsRequest createCreateMonitoredItemsRequest(
 
 template <typename MonitoringParameters>
 UA_MonitoredItemModifyRequest createMonitoredItemModifyRequest(
-    uint32_t monitoredItemId, MonitoringParameters& parameters
+    IntegerId monitoredItemId, MonitoringParameters& parameters
 ) noexcept {
     UA_MonitoredItemModifyRequest item{};
     item.monitoredItemId = monitoredItemId;
@@ -338,7 +338,7 @@ UA_MonitoredItemModifyRequest createMonitoredItemModifyRequest(
 
 template <typename MonitoringParameters>
 UA_ModifyMonitoredItemsRequest createModifyMonitoredItemsRequest(
-    uint32_t subscriptionId, MonitoringParameters& parameters, UA_MonitoredItemModifyRequest& item
+    IntegerId subscriptionId, MonitoringParameters& parameters, UA_MonitoredItemModifyRequest& item
 ) noexcept {
     UA_ModifyMonitoredItemsRequest request{};
     request.subscriptionId = subscriptionId;
@@ -349,7 +349,7 @@ UA_ModifyMonitoredItemsRequest createModifyMonitoredItemsRequest(
 }
 
 inline UA_SetMonitoringModeRequest createSetMonitoringModeRequest(
-    uint32_t subscriptionId, Span<const uint32_t> monitoredItemIds, MonitoringMode monitoringMode
+    IntegerId subscriptionId, Span<const IntegerId> monitoredItemIds, MonitoringMode monitoringMode
 ) noexcept {
     UA_SetMonitoringModeRequest request{};
     request.subscriptionId = subscriptionId;
@@ -360,10 +360,10 @@ inline UA_SetMonitoringModeRequest createSetMonitoringModeRequest(
 }
 
 inline UA_SetTriggeringRequest createSetTriggeringRequest(
-    uint32_t subscriptionId,
-    uint32_t triggeringItemId,
-    Span<const uint32_t> linksToAdd,
-    Span<const uint32_t> linksToRemove
+    IntegerId subscriptionId,
+    IntegerId triggeringItemId,
+    Span<const IntegerId> linksToAdd,
+    Span<const IntegerId> linksToRemove
 ) noexcept {
     UA_SetTriggeringRequest request{};
     request.subscriptionId = subscriptionId;
@@ -376,7 +376,7 @@ inline UA_SetTriggeringRequest createSetTriggeringRequest(
 }
 
 inline UA_DeleteMonitoredItemsRequest createDeleteMonitoredItemsRequest(
-    uint32_t subscriptionId, Span<const uint32_t> monitoredItemIds
+    IntegerId subscriptionId, Span<const IntegerId> monitoredItemIds
 ) noexcept {
     UA_DeleteMonitoredItemsRequest request{};
     request.subscriptionId = subscriptionId;

--- a/include/open62541pp/services/detail/subscription_context.hpp
+++ b/include/open62541pp/services/detail/subscription_context.hpp
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <cstdint>
 #include <functional>
 
+#include "open62541pp/common.hpp"
 #include "open62541pp/config.hpp"
 #include "open62541pp/services/detail/callbackadapter.hpp"
 #include "open62541pp/types_composed.hpp"  // StatusChangeNotification
@@ -16,12 +16,12 @@ namespace opcua::services::detail {
 
 struct SubscriptionContext : CallbackAdapter {
     bool stale{false};
-    std::function<void(uint32_t subId, StatusChangeNotification&)> statusChangeCallback;
-    std::function<void(uint32_t subId)> deleteCallback;
+    std::function<void(IntegerId subId, StatusChangeNotification&)> statusChangeCallback;
+    std::function<void(IntegerId subId)> deleteCallback;
 
     static void statusChangeCallbackNative(
         [[maybe_unused]] UA_Client* client,
-        uint32_t subId,
+        IntegerId subId,
         void* subContext,
         UA_StatusChangeNotification* notification
     ) noexcept {
@@ -36,7 +36,7 @@ struct SubscriptionContext : CallbackAdapter {
     }
 
     static void deleteCallbackNative(
-        [[maybe_unused]] UA_Client* client, uint32_t subId, void* subContext
+        [[maybe_unused]] UA_Client* client, IntegerId subId, void* subContext
     ) noexcept {
         if (subContext != nullptr) {
             auto* self = static_cast<SubscriptionContext*>(subContext);

--- a/include/open62541pp/services/detail/subscription_context.hpp
+++ b/include/open62541pp/services/detail/subscription_context.hpp
@@ -2,10 +2,9 @@
 
 #include <functional>
 
-#include "open62541pp/common.hpp"
 #include "open62541pp/config.hpp"
 #include "open62541pp/services/detail/callbackadapter.hpp"
-#include "open62541pp/types_composed.hpp"  // StatusChangeNotification
+#include "open62541pp/types_composed.hpp"  // IntegerId, StatusChangeNotification
 #include "open62541pp/wrapper.hpp"  // asWrapper
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS

--- a/include/open62541pp/services/monitoreditem.hpp
+++ b/include/open62541pp/services/monitoreditem.hpp
@@ -88,7 +88,7 @@ struct MonitoringParametersEx {
  * @param subId Subscription identifier
  * @param monId MonitoredItem identifier
  */
-using DeleteMonitoredItemCallback = std::function<void(uint32_t subId, uint32_t monId)>;
+using DeleteMonitoredItemCallback = std::function<void(IntegerId subId, IntegerId monId)>;
 
 /**
  * Data change notification callback.
@@ -97,7 +97,7 @@ using DeleteMonitoredItemCallback = std::function<void(uint32_t subId, uint32_t 
  * @param value Changed value
  */
 using DataChangeNotificationCallback =
-    std::function<void(uint32_t subId, uint32_t monId, const DataValue& value)>;
+    std::function<void(IntegerId subId, IntegerId monId, const DataValue& value)>;
 
 /**
  * Event notification callback.
@@ -106,7 +106,7 @@ using DataChangeNotificationCallback =
  * @param eventFields Event fields
  */
 using EventNotificationCallback =
-    std::function<void(uint32_t subId, uint32_t monId, Span<const Variant> eventFields)>;
+    std::function<void(IntegerId subId, IntegerId monId, Span<const Variant> eventFields)>;
 
 namespace detail {
 std::vector<std::unique_ptr<MonitoredItemContext>> createMonitoredItemContexts(
@@ -127,7 +127,7 @@ void convertMonitoredItemContexts(
 
 void storeMonitoredItemContexts(
     Client& connection,
-    uint32_t subscriptionId,
+    IntegerId subscriptionId,
     const CreateMonitoredItemsResponse& response,
     Span<std::unique_ptr<MonitoredItemContext>> contexts
 );
@@ -217,7 +217,7 @@ auto createMonitoredItemsDataChangeAsync(
 template <typename T>
 [[nodiscard]] MonitoredItemCreateResult createMonitoredItemDataChange(
     T& connection,
-    uint32_t subscriptionId,
+    IntegerId subscriptionId,
     const ReadValueId& itemToMonitor,
     MonitoringMode monitoringMode,
     const MonitoringParametersEx& parameters,
@@ -227,7 +227,7 @@ template <typename T>
 
 #if UAPP_HAS_ASYNC_SUBSCRIPTIONS
 /**
- * @copydoc createMonitoredItemDataChange(Client&, uint32_t, const ReadValueId&, MonitoringMode,
+ * @copydoc createMonitoredItemDataChange(Client&, IntegerId, const ReadValueId&, MonitoringMode,
  *          const MonitoringParametersEx&, DataChangeNotificationCallback,
  *          DeleteMonitoredItemCallback)
  * @param token @completiontoken{void(MonitoredItemCreateResult&)}
@@ -236,7 +236,7 @@ template <typename T>
 template <typename CompletionToken>
 auto createMonitoredItemDataChangeAsync(
     Client& connection,
-    uint32_t subscriptionId,
+    IntegerId subscriptionId,
     const ReadValueId& itemToMonitor,
     MonitoringMode monitoringMode,
     const MonitoringParametersEx& parameters,
@@ -343,7 +343,7 @@ auto createMonitoredItemsEventAsync(
  */
 [[nodiscard]] MonitoredItemCreateResult createMonitoredItemEvent(
     Client& connection,
-    uint32_t subscriptionId,
+    IntegerId subscriptionId,
     const ReadValueId& itemToMonitor,
     MonitoringMode monitoringMode,
     const MonitoringParametersEx& parameters,
@@ -353,7 +353,7 @@ auto createMonitoredItemsEventAsync(
 
 #if UAPP_HAS_ASYNC_SUBSCRIPTIONS
 /**
- * @copydoc createMonitoredItemEvent(Client&, uint32_t, const ReadValueId&, MonitoringMode,
+ * @copydoc createMonitoredItemEvent(Client&, IntegerId, const ReadValueId&, MonitoringMode,
  *          const MonitoringParametersEx&, EventNotificationCallback, DeleteMonitoredItemCallback)
  * @param token @completiontoken{void(MonitoredItemCreateResult&)}
  * @return @asyncresult{MonitoredItemCreateResult}
@@ -361,7 +361,7 @@ auto createMonitoredItemsEventAsync(
 template <typename CompletionToken>
 auto createMonitoredItemEventAsync(
     Client& connection,
-    uint32_t subscriptionId,
+    IntegerId subscriptionId,
     const ReadValueId& itemToMonitor,
     MonitoringMode monitoringMode,
     const MonitoringParametersEx& parameters,
@@ -438,8 +438,8 @@ auto modifyMonitoredItemsAsync(
  */
 inline MonitoredItemModifyResult modifyMonitoredItem(
     Client& connection,
-    uint32_t subscriptionId,
-    uint32_t monitoredItemId,
+    IntegerId subscriptionId,
+    IntegerId monitoredItemId,
     const MonitoringParametersEx& parameters
 ) noexcept {
     auto item = detail::createMonitoredItemModifyRequest(monitoredItemId, parameters);
@@ -452,15 +452,15 @@ inline MonitoredItemModifyResult modifyMonitoredItem(
 
 #if UAPP_HAS_ASYNC_SUBSCRIPTIONS
 /**
- * @copydoc modifyMonitoredItems(Client&, uint32_t, uint32_t, const MonitoringParametersEx&)
+ * @copydoc modifyMonitoredItems(Client&, IntegerId, IntegerId, const MonitoringParametersEx&)
  * @param token @completiontoken{void(MonitoredItemModifyResult&)}
  * @return @asyncresult{MonitoredItemModifyResult}
  */
 template <typename CompletionToken>
 auto modifyMonitoredItemAsync(
     Client& connection,
-    uint32_t subscriptionId,
-    uint32_t monitoredItemId,
+    IntegerId subscriptionId,
+    IntegerId monitoredItemId,
     const MonitoringParametersEx& parameters,
     CompletionToken&& token
 ) {
@@ -521,8 +521,8 @@ auto setMonitoringModeAsync(
  */
 inline StatusCode setMonitoringMode(
     Client& connection,
-    uint32_t subscriptionId,
-    uint32_t monitoredItemId,
+    IntegerId subscriptionId,
+    IntegerId monitoredItemId,
     MonitoringMode monitoringMode
 ) noexcept {
     const auto request = detail::createSetMonitoringModeRequest(
@@ -534,15 +534,15 @@ inline StatusCode setMonitoringMode(
 }
 
 /**
- * @copydoc setMonitoringMode(Client&, uint32_t, uint32_t, MonitoringMode)
+ * @copydoc setMonitoringMode(Client&, IntegerId, IntegerId, MonitoringMode)
  * @param token @completiontoken{void(StatusCode)}
  * @return @asyncresult{StatusCode}
  */
 template <typename CompletionToken>
 auto setMonitoringModeAsync(
     Client& connection,
-    uint32_t subscriptionId,
-    uint32_t monitoredItemId,
+    IntegerId subscriptionId,
+    IntegerId monitoredItemId,
     MonitoringMode monitoringMode,
     CompletionToken&& token
 ) {
@@ -642,7 +642,7 @@ auto deleteMonitoredItemsAsync(
  * @param monitoredItemId Identifier of the monitored item
  */
 template <typename T>
-StatusCode deleteMonitoredItem(T& connection, uint32_t subscriptionId, uint32_t monitoredItemId);
+StatusCode deleteMonitoredItem(T& connection, IntegerId subscriptionId, IntegerId monitoredItemId);
 
 #if UAPP_HAS_ASYNC_SUBSCRIPTIONS
 /**
@@ -652,7 +652,7 @@ StatusCode deleteMonitoredItem(T& connection, uint32_t subscriptionId, uint32_t 
  */
 template <typename CompletionToken>
 auto deleteMonitoredItemAsync(
-    Client& connection, uint32_t subscriptionId, uint32_t monitoredItemId, CompletionToken&& token
+    Client& connection, IntegerId subscriptionId, IntegerId monitoredItemId, CompletionToken&& token
 ) {
     const auto request = detail::createDeleteMonitoredItemsRequest(
         subscriptionId, {&monitoredItemId, 1}

--- a/include/open62541pp/services/subscription.hpp
+++ b/include/open62541pp/services/subscription.hpp
@@ -16,7 +16,7 @@
 #include "open62541pp/services/detail/request_handling.hpp"
 #include "open62541pp/services/detail/response_handling.hpp"
 #include "open62541pp/services/detail/subscription_context.hpp"
-#include "open62541pp/types_composed.hpp"  // StatusChangeNotification
+#include "open62541pp/types_composed.hpp"  // IntegerId, StatusChangeNotification
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
 

--- a/include/open62541pp/services/subscription.hpp
+++ b/include/open62541pp/services/subscription.hpp
@@ -68,7 +68,7 @@ struct SubscriptionParameters {
  * Subscription deletion callback.
  * @param subId Subscription identifier
  */
-using DeleteSubscriptionCallback = std::function<void(uint32_t subId)>;
+using DeleteSubscriptionCallback = std::function<void(IntegerId subId)>;
 
 /**
  * Subscription status change notification callback.
@@ -76,7 +76,7 @@ using DeleteSubscriptionCallback = std::function<void(uint32_t subId)>;
  * @param notification Status change notification
  */
 using StatusChangeNotificationCallback =
-    std::function<void(uint32_t subId, StatusChangeNotification& notification)>;
+    std::function<void(IntegerId subId, StatusChangeNotification& notification)>;
 
 namespace detail {
 std::unique_ptr<SubscriptionContext> createSubscriptionContext(
@@ -86,7 +86,7 @@ std::unique_ptr<SubscriptionContext> createSubscriptionContext(
 );
 
 void storeSubscriptionContext(
-    Client& connection, uint32_t subscriptionId, std::unique_ptr<SubscriptionContext>&& context
+    Client& connection, IntegerId subscriptionId, std::unique_ptr<SubscriptionContext>&& context
 );
 }  // namespace detail
 
@@ -198,7 +198,7 @@ ModifySubscriptionResponse modifySubscription(
 
 /// @overload
 inline ModifySubscriptionResponse modifySubscription(
-    Client& connection, uint32_t subscriptionId, const SubscriptionParameters& parameters
+    Client& connection, IntegerId subscriptionId, const SubscriptionParameters& parameters
 ) noexcept {
     const auto request = detail::createModifySubscriptionRequest(subscriptionId, parameters);
     return modifySubscription(connection, asWrapper<ModifySubscriptionRequest>(request));
@@ -229,7 +229,7 @@ auto modifySubscriptionAsync(
 template <typename CompletionToken>
 auto modifySubscriptionAsync(
     Client& connection,
-    uint32_t subscriptionId,
+    IntegerId subscriptionId,
     const SubscriptionParameters& parameters,
     CompletionToken&& token
 ) {
@@ -282,7 +282,7 @@ auto setPublishingModeAsync(
  * @param publishing Enable/disable publishing
  */
 inline StatusCode setPublishingMode(
-    Client& connection, uint32_t subscriptionId, bool publishing
+    Client& connection, IntegerId subscriptionId, bool publishing
 ) noexcept {
     const auto request = detail::createSetPublishingModeRequest(publishing, {&subscriptionId, 1});
     return detail::getSingleStatus(
@@ -291,13 +291,13 @@ inline StatusCode setPublishingMode(
 }
 
 /**
- * @copydoc setPublishingMode(Client&, uint32_t, bool)
+ * @copydoc setPublishingMode(Client&, IntegerId, bool)
  * @param token @completiontoken{void(StatusCode)}
  * @return @asyncresult{StatusCode}
  */
 template <typename CompletionToken>
 auto setPublishingModeAsync(
-    Client& connection, uint32_t subscriptionId, bool publishing, CompletionToken&& token
+    Client& connection, IntegerId subscriptionId, bool publishing, CompletionToken&& token
 ) {
     const auto request = detail::createSetPublishingModeRequest(publishing, {&subscriptionId, 1});
     return setPublishingModeAsync(
@@ -354,7 +354,7 @@ auto deleteSubscriptionsAsync(
  * @param connection Instance of type Client
  * @param subscriptionId Identifier of the subscription returned by @ref createSubscription
  */
-inline StatusCode deleteSubscription(Client& connection, uint32_t subscriptionId) noexcept {
+inline StatusCode deleteSubscription(Client& connection, IntegerId subscriptionId) noexcept {
     const auto request = detail::createDeleteSubscriptionsRequest(subscriptionId);
     return detail::getSingleStatus(
         deleteSubscriptions(connection, asWrapper<DeleteSubscriptionsRequest>(request))
@@ -368,7 +368,9 @@ inline StatusCode deleteSubscription(Client& connection, uint32_t subscriptionId
  * @return @asyncresult{StatusCode}
  */
 template <typename CompletionToken>
-auto deleteSubscriptionAsync(Client& connection, uint32_t subscriptionId, CompletionToken&& token) {
+auto deleteSubscriptionAsync(
+    Client& connection, IntegerId subscriptionId, CompletionToken&& token
+) {
     const auto request = detail::createDeleteSubscriptionsRequest(subscriptionId);
     return deleteSubscriptionsAsync(
         connection,

--- a/include/open62541pp/subscription.hpp
+++ b/include/open62541pp/subscription.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
-#include <cstdint>
 #include <type_traits>
 #include <utility>  // move
 #include <vector>
 
-#include "open62541pp/common.hpp"  // AttributeId, MonitoringMode
+#include "open62541pp/common.hpp"  // AttributeId, IntegerId, MonitoringMode
 #include "open62541pp/config.hpp"
 #include "open62541pp/monitoreditem.hpp"
 #include "open62541pp/services/monitoreditem.hpp"
@@ -44,7 +43,7 @@ class Subscription {
 public:
     /// Wrap an existing subscription.
     /// The `subscriptionId` is ignored and set to `0U` for servers.
-    Subscription(Connection& connection, uint32_t subscriptionId) noexcept
+    Subscription(Connection& connection, IntegerId subscriptionId) noexcept
         : connection_(&connection),
           subscriptionId_(std::is_same_v<Connection, Server> ? 0U : subscriptionId) {}
 
@@ -59,7 +58,7 @@ public:
     }
 
     /// Get the server-assigned identifier of this subscription.
-    uint32_t subscriptionId() const noexcept {
+    IntegerId subscriptionId() const noexcept {
         return subscriptionId_;
     }
 
@@ -156,7 +155,7 @@ public:
 
 private:
     Connection* connection_;
-    uint32_t subscriptionId_{0U};
+    IntegerId subscriptionId_{0U};
 };
 
 /* ---------------------------------------------------------------------------------------------- */

--- a/include/open62541pp/subscription.hpp
+++ b/include/open62541pp/subscription.hpp
@@ -4,12 +4,13 @@
 #include <utility>  // move
 #include <vector>
 
-#include "open62541pp/common.hpp"  // AttributeId, IntegerId, MonitoringMode
+#include "open62541pp/common.hpp"  // AttributeId, MonitoringMode
 #include "open62541pp/config.hpp"
 #include "open62541pp/monitoreditem.hpp"
 #include "open62541pp/services/monitoreditem.hpp"
 #include "open62541pp/services/subscription.hpp"
 #include "open62541pp/types.hpp"
+#include "open62541pp/types_composed.hpp"  // IntegerId
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
 

--- a/include/open62541pp/types_composed.hpp
+++ b/include/open62541pp/types_composed.hpp
@@ -75,6 +75,10 @@ UA_EXPORT extern const UA_ViewAttributes UA_ViewAttributes_default;
 
 namespace opcua {
 
+/// IntegerId.
+/// @see https://reference.opcfoundation.org/Core/Part4/v105/docs/7.19
+using IntegerId = uint32_t;
+
 /**
  * @addtogroup Wrapper
  * @{

--- a/include/open62541pp/types_composed.hpp
+++ b/include/open62541pp/types_composed.hpp
@@ -128,7 +128,7 @@ public:
     RequestHeader(
         NodeId authenticationToken,
         DateTime timestamp,
-        uint32_t requestHandle,
+        IntegerId requestHandle,
         uint32_t returnDiagnostics,
         std::string_view auditEntryId,
         uint32_t timeoutHint,
@@ -145,7 +145,7 @@ public:
 
     UAPP_GETTER_WRAPPER(NodeId, getAuthenticationToken, authenticationToken)
     UAPP_GETTER_WRAPPER(DateTime, getTimestamp, timestamp)
-    UAPP_GETTER(uint32_t, getRequestHandle, requestHandle)
+    UAPP_GETTER(IntegerId, getRequestHandle, requestHandle)
     UAPP_GETTER(uint32_t, getReturnDiagnostics, returnDiagnostics)
     UAPP_GETTER_WRAPPER(String, getAuditEntryId, auditEntryId)
     UAPP_GETTER(uint32_t, getTimeoutHint, timeoutHint)
@@ -161,7 +161,7 @@ public:
     using TypeWrapper::TypeWrapper;
 
     UAPP_GETTER_WRAPPER(DateTime, getTimestamp, timestamp)
-    UAPP_GETTER(uint32_t, getRequestHandle, requestHandle)
+    UAPP_GETTER(IntegerId, getRequestHandle, requestHandle)
     UAPP_GETTER(StatusCode, getServiceResult, serviceResult)
     UAPP_GETTER_WRAPPER(DiagnosticInfo, getServiceDiagnostics, serviceDiagnostics)
     UAPP_GETTER_SPAN_WRAPPER(String, getStringTable, stringTable, stringTableSize)
@@ -1922,9 +1922,9 @@ public:
     using TypeWrapper::TypeWrapper;
 
     UAPP_GETTER_WRAPPER(StatusCode, getStatusCode, statusCode);
-    UAPP_GETTER(uint32_t, getMonitoredItemId, monitoredItemId);
+    UAPP_GETTER(IntegerId, getMonitoredItemId, monitoredItemId);
     UAPP_GETTER(double, getRevisedSamplingInterval, revisedSamplingInterval);
-    UAPP_GETTER(uint32_t, getRevisedQueueSize, revisedQueueSize);
+    UAPP_GETTER(IntegerId, getRevisedQueueSize, revisedQueueSize);
     UAPP_GETTER_WRAPPER(ExtensionObject, getFilterResult, filterResult);
 };
 
@@ -1939,7 +1939,7 @@ public:
 
     CreateMonitoredItemsRequest(
         RequestHeader requestHeader,
-        uint32_t subscriptionId,
+        IntegerId subscriptionId,
         TimestampsToReturn timestampsToReturn,
         Span<const MonitoredItemCreateRequest> itemsToCreate
     ) {
@@ -1951,7 +1951,7 @@ public:
     }
 
     UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER(uint32_t, getSubscriptionId, subscriptionId)
+    UAPP_GETTER(IntegerId, getSubscriptionId, subscriptionId)
     UAPP_GETTER_CAST(TimestampsToReturn, getTimestampsToReturn, timestampsToReturn)
     UAPP_GETTER_SPAN_WRAPPER(
         MonitoredItemCreateRequest, getItemsToCreate, itemsToCreate, itemsToCreateSize
@@ -1983,12 +1983,14 @@ class MonitoredItemModifyRequest
 public:
     using TypeWrapper::TypeWrapper;
 
-    MonitoredItemModifyRequest(uint32_t monitoredItemId, MonitoringParameters requestedParameters) {
+    MonitoredItemModifyRequest(
+        IntegerId monitoredItemId, MonitoringParameters requestedParameters
+    ) {
         handle()->monitoredItemId = monitoredItemId;
         handle()->requestedParameters = detail::toNative(std::move(requestedParameters));
     }
 
-    UAPP_GETTER(uint32_t, getMonitoredItemId, monitoredItemId);
+    UAPP_GETTER(IntegerId, getMonitoredItemId, monitoredItemId);
     UAPP_GETTER_WRAPPER(MonitoringParameters, getRequestedParameters, requestedParameters)
 };
 
@@ -2018,7 +2020,7 @@ public:
 
     ModifyMonitoredItemsRequest(
         RequestHeader requestHeader,
-        uint32_t subscriptionId,
+        IntegerId subscriptionId,
         TimestampsToReturn timestampsToReturn,
         Span<const MonitoredItemModifyRequest> itemsToModify
     ) {
@@ -2030,7 +2032,7 @@ public:
     }
 
     UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER(uint32_t, getSubscriptionId, subscriptionId)
+    UAPP_GETTER(IntegerId, getSubscriptionId, subscriptionId)
     UAPP_GETTER_CAST(TimestampsToReturn, getTimestampsToReturn, timestampsToReturn)
     UAPP_GETTER_SPAN_WRAPPER(
         MonitoredItemModifyRequest, getItemsToModify, itemsToModify, itemsToModifySize
@@ -2064,9 +2066,9 @@ public:
 
     SetMonitoringModeRequest(
         RequestHeader requestHeader,
-        uint32_t subscriptionId,
+        IntegerId subscriptionId,
         MonitoringMode monitoringMode,
-        Span<const uint32_t> monitoredItemIds
+        Span<const IntegerId> monitoredItemIds
     ) {
         handle()->requestHeader = detail::toNative(std::move(requestHeader));
         handle()->subscriptionId = subscriptionId;
@@ -2076,9 +2078,9 @@ public:
     }
 
     UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER(uint32_t, getSubscriptionId, subscriptionId)
+    UAPP_GETTER(IntegerId, getSubscriptionId, subscriptionId)
     UAPP_GETTER_CAST(MonitoringMode, getMonitoringMode, monitoringMode)
-    UAPP_GETTER_SPAN(uint32_t, getMonitoredItemIds, monitoredItemIds, monitoredItemIdsSize)
+    UAPP_GETTER_SPAN(IntegerId, getMonitoredItemIds, monitoredItemIds, monitoredItemIdsSize)
 };
 
 /**
@@ -2108,10 +2110,10 @@ public:
 
     SetTriggeringRequest(
         RequestHeader requestHeader,
-        uint32_t subscriptionId,
-        uint32_t triggeringItemId,
-        Span<const uint32_t> linksToAdd,
-        Span<const uint32_t> linksToRemove
+        IntegerId subscriptionId,
+        IntegerId triggeringItemId,
+        Span<const IntegerId> linksToAdd,
+        Span<const IntegerId> linksToRemove
     ) {
         handle()->requestHeader = detail::toNative(std::move(requestHeader));
         handle()->subscriptionId = subscriptionId;
@@ -2123,10 +2125,10 @@ public:
     }
 
     UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER(uint32_t, getSubscriptionId, subscriptionId)
-    UAPP_GETTER(uint32_t, getTriggeringItemId, triggeringItemId)
-    UAPP_GETTER_SPAN(uint32_t, getLinksToAdd, linksToAdd, linksToAddSize)
-    UAPP_GETTER_SPAN(uint32_t, getLinksToRemove, linksToRemove, linksToRemoveSize)
+    UAPP_GETTER(IntegerId, getSubscriptionId, subscriptionId)
+    UAPP_GETTER(IntegerId, getTriggeringItemId, triggeringItemId)
+    UAPP_GETTER_SPAN(IntegerId, getLinksToAdd, linksToAdd, linksToAddSize)
+    UAPP_GETTER_SPAN(IntegerId, getLinksToRemove, linksToRemove, linksToRemoveSize)
 };
 
 /**
@@ -2159,7 +2161,9 @@ public:
     using TypeWrapper::TypeWrapper;
 
     DeleteMonitoredItemsRequest(
-        RequestHeader requestHeader, uint32_t subscriptionId, Span<const uint32_t> monitoredItemIds
+        RequestHeader requestHeader,
+        IntegerId subscriptionId,
+        Span<const IntegerId> monitoredItemIds
     ) {
         handle()->requestHeader = detail::toNative(std::move(requestHeader));
         handle()->subscriptionId = subscriptionId;
@@ -2168,8 +2172,8 @@ public:
     }
 
     UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER(uint32_t, getSubscriptionId, subscriptionId)
-    UAPP_GETTER_SPAN(uint32_t, getMonitoredItemIds, monitoredItemIds, monitoredItemIdsSize)
+    UAPP_GETTER(IntegerId, getSubscriptionId, subscriptionId)
+    UAPP_GETTER_SPAN(IntegerId, getMonitoredItemIds, monitoredItemIds, monitoredItemIdsSize)
 };
 
 /**
@@ -2234,7 +2238,7 @@ public:
     using TypeWrapper::TypeWrapper;
 
     UAPP_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
-    UAPP_GETTER(uint32_t, getSubscriptionId, subscriptionId)
+    UAPP_GETTER(IntegerId, getSubscriptionId, subscriptionId)
     UAPP_GETTER(bool, getRevisedPublishingInterval, revisedPublishingInterval)
     UAPP_GETTER(uint32_t, getRevisedLifetimeCount, revisedLifetimeCount)
     UAPP_GETTER(uint32_t, getRevisedMaxKeepAliveCount, revisedMaxKeepAliveCount)
@@ -2251,7 +2255,7 @@ public:
 
     ModifySubscriptionRequest(
         RequestHeader requestHeader,
-        uint32_t subscriptionId,
+        IntegerId subscriptionId,
         double requestedPublishingInterval,
         uint32_t requestedLifetimeCount,
         uint32_t requestedMaxKeepAliveCount,
@@ -2268,7 +2272,7 @@ public:
     }
 
     UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER(uint32_t, getSubscriptionId, subscriptionId)
+    UAPP_GETTER(IntegerId, getSubscriptionId, subscriptionId)
     UAPP_GETTER(double, getRequestedPublishingInterval, requestedPublishingInterval)
     UAPP_GETTER(uint32_t, getRequestedLifetimeCount, requestedLifetimeCount)
     UAPP_GETTER(uint32_t, getRequestedMaxKeepAliveCount, requestedMaxKeepAliveCount)
@@ -2301,7 +2305,7 @@ public:
     using TypeWrapper::TypeWrapper;
 
     SetPublishingModeRequest(
-        RequestHeader requestHeader, bool publishingEnabled, Span<const uint32_t> subscriptionIds
+        RequestHeader requestHeader, bool publishingEnabled, Span<const IntegerId> subscriptionIds
     ) {
         handle()->requestHeader = detail::toNative(std::move(requestHeader));
         handle()->publishingEnabled = publishingEnabled;
@@ -2311,7 +2315,7 @@ public:
 
     UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
     UAPP_GETTER(bool, getPublishingEnabled, publishingEnabled)
-    UAPP_GETTER_SPAN(uint32_t, getSubscriptionIds, subscriptionIds, subscriptionIdsSize)
+    UAPP_GETTER_SPAN(IntegerId, getSubscriptionIds, subscriptionIds, subscriptionIdsSize)
 };
 
 /**
@@ -2352,14 +2356,14 @@ class DeleteSubscriptionsRequest
 public:
     using TypeWrapper::TypeWrapper;
 
-    DeleteSubscriptionsRequest(RequestHeader requestHeader, Span<const uint32_t> subscriptionIds) {
+    DeleteSubscriptionsRequest(RequestHeader requestHeader, Span<const IntegerId> subscriptionIds) {
         handle()->requestHeader = detail::toNative(std::move(requestHeader));
         handle()->subscriptionIdsSize = subscriptionIds.size();
         handle()->subscriptionIds = detail::toNativeArray(subscriptionIds);
     }
 
     UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER_SPAN(uint32_t, getSubscriptionIds, subscriptionIds, subscriptionIdsSize)
+    UAPP_GETTER_SPAN(IntegerId, getSubscriptionIds, subscriptionIds, subscriptionIdsSize)
 };
 
 /**

--- a/src/monitoreditem.cpp
+++ b/src/monitoreditem.cpp
@@ -13,7 +13,7 @@ namespace opcua {
 
 template <typename T>
 static auto& getMonitoredItemContext(
-    T& connection, uint32_t subscriptionId, uint32_t monitoredItemId
+    T& connection, IntegerId subscriptionId, IntegerId monitoredItemId
 ) {
     const auto* context =
         detail::getContext(connection).monitoredItems.find({subscriptionId, monitoredItemId});

--- a/src/services_monitoreditem.cpp
+++ b/src/services_monitoreditem.cpp
@@ -95,7 +95,7 @@ void convertMonitoredItemContexts(
 template <typename T>
 static void storeMonitoredItemContext(
     T& connection,
-    uint32_t subscriptionId,
+    IntegerId subscriptionId,
     const MonitoredItemCreateResult& result,
     std::unique_ptr<MonitoredItemContext>& context
 ) {
@@ -111,7 +111,7 @@ static void storeMonitoredItemContext(
 
 void storeMonitoredItemContexts(
     Client& connection,
-    uint32_t subscriptionId,
+    IntegerId subscriptionId,
     const CreateMonitoredItemsResponse& response,
     Span<std::unique_ptr<MonitoredItemContext>> contexts
 ) {
@@ -155,7 +155,7 @@ CreateMonitoredItemsResponse createMonitoredItemsDataChange(
 template <>
 MonitoredItemCreateResult createMonitoredItemDataChange<Client>(
     Client& connection,
-    uint32_t subscriptionId,
+    IntegerId subscriptionId,
     const ReadValueId& itemToMonitor,
     MonitoringMode monitoringMode,
     const MonitoringParametersEx& parameters,
@@ -178,7 +178,7 @@ MonitoredItemCreateResult createMonitoredItemDataChange<Client>(
 template <>
 MonitoredItemCreateResult createMonitoredItemDataChange<Server>(
     Server& connection,
-    [[maybe_unused]] uint32_t subscriptionId,
+    [[maybe_unused]] IntegerId subscriptionId,
     const ReadValueId& itemToMonitor,
     MonitoringMode monitoringMode,
     const MonitoringParametersEx& parameters,
@@ -228,7 +228,7 @@ CreateMonitoredItemsResponse createMonitoredItemsEvent(
 
 MonitoredItemCreateResult createMonitoredItemEvent(
     Client& connection,
-    uint32_t subscriptionId,
+    IntegerId subscriptionId,
     const ReadValueId& itemToMonitor,
     MonitoringMode monitoringMode,
     const MonitoringParametersEx& parameters,
@@ -274,7 +274,7 @@ DeleteMonitoredItemsResponse deleteMonitoredItems(
 
 template <>
 StatusCode deleteMonitoredItem<Client>(
-    Client& connection, uint32_t subscriptionId, uint32_t monitoredItemId
+    Client& connection, IntegerId subscriptionId, IntegerId monitoredItemId
 ) {
     const auto request = detail::createDeleteMonitoredItemsRequest(
         subscriptionId, {&monitoredItemId, 1}
@@ -286,7 +286,7 @@ StatusCode deleteMonitoredItem<Client>(
 
 template <>
 StatusCode deleteMonitoredItem<Server>(
-    Server& connection, [[maybe_unused]] uint32_t subscriptionId, uint32_t monitoredItemId
+    Server& connection, [[maybe_unused]] IntegerId subscriptionId, IntegerId monitoredItemId
 ) {
     const auto status = UA_Server_deleteMonitoredItem(connection.handle(), monitoredItemId);
     opcua::detail::getContext(connection).monitoredItems.erase({0U, monitoredItemId});

--- a/src/services_subscription.cpp
+++ b/src/services_subscription.cpp
@@ -29,7 +29,7 @@ std::unique_ptr<SubscriptionContext> createSubscriptionContext(
 }
 
 void storeSubscriptionContext(
-    Client& connection, uint32_t subscriptionId, std::unique_ptr<SubscriptionContext>&& context
+    Client& connection, IntegerId subscriptionId, std::unique_ptr<SubscriptionContext>&& context
 ) {
     opcua::detail::getContext(connection).subscriptions.insert(subscriptionId, std::move(context));
 }

--- a/tests/services_monitoreditem.cpp
+++ b/tests/services_monitoreditem.cpp
@@ -60,7 +60,7 @@ TEST_CASE_TEMPLATE("MonitoredItem service set", T, Client, Async<Client>) {
     SUBCASE("createMonitoredItemDataChange") {
         size_t notificationCount = 0;
         DataValue changedValue;
-        const auto callback = [&](uint32_t, uint32_t, const DataValue& value) {
+        const auto callback = [&](IntegerId, IntegerId, const DataValue& value) {
             notificationCount++;
             changedValue = value;
         };
@@ -110,7 +110,7 @@ TEST_CASE_TEMPLATE("MonitoredItem service set", T, Client, Async<Client>) {
 
         size_t notificationCount = 0;
         size_t eventFieldsSize = 0;
-        const auto callback = [&](uint32_t, uint32_t, Span<const Variant> eventFields) {
+        const auto callback = [&](IntegerId, IntegerId, Span<const Variant> eventFields) {
             notificationCount++;
             eventFieldsSize = eventFields.size();
         };
@@ -222,7 +222,7 @@ TEST_CASE_TEMPLATE("MonitoredItem service set", T, Client, Async<Client>) {
                 {VariableId::Server_ServerStatus_CurrentTime, AttributeId::Value},
                 MonitoringMode::Reporting,
                 monitoringParameters,
-                [&](uint32_t, uint32_t, const DataValue&) { notificationCountTriggering++; },
+                [&](IntegerId, IntegerId, const DataValue&) { notificationCountTriggering++; },
                 {}
             )
                 .getMonitoredItemId();
@@ -237,7 +237,7 @@ TEST_CASE_TEMPLATE("MonitoredItem service set", T, Client, Async<Client>) {
                 {id, AttributeId::Value},
                 MonitoringMode::Sampling,
                 monitoringParameters,
-                [&](uint32_t, uint32_t, const DataValue&) { notificationCount++; },
+                [&](IntegerId, IntegerId, const DataValue&) { notificationCount++; },
                 {}
             )
                 .getMonitoredItemId();
@@ -293,7 +293,7 @@ TEST_CASE_TEMPLATE("MonitoredItem service set", T, Client, Async<Client>) {
                 MonitoringMode::Reporting,
                 monitoringParameters,
                 {},
-                [&](uint32_t, uint32_t) { deleted = true; }
+                [&](IntegerId, IntegerId) { deleted = true; }
             ).getMonitoredItemId();
 
         const auto deleteMonitoredItem = [&](auto&&... args) {
@@ -339,7 +339,7 @@ TEST_CASE("MonitoredItem service set (server)") {
                 {id, AttributeId::Value},
                 MonitoringMode::Reporting,
                 monitoringParameters,
-                [&](uint32_t, uint32_t, const DataValue&) { notificationCount++; },
+                [&](IntegerId, IntegerId, const DataValue&) { notificationCount++; },
                 {}
             )
                 .getMonitoredItemId();

--- a/tests/services_subscription.cpp
+++ b/tests/services_subscription.cpp
@@ -100,7 +100,7 @@ TEST_CASE_TEMPLATE("Subscription service set", T, Client, Async<Client>) {
 
     SUBCASE("deleteSubscription with callback") {
         bool deleted = false;
-        const auto deleteCallback = [&](uint32_t) { deleted = true; };
+        const auto deleteCallback = [&](IntegerId) { deleted = true; };
         const auto subId =
             services::createSubscription(connection, parameters, true, {}, deleteCallback)
                 .getSubscriptionId();

--- a/tests/subscription_monitoreditem.cpp
+++ b/tests/subscription_monitoreditem.cpp
@@ -43,7 +43,7 @@ TEST_CASE("Subscription & MonitoredItem (server)") {
             AttributeId::Value,
             MonitoringMode::Reporting,
             monitoringParameters,
-            [&](uint32_t, uint32_t, const DataValue&) { notificationCount++; }
+            [&](IntegerId, IntegerId, const DataValue&) { notificationCount++; }
         );
         CHECK(sub.getMonitoredItems().size() == 1);
 
@@ -111,7 +111,7 @@ TEST_CASE("Subscription & MonitoredItem (client)") {
             AttributeId::Value,
             MonitoringMode::Sampling,  // won't trigger notifications
             monitoringParameters,
-            [&](uint32_t, uint32_t, const DataValue&) { notificationCount++; }
+            [&](IntegerId, IntegerId, const DataValue&) { notificationCount++; }
         );
 
         CHECK(sub.getMonitoredItems().size() == 1);
@@ -138,18 +138,18 @@ TEST_CASE("Subscription & MonitoredItem (client)") {
     SUBCASE("Monitor data change with multiple monitored items") {
         auto sub = client.createSubscription();
 
-        uint32_t monId1 = 0;
+        IntegerId monId1 = 0;
         auto monItem1 = sub.subscribeDataChange(
             VariableId::Server_ServerStatus_CurrentTime,
             AttributeId::Value,
-            [&](uint32_t, uint32_t monId, const DataValue&) { monId1 = monId; }
+            [&](IntegerId, IntegerId monId, const DataValue&) { monId1 = monId; }
         );
 
-        uint32_t monId2 = 0;
+        IntegerId monId2 = 0;
         auto monItem2 = sub.subscribeDataChange(
             VariableId::Server_ServerStatus_CurrentTime,
             AttributeId::Value,
-            [&](uint32_t, uint32_t monId, const DataValue&) { monId2 = monId; }
+            [&](IntegerId, IntegerId monId, const DataValue&) { monId2 = monId; }
         );
 
         client.runIterate();
@@ -190,7 +190,7 @@ TEST_CASE("Subscription & MonitoredItem (client)") {
         auto mon = sub.subscribeEvent(
             ObjectId::Server,
             eventFilter,
-            [](uint32_t subId, uint32_t monId, const auto& eventFields) {
+            [](IntegerId subId, IntegerId monId, const auto& eventFields) {
                 CAPTURE(subId);
                 CAPTURE(monId);
                 CAPTURE(eventFields.size());


### PR DESCRIPTION
The type [`IntegerId`](https://reference.opcfoundation.org/Core/Part4/v105/docs/7.19) is an alias for `uint32_t` and is used in the OPC UA standard for identifiers like:
- subscription id
- monitored item id
- client handle
- ...