### PR TITLE
build: move doxygen-awesome-css submodule to 3rdparty folder

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "3rdparty/open62541"]
 	path = 3rdparty/open62541
 	url = https://github.com/open62541/open62541.git
-[submodule "doc/doxygen-awesome-css"]
-	path = doc/doxygen-awesome-css
-	url = https://github.com/jothepro/doxygen-awesome-css.git
 [submodule "3rdparty/doctest"]
 	path = 3rdparty/doctest
 	url = https://github.com/doctest/doctest.git
+[submodule "3rdparty/doxygen-awesome-css"]
+	path = 3rdparty/doxygen-awesome-css
+	url = https://github.com/jothepro/doxygen-awesome-css.git

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -60,7 +60,7 @@ GENERATE_HTML          = YES
 GENERATE_XML           = NO
 
 HTML_HEADER            = "${CMAKE_CURRENT_SOURCE_DIR}/header.html"
-HTML_EXTRA_STYLESHEET  = "${CMAKE_CURRENT_SOURCE_DIR}/doxygen-awesome-css/doxygen-awesome.css" \
+HTML_EXTRA_STYLESHEET  = "${PROJECT_SOURCE_DIR}/3rdparty/doxygen-awesome-css/doxygen-awesome.css" \
                          "${CMAKE_CURRENT_SOURCE_DIR}/custom.css"
 HTML_EXTRA_FILES       = "${CMAKE_CURRENT_SOURCE_DIR}/googleeace6f5ccc88b340.html"
 HTML_DYNAMIC_MENUS     = YES

--- a/doc/Doxyfile_open62541.in
+++ b/doc/Doxyfile_open62541.in
@@ -44,7 +44,7 @@ GENERATE_HTML          = YES
 GENERATE_XML           = NO
 
 HTML_HEADER            = "${CMAKE_CURRENT_SOURCE_DIR}/header.html"
-HTML_EXTRA_STYLESHEET  = "${CMAKE_CURRENT_SOURCE_DIR}/doxygen-awesome-css/doxygen-awesome.css" \
+HTML_EXTRA_STYLESHEET  = "${PROJECT_SOURCE_DIR}/3rdparty/doxygen-awesome-css/doxygen-awesome.css" \
                          "${CMAKE_CURRENT_SOURCE_DIR}/custom.css"
 HTML_DYNAMIC_MENUS     = YES
 HTML_DYNAMIC_SECTIONS  = NO


### PR DESCRIPTION
Prevents accidental includes of documentation snippets of the library.