### PR TITLE
feat!: create ExtensionObject with custom data types from references, not pointers

### DIFF
--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -1874,44 +1874,43 @@ public:
     /// @param data Decoded data
     template <typename T>
     [[nodiscard]] static ExtensionObject fromDecoded(T& data) noexcept {
-        return fromDecoded(&data, getDataType<T>());
+        return fromDecoded(data, getDataType<T>());
     }
 
-    /// Create an ExtensionObject from a decoded object (reference).
+    /// Create an ExtensionObject from a decoded object (reference) with a custom data type.
     /// The data will *not* be deleted when the ExtensionObject is destructed.
     /// @param data Decoded data
     /// @param type Data type of the decoded data
-    /// @warning Type erased version, use with caution.
-    [[nodiscard]] static ExtensionObject fromDecoded(void* data, const UA_DataType& type) noexcept {
+    template <typename T>
+    [[nodiscard]] static ExtensionObject fromDecoded(T& data, const UA_DataType& type) noexcept {
+        assert(sizeof(T) == type.memSize);
         ExtensionObject obj;
         obj->encoding = UA_EXTENSIONOBJECT_DECODED_NODELETE;
         obj->content.decoded.type = &type;  // NOLINT
-        obj->content.decoded.data = data;  // NOLINT
+        obj->content.decoded.data = &data;  // NOLINT
         return obj;
     }
 
     /// Create an ExtensionObject from a decoded object (copy).
-    /// Set the "decoded" data to a copy of the given object.
     /// @param data Decoded data
     template <typename T>
     [[nodiscard]] static ExtensionObject fromDecodedCopy(const T& data) {
-        return fromDecodedCopy(&data, getDataType<T>());
+        return fromDecodedCopy(data, getDataType<T>());
     }
 
-    /// Create an ExtensionObject from a decoded object (copy).
+    /// Create an ExtensionObject from a decoded object (copy) with a custom data type.
     /// @param data Decoded data
     /// @param type Data type of the decoded data
-    /// @warning Type erased version, use with caution.
-    [[nodiscard]] static ExtensionObject fromDecodedCopy(
-        const void* data, const UA_DataType& type
-    ) {
+    template <typename T>
+    [[nodiscard]] static ExtensionObject fromDecodedCopy(const T& data, const UA_DataType& type) {
         // manual implementation instead of UA_ExtensionObject_setValueCopy to support open62541
         // v1.0 https://github.com/open62541/open62541/blob/v1.3.5/src/ua_types.c#L503-L524
+        assert(sizeof(T) == type.memSize);
         ExtensionObject obj;
         obj->encoding = UA_EXTENSIONOBJECT_DECODED;
         obj->content.decoded.data = detail::allocate<void>(type);  // NOLINT
         obj->content.decoded.type = &type;  // NOLINT
-        throwIfBad(UA_copy(data, obj->content.decoded.data, &type));  // NOLINT
+        throwIfBad(UA_copy(&data, obj->content.decoded.data, &type));  // NOLINT
         return obj;
     }
 

--- a/tests/types_builtin.cpp
+++ b/tests/types_builtin.cpp
@@ -963,18 +963,15 @@ TEST_CASE("ExtensionObject") {
         CHECK(obj.decodedData() == nullptr);
     }
 
-    SUBCASE("fromDecoded (type erased variant)") {
-        int32_t value = 11;
-        const auto obj = ExtensionObject::fromDecoded(&value, UA_TYPES[UA_TYPES_INT32]);
-        CHECK(obj.encoding() == ExtensionObjectEncoding::DecodedNoDelete);
-        CHECK(obj.isDecoded());
-        CHECK(obj.decodedType() == &UA_TYPES[UA_TYPES_INT32]);
-        CHECK(obj.decodedData() == &value);
-    }
-
     SUBCASE("fromDecoded") {
+        ExtensionObject obj;
         String value("test123");
-        const auto obj = ExtensionObject::fromDecoded(value);
+        SUBCASE("Deduce data type") {
+            obj = ExtensionObject::fromDecoded(value);
+        }
+        SUBCASE("Custom data type") {
+            obj = ExtensionObject::fromDecoded(value, UA_TYPES[UA_TYPES_STRING]);
+        }
         CHECK(obj.encoding() == ExtensionObjectEncoding::DecodedNoDelete);
         CHECK(obj.isDecoded());
         CHECK(obj.decodedType() == &UA_TYPES[UA_TYPES_STRING]);
@@ -982,16 +979,22 @@ TEST_CASE("ExtensionObject") {
     }
 
     SUBCASE("fromDecodedCopy") {
-        auto obj = ExtensionObject::fromDecodedCopy(Variant::fromScalar(11.11));
+        ExtensionObject obj;
+        const auto value = Variant::fromScalar(11.11);
+        SUBCASE("Deduce data type") {
+            obj = ExtensionObject::fromDecodedCopy(value);
+        }
+        SUBCASE("Custom data type") {
+            obj = ExtensionObject::fromDecodedCopy(value, UA_TYPES[UA_TYPES_VARIANT]);
+        }
         CHECK(obj.encoding() == ExtensionObjectEncoding::Decoded);
         CHECK(obj.isDecoded());
         CHECK(obj.decodedType() == &UA_TYPES[UA_TYPES_VARIANT]);
-        auto* varPtr = static_cast<Variant*>(obj.decodedData());
-        CHECK(varPtr != nullptr);
-        CHECK(varPtr->getScalar<double>() == 11.11);
+        CHECK(obj.decodedData<Variant>() != nullptr);
+        CHECK(obj.decodedData<Variant>()->getScalar<double>() == 11.11);
     }
 
-    SUBCASE("getDecodedData") {
+    SUBCASE("decodedData") {
         double value = 11.11;
         auto obj = ExtensionObject::fromDecoded(value);
         CHECK(obj.decodedData() == &value);


### PR DESCRIPTION
Pass data as references to `fromDecoded*` factory functions instead of type-erased pointers.

```diff
- static ExtensionObject fromDecoded(void* data, const UA_DataType& type) noexcept;
- static ExtensionObject fromDecodedCopy(const void* data, const UA_DataType& type) noexcept;

+ template <typename T>
+ static ExtensionObject fromDecoded(T& data, const UA_DataType& type);
+ template <typename T>
+ static ExtensionObject fromDecodedCopy(const T& data, const UA_DataType& type);
```