### PR TITLE
feat!: remove maxReferences parameter from services::browseAll

### DIFF
--- a/include/open62541pp/services/view.hpp
+++ b/include/open62541pp/services/view.hpp
@@ -2,7 +2,6 @@
 
 #include <cstdint>
 #include <iterator>  // make_move_iterator
-#include <memory>  // enable_shared_from_this, make_shared
 #include <type_traits>
 #include <utility>
 #include <vector>

--- a/include/open62541pp/services/view.hpp
+++ b/include/open62541pp/services/view.hpp
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <cstdint>
+#include <iterator>  // make_move_iterator
+#include <memory>  // enable_shared_from_this, make_shared
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -329,14 +332,33 @@ auto unregisterNodesAsync(
 /* ----------------------------------- Non-standard functions ----------------------------------- */
 
 /**
- * Discover all the references of a specified node (without calling @ref browseNext).
- * @copydetails browse(T&, const BrowseDescription&, uint32_t)
  * @ingroup Browse
+ * @{
+ */
+
+/**
+ * Discover all the references of a specified node (without calling @ref browseNext).
+ * @param connection Instance of type Server or Client
+ * @param bd Browse description
  */
 template <typename T>
-Result<std::vector<ReferenceDescription>> browseAll(
-    T& connection, const BrowseDescription& bd, uint32_t maxReferences = 0
-);
+Result<std::vector<ReferenceDescription>> browseAll(T& connection, const BrowseDescription& bd) {
+    std::vector<ReferenceDescription> refs;
+    auto handler = [&](BrowseResult& result) {
+        refs.insert(
+            refs.end(),
+            std::make_move_iterator(result.getReferences().begin()),
+            std::make_move_iterator(result.getReferences().end())
+        );
+    };
+    BrowseResult result = browse(connection, bd, 0U);
+    handler(result);
+    while (!result.getContinuationPoint().empty()) {
+        result = browseNext(connection, false, result.getContinuationPoint());
+        handler(result);
+    }
+    return {std::move(refs), result.getStatusCode()};
+}
 
 /**
  * Discover child nodes recursively (non-standard).
@@ -358,6 +380,10 @@ Result<std::vector<ReferenceDescription>> browseAll(
 Result<std::vector<ExpandedNodeId>> browseRecursive(
     Server& connection, const BrowseDescription& bd
 );
+
+/**
+ * @}
+ */
 
 /**
  * @}

--- a/src/services_view.cpp
+++ b/src/services_view.cpp
@@ -1,7 +1,6 @@
 #include "open62541pp/services/view.hpp"
 
 #include <cstddef>  // size_t
-#include <iterator>  // make_move_iterator
 
 #include "open62541pp/client.hpp"
 #include "open62541pp/server.hpp"
@@ -89,40 +88,6 @@ UnregisterNodesResponse unregisterNodes(
 ) noexcept {
     return UA_Client_Service_unregisterNodes(connection.handle(), request);
 }
-
-template <typename T>
-Result<std::vector<ReferenceDescription>> browseAll(
-    T& connection, const BrowseDescription& bd, uint32_t maxReferences
-) {
-    std::vector<ReferenceDescription> refs;
-    auto append = [&](Span<ReferenceDescription> refsNew) {
-        refs.insert(
-            refs.end(),
-            std::make_move_iterator(refsNew.begin()),
-            std::make_move_iterator(refsNew.end())
-        );
-    };
-    BrowseResult result = browse(connection, bd, maxReferences);
-    append(result.getReferences());
-    while (!result.getContinuationPoint().empty()) {
-        result = browseNext(connection, false, result.getContinuationPoint());
-        append(result.getReferences());
-    }
-    if (result.getStatusCode().isBad()) {
-        return BadResult(result.getStatusCode());
-    }
-    if ((maxReferences > 0) && (refs.size() > maxReferences)) {
-        refs.resize(maxReferences);
-    }
-    return refs;
-}
-
-template Result<std::vector<ReferenceDescription>> browseAll<Client>(
-    Client&, const BrowseDescription&, uint32_t
-);
-template Result<std::vector<ReferenceDescription>> browseAll<Server>(
-    Server&, const BrowseDescription&, uint32_t
-);
 
 Result<std::vector<ExpandedNodeId>> browseRecursive(
     Server& connection, const BrowseDescription& bd

--- a/tests/services_view.cpp
+++ b/tests/services_view.cpp
@@ -96,8 +96,7 @@ TEST_CASE_TEMPLATE("View service set", T, Server, Client, Async<Client>) {
 
     SUBCASE("browseAll") {
         const BrowseDescription bd(id, BrowseDirection::Both);
-        CHECK(services::browseAll(connection, bd, 0).value().size() == 2);
-        CHECK(services::browseAll(connection, bd, 1).value().size() == 1);
+        CHECK(services::browseAll(connection, bd).value().size() == 2);
     }
 
     SUBCASE("browseSimplifiedBrowsePath") {


### PR DESCRIPTION
As the name implies, `browseAll` should be used to retrieve all references. Use `browse` to get only a limited set of references.