### PR TITLE
feat: Client::onSubscriptionInactive

### DIFF
--- a/include/open62541pp/client.hpp
+++ b/include/open62541pp/client.hpp
@@ -100,6 +100,7 @@ public:
 
 using StateCallback = std::function<void()>;
 using InactivityCallback = std::function<void()>;
+using SubscriptionInactivityCallback = std::function<void(IntegerId subscriptionId)>;
 
 /**
  * High-level client class.
@@ -199,6 +200,10 @@ public:
     /// Every UA_ClientConfig::connectivityCheckInterval (in ms), an async read request is performed
     /// on the server. The callback is called when the client receives no response for this request.
     void onInactive(InactivityCallback callback);
+    /// Set a subscription inactivity callback.
+    /// The callback is called when the client does not receive a publish response after the defined
+    /// delay of `(publishingInterval * maxKeepAliveCount) + UA_ClientConfig::timeout)`.
+    void onSubscriptionInactive(SubscriptionInactivityCallback callback);
 
     /**
      * Connect to the selected server.

--- a/include/open62541pp/detail/client_context.hpp
+++ b/include/open62541pp/detail/client_context.hpp
@@ -37,14 +37,6 @@ struct ClientContext {
     std::vector<DataType> dataTypes;
     std::unique_ptr<UA_DataTypeArray> dataTypeArray;
 
-#ifdef UA_ENABLE_SUBSCRIPTIONS
-    using SubId = IntegerId;
-    using MonId = IntegerId;
-    using SubMonId = std::pair<SubId, MonId>;
-    ContextMap<SubId, services::detail::SubscriptionContext> subscriptions;
-    ContextMap<SubMonId, services::detail::MonitoredItemContext> monitoredItems;
-#endif
-
 #if UAPP_OPEN62541_VER_LE(1, 0)
     UA_ClientState lastClientState{};
 #else
@@ -53,6 +45,15 @@ struct ClientContext {
 #endif
     std::array<std::function<void()>, clientStateCount> stateCallbacks;
     std::function<void()> inactivityCallback;
+
+#ifdef UA_ENABLE_SUBSCRIPTIONS
+    using SubId = IntegerId;
+    using MonId = IntegerId;
+    using SubMonId = std::pair<SubId, MonId>;
+    ContextMap<SubId, services::detail::SubscriptionContext> subscriptions;
+    ContextMap<SubMonId, services::detail::MonitoredItemContext> monitoredItems;
+    std::function<void(IntegerId)> subscriptionInactivityCallback;
+#endif
 };
 
 }  // namespace opcua::detail

--- a/tests/client.cpp
+++ b/tests/client.cpp
@@ -246,6 +246,21 @@ TEST_CASE("Client inactivity callback") {
     CHECK(inactive);
 }
 
+TEST_CASE("Client subscription inactivity callback") {
+    Client client;
+    bool inactive = false;
+    IntegerId subscriptionId = 0;
+    client.onSubscriptionInactive([&](IntegerId id) {
+        inactive = true;
+        subscriptionId = id;
+    });
+#ifdef UA_ENABLE_SUBSCRIPTIONS
+    client.config()->subscriptionInactivityCallback(client.handle(), 11, nullptr);
+    CHECK(inactive);
+    CHECK(subscriptionId == 11);
+#endif
+}
+
 TEST_CASE("Client methods") {
     Server server;
     ServerRunner serverRunner(server);


### PR DESCRIPTION
Define a subscription inactivity callback via `Client::onSubscriptionInactive`.

The callback is called when the client does not receive a publish response after the defined delay of `(publishingInterval * maxKeepAliveCount) + UA_ClientConfig::timeout)`.

Closes #455.