### PR TITLE
fix: zero initialization of unions or structs with unions

### DIFF
--- a/include/open62541pp/detail/types_handling.hpp
+++ b/include/open62541pp/detail/types_handling.hpp
@@ -59,13 +59,24 @@ constexpr bool isValidTypeCombination(const UA_DataType& type) {
 }
 
 template <typename T>
+constexpr void init(T& native) noexcept {
+    // caution: braced initialization will only zero-initialize the first member of a union
+    // use memset for unions or structs that may contain unions
+    if constexpr (std::is_union_v<T> || std::is_class_v<T>) {
+        std::memset(&native, 0, sizeof(T));
+    } else {
+        native = {};
+    }
+}
+
+template <typename T>
 constexpr void clear(T& native, const UA_DataType& type) noexcept {
     assert(isValidTypeCombination<T>(type));
     // NOLINTNEXTLINE(bugprone-branch-clone)
     if constexpr (isPointerFree<T>) {
-        native = {};
+        init(native);
     } else if (isBorrowed(native)) {
-        native = {};
+        init(native);
     } else {
         UA_clear(&native, &type);
     }

--- a/include/open62541pp/wrapper.hpp
+++ b/include/open62541pp/wrapper.hpp
@@ -3,6 +3,8 @@
 #include <type_traits>
 #include <utility>  // move
 
+#include "open62541pp/detail/types_handling.hpp"
+
 namespace opcua {
 
 /**
@@ -36,7 +38,9 @@ public:
 
     using NativeType = T;
 
-    constexpr Wrapper() noexcept = default;
+    constexpr Wrapper() noexcept {
+        detail::init(native());
+    }
 
     /// Copy constructor with native object.
     constexpr explicit Wrapper(const T& native) noexcept
@@ -108,7 +112,7 @@ protected:
     }
 
 private:
-    T native_{};
+    T native_;
 };
 
 /* -------------------------------------------- Trait ------------------------------------------- */

--- a/include/open62541pp/wrapper.hpp
+++ b/include/open62541pp/wrapper.hpp
@@ -1,9 +1,8 @@
 #pragma once
 
+#include <cstring>  // memset
 #include <type_traits>
 #include <utility>  // move
-
-#include "open62541pp/detail/types_handling.hpp"
 
 namespace opcua {
 
@@ -39,7 +38,9 @@ public:
     using NativeType = T;
 
     constexpr Wrapper() noexcept {
-        detail::init(native());
+        // caution: braced initialization will only zero-initialize the first member of a union
+        // use memset for unions or structs that may contain unions
+        std::memset(&native_, 0, sizeof(T));
     }
 
     /// Copy constructor with native object.
@@ -52,13 +53,13 @@ public:
 
     /// Copy assignment with native object.
     constexpr Wrapper& operator=(const T& native) noexcept {
-        this->native() = native;
+        native_ = native;
         return *this;
     }
 
     /// Move assignment with native object.
     constexpr Wrapper& operator=(T&& native) noexcept {
-        this->native() = std::move(native);
+        native_ = std::move(native);
         return *this;
     }
 
@@ -94,12 +95,12 @@ public:
 
     /// Swap with wrapper object.
     constexpr void swap(Wrapper& other) noexcept {
-        std::swap(this->native(), other.native());
+        std::swap(native_, other.native_);
     }
 
     /// Swap with native object.
     constexpr void swap(T& native) noexcept {
-        std::swap(this->native(), native);
+        std::swap(native_, native);
     }
 
 protected:
@@ -112,7 +113,7 @@ protected:
     }
 
 private:
-    T native_;
+    T native_{};
 };
 
 /* -------------------------------------------- Trait ------------------------------------------- */

--- a/src/plugin/accesscontrol.cpp
+++ b/src/plugin/accesscontrol.cpp
@@ -21,8 +21,10 @@ static AccessControlBase& getAdapter(UA_AccessControl* ac) {
 
 template <typename WrapperType, typename NativeType = typename WrapperType::NativeType>
 static const WrapperType& asWrapperRef(const NativeType* nativePtr) {
-    static const WrapperType empty;
-    return nativePtr == nullptr ? empty : asWrapper<WrapperType>(*nativePtr);
+    static constexpr NativeType empty{};
+    return nativePtr == nullptr
+        ? asWrapper<WrapperType>(empty)
+        : asWrapper<WrapperType>(*nativePtr);
 }
 
 static std::optional<Session> getSession(UA_Server* server, const UA_NodeId* sessionId) noexcept {

--- a/tests/wrapper.cpp
+++ b/tests/wrapper.cpp
@@ -73,6 +73,26 @@ TEST_CASE("Wrapper") {
         Wrapper<S> wrapper(S{11});
         CHECK(wrapper->value == 11);
     }
+
+    SUBCASE("Zero-initialize unions or structs with unions") {
+        union U {
+            char c;  // braced-initialization will only zero-initialize c
+            int i;
+        };
+
+        struct S {
+            U u;
+        };
+
+        SUBCASE("Union") {
+            Wrapper<U> wrapper;
+            CHECK(wrapper->i == 0);  // NOLINT
+        }
+        SUBCASE("Struct with union") {
+            Wrapper<S> wrapper;
+            CHECK(wrapper->u.i == 0);  // NOLINT
+        }
+    }
 }
 
 TEST_CASE("asWrapper / asNative") {


### PR DESCRIPTION
The `Wrapper` template base class uses braced initialization, but braced initialization will only zero-initialize the first member of a union. If the first member of a union is small than the other union members, than the rest of the union remains uninitialized. This caused errors detected in #447.

Solution: Use `std::memset` for unions or structs that may contain unions.