### PR TITLE
feat!: remove get prefix of ExtensionObject getters

### DIFF
--- a/examples/custom_datatypes/client_custom_datatypes.cpp
+++ b/examples/custom_datatypes/client_custom_datatypes.cpp
@@ -49,7 +49,7 @@ int main() {
     if (variant.isArray() && variant.isType<opcua::ExtensionObject>()) {
         size_t i = 0;
         for (auto&& extObj : variant.getArray<opcua::ExtensionObject>()) {
-            const auto* p = static_cast<Point*>(extObj.getDecodedData());
+            const auto* p = static_cast<Point*>(extObj.decodedData());
             std::cout << "PointVec[" << i++ << "]:\n";
             std::cout << "- x = " << p->x << "\n";
             std::cout << "- y = " << p->y << "\n";

--- a/examples/server_accesscontrol.cpp
+++ b/examples/server_accesscontrol.cpp
@@ -23,7 +23,7 @@ public:
     ) override {
         // Grant admin rights if user is logged in as "admin"
         // Store attribute "isAdmin" as session attribute to use it in access callbacks
-        const auto* token = userIdentityToken.getDecodedData<UserNameIdentityToken>();
+        const auto* token = userIdentityToken.decodedData<UserNameIdentityToken>();
         const bool isAdmin = (token != nullptr && token->getUserName() == "admin");
         std::cout << "User has admin rights: " << isAdmin << std::endl;
         session.setSessionAttribute({0, "isAdmin"}, Variant::fromScalar(isAdmin));

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -1933,72 +1933,122 @@ public:
     }
 
     /// Get the encoding.
-    ExtensionObjectEncoding getEncoding() const noexcept {
+    ExtensionObjectEncoding encoding() const noexcept {
         return static_cast<ExtensionObjectEncoding>(handle()->encoding);
+    }
+
+    /// @deprecated Use encoding() instead
+    [[deprecated("use encoding() instead")]]
+    ExtensionObjectEncoding getEncoding() const noexcept {
+        return encoding();
     }
 
     /// Get the encoded type id.
     /// Returns `nullptr` if ExtensionObject is not encoded.
-    const NodeId* getEncodedTypeId() const noexcept {
+    const NodeId* encodedTypeId() const noexcept {
         return isEncoded()
             ? asWrapper<NodeId>(&handle()->content.encoded.typeId)  // NOLINT
             : nullptr;
     }
 
+    /// @deprecated Use encodedTypeId() instead
+    [[deprecated("use encodedTypeId() instead")]]
+    const NodeId* getEncodedTypeId() const noexcept {
+        return encodedTypeId();
+    }
+
     /// Get the encoded body.
     /// Returns `nullptr` if ExtensionObject is not encoded.
-    const ByteString* getEncodedBody() const noexcept {
+    const ByteString* encodedBody() const noexcept {
         return isEncoded()
             ? asWrapper<ByteString>(&handle()->content.encoded.body)  // NOLINT
             : nullptr;
     }
 
+    /// @deprecated Use encodedBody() instead
+    [[deprecated("use encodedBody() instead")]]
+    const ByteString* getEncodedBody() const noexcept {
+        return encodedBody();
+    }
+
     /// Get the decoded data type.
     /// Returns `nullptr` if ExtensionObject is not decoded.
-    const UA_DataType* getDecodedDataType() const noexcept {
+    const UA_DataType* decodedType() const noexcept {
         return isDecoded()
             ? handle()->content.decoded.type  // NOLINT
             : nullptr;
+    }
+
+    /// @deprecated Use decodedType() instead
+    [[deprecated("use decodedType() instead")]]
+    const UA_DataType* getDecodedDataType() const noexcept {
+        return decodedType();
     }
 
     /// Get pointer to the decoded data with given template type.
     /// Returns `nullptr` if the ExtensionObject is either not decoded or the decoded data is not of
     /// type `T`.
     template <typename T>
+    T* decodedData() noexcept {
+        return isDecodedType<T>() ? static_cast<T*>(decodedData()) : nullptr;
+    }
+
+    /// @deprecated Use decodedData<T>() instead
+    template <typename T>
+    [[deprecated("use decodedData<T>() instead")]]
     T* getDecodedData() noexcept {
-        return isDecodedDataType<T>() ? static_cast<T*>(getDecodedData()) : nullptr;
+        return decodedData<T>();
     }
 
     /// Get const pointer to the decoded data with given template type.
     /// Returns `nullptr` if the ExtensionObject is either not decoded or the decoded data is not of
     /// type `T`.
     template <typename T>
+    const T* decodedData() const noexcept {
+        return isDecodedType<T>() ? static_cast<const T*>(decodedData()) : nullptr;
+    }
+
+    /// @deprecated Use decodedData<T>() instead
+    template <typename T>
+    [[deprecated("use decodedData<T>() instead")]]
     const T* getDecodedData() const noexcept {
-        return isDecodedDataType<T>() ? static_cast<const T*>(getDecodedData()) : nullptr;
+        return decodedData<T>();
     }
 
     /// Get pointer to the decoded data.
     /// Returns `nullptr` if the ExtensionObject is not decoded.
     /// @warning Type erased version, use with caution.
+    void* decodedData() noexcept {
+        return isDecoded()
+            ? handle()->content.decoded.data  // NOLINT
+            : nullptr;
+    }
+
+    /// @deprecated Use decodedData() instead
+    [[deprecated("use decodedData() instead")]]
     void* getDecodedData() noexcept {
-        return isDecoded()
-            ? handle()->content.decoded.data  // NOLINT
-            : nullptr;
+        return decodedData();
     }
 
     /// Get pointer to the decoded data.
     /// Returns `nullptr` if the ExtensionObject is not decoded.
     /// @warning Type erased version, use with caution.
-    const void* getDecodedData() const noexcept {
+    const void* decodedData() const noexcept {
         return isDecoded()
             ? handle()->content.decoded.data  // NOLINT
             : nullptr;
+    }
+
+    /// @deprecated Use decodedData() instead
+    [[deprecated("use decodedData() instead")]]
+    const void* getDecodedData() const noexcept {
+        return decodedData();
     }
 
 private:
     template <typename T>
-    bool isDecodedDataType() const noexcept {
-        const auto* type = getDecodedDataType();
+    bool isDecodedType() const noexcept {
+        const auto* type = decodedType();
         return (type != nullptr) && (type->typeId == getDataType<T>().typeId);
     }
 };

--- a/src/plugin/accesscontrol_default.cpp
+++ b/src/plugin/accesscontrol_default.cpp
@@ -62,7 +62,7 @@ StatusCode AccessControlDefault::activateSession(
     }
 
     // anonymous login
-    if (const auto* token = userIdentityToken.getDecodedData<AnonymousIdentityToken>();
+    if (const auto* token = userIdentityToken.decodedData<AnonymousIdentityToken>();
         token != nullptr) {
         if (!allowAnonymous_) {
             return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
@@ -74,7 +74,7 @@ StatusCode AccessControlDefault::activateSession(
     }
 
     // username and password
-    if (const auto* token = userIdentityToken.getDecodedData<UserNameIdentityToken>();
+    if (const auto* token = userIdentityToken.decodedData<UserNameIdentityToken>();
         token != nullptr) {
         if (token->getPolicyId() != policyIdUsername) {
             return UA_STATUSCODE_BADIDENTITYTOKENINVALID;

--- a/src/services_nodemanagement.cpp
+++ b/src/services_nodemanagement.cpp
@@ -52,8 +52,8 @@ Result<NodeId> addNode<Server>(
         referenceType.handle(),
         {id.namespaceIndex(), opcua::detail::toNativeString(browseName)},
         typeDefinition.handle(),
-        static_cast<const UA_NodeAttributes*>(nodeAttributes.getDecodedData()),
-        nodeAttributes.getDecodedDataType(),
+        static_cast<const UA_NodeAttributes*>(nodeAttributes.decodedData()),
+        nodeAttributes.decodedType(),
         nullptr,  // nodeContext
         addedNodeId.handle()
     );

--- a/src/ua_types.cpp
+++ b/src/ua_types.cpp
@@ -65,7 +65,7 @@ static ContentFilter concatFilterElements(
         // increment element operand indexes by offset
         for (auto& element : resultElementsView) {
             for (auto& operand : element.getFilterOperands()) {
-                auto* elementOperand = operand.getDecodedData<ElementOperand>();
+                auto* elementOperand = operand.decodedData<ElementOperand>();
                 if (elementOperand != nullptr) {
                     elementOperand->handle()->index += static_cast<uint32_t>(offset);
                 }

--- a/tests/client.cpp
+++ b/tests/client.cpp
@@ -29,16 +29,16 @@ TEST_CASE("ClientConfig") {
         CHECK(token.isEmpty());
 
         config.setUserIdentityToken(AnonymousIdentityToken{});
-        CHECK(token.getDecodedData<AnonymousIdentityToken>() != nullptr);
+        CHECK(token.decodedData<AnonymousIdentityToken>() != nullptr);
 
         config.setUserIdentityToken(UserNameIdentityToken{});
-        CHECK(token.getDecodedData<UserNameIdentityToken>() != nullptr);
+        CHECK(token.decodedData<UserNameIdentityToken>() != nullptr);
 
         config.setUserIdentityToken(X509IdentityToken{});
-        CHECK(token.getDecodedData<X509IdentityToken>() != nullptr);
+        CHECK(token.decodedData<X509IdentityToken>() != nullptr);
 
         config.setUserIdentityToken(IssuedIdentityToken{});
-        CHECK(token.getDecodedData<IssuedIdentityToken>() != nullptr);
+        CHECK(token.decodedData<IssuedIdentityToken>() != nullptr);
 
         CHECK_FALSE(token.isEmpty());
     }

--- a/tests/types_builtin.cpp
+++ b/tests/types_builtin.cpp
@@ -956,37 +956,37 @@ TEST_CASE("ExtensionObject") {
         CHECK(obj.isEmpty());
         CHECK_FALSE(obj.isEncoded());
         CHECK_FALSE(obj.isDecoded());
-        CHECK(obj.getEncoding() == ExtensionObjectEncoding::EncodedNoBody);
-        CHECK(obj.getEncodedTypeId() == nullptr);
-        CHECK(obj.getEncodedBody() == nullptr);
-        CHECK(obj.getDecodedDataType() == nullptr);
-        CHECK(obj.getDecodedData() == nullptr);
+        CHECK(obj.encoding() == ExtensionObjectEncoding::EncodedNoBody);
+        CHECK(obj.encodedTypeId() == nullptr);
+        CHECK(obj.encodedBody() == nullptr);
+        CHECK(obj.decodedType() == nullptr);
+        CHECK(obj.decodedData() == nullptr);
     }
 
     SUBCASE("fromDecoded (type erased variant)") {
         int32_t value = 11;
         const auto obj = ExtensionObject::fromDecoded(&value, UA_TYPES[UA_TYPES_INT32]);
-        CHECK(obj.getEncoding() == ExtensionObjectEncoding::DecodedNoDelete);
+        CHECK(obj.encoding() == ExtensionObjectEncoding::DecodedNoDelete);
         CHECK(obj.isDecoded());
-        CHECK(obj.getDecodedDataType() == &UA_TYPES[UA_TYPES_INT32]);
-        CHECK(obj.getDecodedData() == &value);
+        CHECK(obj.decodedType() == &UA_TYPES[UA_TYPES_INT32]);
+        CHECK(obj.decodedData() == &value);
     }
 
     SUBCASE("fromDecoded") {
         String value("test123");
         const auto obj = ExtensionObject::fromDecoded(value);
-        CHECK(obj.getEncoding() == ExtensionObjectEncoding::DecodedNoDelete);
+        CHECK(obj.encoding() == ExtensionObjectEncoding::DecodedNoDelete);
         CHECK(obj.isDecoded());
-        CHECK(obj.getDecodedDataType() == &UA_TYPES[UA_TYPES_STRING]);
-        CHECK(obj.getDecodedData() == value.handle());
+        CHECK(obj.decodedType() == &UA_TYPES[UA_TYPES_STRING]);
+        CHECK(obj.decodedData() == value.handle());
     }
 
     SUBCASE("fromDecodedCopy") {
         auto obj = ExtensionObject::fromDecodedCopy(Variant::fromScalar(11.11));
-        CHECK(obj.getEncoding() == ExtensionObjectEncoding::Decoded);
+        CHECK(obj.encoding() == ExtensionObjectEncoding::Decoded);
         CHECK(obj.isDecoded());
-        CHECK(obj.getDecodedDataType() == &UA_TYPES[UA_TYPES_VARIANT]);
-        auto* varPtr = static_cast<Variant*>(obj.getDecodedData());
+        CHECK(obj.decodedType() == &UA_TYPES[UA_TYPES_VARIANT]);
+        auto* varPtr = static_cast<Variant*>(obj.decodedData());
         CHECK(varPtr != nullptr);
         CHECK(varPtr->getScalar<double>() == 11.11);
     }
@@ -994,8 +994,8 @@ TEST_CASE("ExtensionObject") {
     SUBCASE("getDecodedData") {
         double value = 11.11;
         auto obj = ExtensionObject::fromDecoded(value);
-        CHECK(obj.getDecodedData() == &value);
-        CHECK(obj.getDecodedData<int>() == nullptr);
-        CHECK(obj.getDecodedData<double>() == &value);
+        CHECK(obj.decodedData() == &value);
+        CHECK(obj.decodedData<int>() == nullptr);
+        CHECK(obj.decodedData<double>() == &value);
     }
 }

--- a/tests/ua_types.cpp
+++ b/tests/ua_types.cpp
@@ -119,7 +119,7 @@ TEST_CASE("AddNodesItem / AddNodesRequest") {
     CHECK(item.getRequestedNewNodeId().nodeId() == NodeId(1, 1002));
     CHECK(item.getBrowseName() == QualifiedName(1, "item"));
     CHECK(item.getNodeClass() == NodeClass::Object);
-    CHECK(item.getNodeAttributes().getDecodedDataType() == &UA_TYPES[UA_TYPES_OBJECTATTRIBUTES]);
+    CHECK(item.getNodeAttributes().decodedType() == &UA_TYPES[UA_TYPES_OBJECTATTRIBUTES]);
     CHECK(item.getTypeDefinition().nodeId() == NodeId(1, 1003));
 
     const AddNodesRequest request({}, {item});
@@ -394,15 +394,15 @@ TEST_CASE("ContentFilter(Element)") {
     CHECK(elements.size() == 3);
     CHECK(elements[0].getFilterOperator() == FilterOperator::And);
     CHECK(elements[0].getFilterOperands().size() == 2);
-    CHECK(elements[0].getFilterOperands()[0].getDecodedData<ElementOperand>()->getIndex() == 1);
-    CHECK(elements[0].getFilterOperands()[1].getDecodedData<ElementOperand>()->getIndex() == 2);
+    CHECK(elements[0].getFilterOperands()[0].decodedData<ElementOperand>()->getIndex() == 1);
+    CHECK(elements[0].getFilterOperands()[1].decodedData<ElementOperand>()->getIndex() == 2);
     CHECK(elements[1].getFilterOperator() == FilterOperator::OfType);
     CHECK(elements[1].getFilterOperands().size() == 1);
-    CHECK(elements[1].getFilterOperands()[0].getDecodedData<LiteralOperand>() != nullptr);
+    CHECK(elements[1].getFilterOperands()[0].decodedData<LiteralOperand>() != nullptr);
     CHECK(elements[2].getFilterOperator() == FilterOperator::Equals);
     CHECK(elements[2].getFilterOperands().size() == 2);
-    CHECK(elements[2].getFilterOperands()[0].getDecodedData<LiteralOperand>() != nullptr);
-    CHECK(elements[2].getFilterOperands()[1].getDecodedData<LiteralOperand>() != nullptr);
+    CHECK(elements[2].getFilterOperands()[0].decodedData<LiteralOperand>() != nullptr);
+    CHECK(elements[2].getFilterOperands()[1].decodedData<LiteralOperand>() != nullptr);
 }
 
 TEST_CASE("ContentFilter(Element) operators") {
@@ -423,7 +423,7 @@ TEST_CASE("ContentFilter(Element) operators") {
     };
 
     auto elementOperandIndex = [](const ExtensionObject& operand) {
-        return operand.getDecodedData<ElementOperand>()->getIndex();
+        return operand.decodedData<ElementOperand>()->getIndex();
     };
 
     auto firstOperator = [](const ContentFilter& contentFilter) {


### PR DESCRIPTION
Remove `get` prefix of `ExtensionObject` getters.
See #459.