### PR TITLE
fix: config include in deprecated.hpp

### DIFF
--- a/include/open62541pp/deprecated.hpp.in
+++ b/include/open62541pp/deprecated.hpp.in
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "open62541pp/Config.h"
+#include "open62541pp/config.hpp"
 #include "open62541pp/${header_new}"
 
 #ifdef __GNUC__


### PR DESCRIPTION
`deprecated.hpp` included the deprecated header `Config.h`, which lead to another deprecation warning.