### PR TITLE
refactor: replace StringWrapper with CRTP mixin class

### DIFF
--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -264,6 +264,8 @@ public:
     using StringLikeMixin ::StringLikeMixin;
     using TypeWrapper::TypeWrapper;
 
+    String() noexcept = default;
+
     explicit String(std::string_view str)
         : TypeWrapper(detail::allocNativeString(str)) {}
 
@@ -507,6 +509,8 @@ public:
     using StringLikeMixin ::StringLikeMixin;
     using TypeWrapper::TypeWrapper;
 
+    ByteString() noexcept = default;
+
     explicit ByteString(std::string_view str)
         : TypeWrapper(detail::allocNativeString(str)) {}
 
@@ -564,6 +568,8 @@ class XmlElement
 public:
     using StringLikeMixin ::StringLikeMixin;
     using TypeWrapper::TypeWrapper;
+
+    XmlElement() noexcept = default;
 
     explicit XmlElement(std::string_view str)
         : TypeWrapper(detail::allocNativeString(str)) {}

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -577,10 +577,6 @@ public:
         init(first, last);
     }
 
-    XmlElement(std::initializer_list<char> values) {
-        init(values.begin(), values.end());
-    }
-
     /// Implicit conversion to std::string_view.
     operator std::string_view() const noexcept {  // NOLINT(hicpp-explicit-conversions)
         return {data(), size()};

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -84,15 +84,16 @@ public:
     }
 };
 
-/* ---------------------------------------- StringWrapper --------------------------------------- */
+/* --------------------------------------- StringLikeMixin -------------------------------------- */
 
 namespace detail {
 
-template <typename T, TypeIndex typeIndex, typename CharT>
-class StringWrapper : public TypeWrapper<T, typeIndex> {
+/**
+ * CRTP mixin class to provide a STL-compatible string interface.
+ */
+template <typename WrapperType, typename CharT>
+class StringLikeMixin {
 public:
-    static_assert(std::is_same_v<T, UA_String>);
-
     // clang-format off
     using value_type             = CharT;
     using size_type              = size_t;
@@ -107,17 +108,18 @@ public:
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
     // clang-format on
 
-    using TypeWrapper<T, typeIndex>::TypeWrapper;  // inherit constructors
-
     template <typename InputIt>
-    StringWrapper(InputIt first, InputIt last)
-        : StringWrapper(first, last, typename std::iterator_traits<InputIt>::iterator_category{}) {}
+    StringLikeMixin(InputIt first, InputIt last)
+        : StringLikeMixin(
+              first, last, typename std::iterator_traits<InputIt>::iterator_category{}
+          ) {}
 
-    StringWrapper(std::initializer_list<CharT> init)
-        : StringWrapper(init.begin(), init.end()) {}
+    StringLikeMixin(std::initializer_list<CharT> init)
+        : StringLikeMixin(init.begin(), init.end()) {}
 
     size_t size() const noexcept {
-        return this->native().length;
+        const auto& native = asNative(static_cast<const WrapperType&>(*this));
+        return native.length;
     }
 
     size_t length() const noexcept {
@@ -129,11 +131,13 @@ public:
     }
 
     pointer data() noexcept {
-        return reinterpret_cast<pointer>(this->native().data);  // NOLINT
+        auto& native = asNative(static_cast<WrapperType&>(*this));
+        return reinterpret_cast<pointer>(native.data);  // NOLINT
     }
 
     const_pointer data() const noexcept {
-        return reinterpret_cast<const_pointer>(this->native().data);  // NOLINT
+        const auto& native = asNative(static_cast<const WrapperType&>(*this));
+        return reinterpret_cast<const_pointer>(native.data);  // NOLINT
     }
 
     reference operator[](size_t index) noexcept {
@@ -215,28 +219,33 @@ public:
     }
 
 protected:
-    void init(size_t length) {
-        this->native().length = length;
-        if (length > 0) {
-            this->native().data = static_cast<uint8_t*>(UA_malloc(length));  // NOLINT
-            if (data() == nullptr) {
-                throw BadStatus(UA_STATUSCODE_BADOUTOFMEMORY);
-            }
-        }
-    }
+    friend WrapperType;
+
+    StringLikeMixin() noexcept = default;
 
     template <typename InputIt, typename Tag>
-    StringWrapper(InputIt first, InputIt last, Tag /* unused */) {
+    StringLikeMixin(InputIt first, InputIt last, Tag /* unused */) {
         init(std::distance(first, last));
         std::copy(first, last, data());
     }
 
     template <typename InputIt>
-    StringWrapper(InputIt first, InputIt last, std::input_iterator_tag /* unused */) {
+    StringLikeMixin(InputIt first, InputIt last, std::input_iterator_tag /* unused */) {
         // input iterator can only be read once -> buffer data in vector
         std::vector<uint8_t> buffer(first, last);
         init(buffer.size());
         std::copy(buffer.begin(), buffer.end(), data());
+    }
+
+    void init(size_t length) {
+        auto& native = asNative(static_cast<WrapperType&>(*this));
+        native.length = length;
+        if (length > 0) {
+            native.data = static_cast<uint8_t*>(UA_malloc(length));  // NOLINT
+            if (data() == nullptr) {
+                throw BadStatus(UA_STATUSCODE_BADOUTOFMEMORY);
+            }
+        }
     }
 };
 
@@ -248,12 +257,15 @@ protected:
  * UA_String wrapper class.
  * @ingroup Wrapper
  */
-class String : public detail::StringWrapper<UA_String, UA_TYPES_STRING, char> {
+class String
+    : public TypeWrapper<UA_String, UA_TYPES_STRING>,
+      public detail::StringLikeMixin<String, char> {
 public:
-    using StringWrapper::StringWrapper;  // inherit constructors
+    using StringLikeMixin ::StringLikeMixin;
+    using TypeWrapper::TypeWrapper;
 
     explicit String(std::string_view str)
-        : StringWrapper(detail::allocNativeString(str)) {}
+        : TypeWrapper(detail::allocNativeString(str)) {}
 
     /// Implicit conversion to std::string_view.
     operator std::string_view() const noexcept {  // NOLINT(hicpp-explicit-conversions)
@@ -488,18 +500,21 @@ std::ostream& operator<<(std::ostream& os, const Guid& guid);
  * UA_ByteString wrapper class.
  * @ingroup Wrapper
  */
-class ByteString : public detail::StringWrapper<UA_ByteString, UA_TYPES_BYTESTRING, uint8_t> {
+class ByteString
+    : public TypeWrapper<UA_String, UA_TYPES_STRING>,
+      public detail::StringLikeMixin<ByteString, uint8_t> {
 public:
-    using StringWrapper::StringWrapper;  // inherit constructors
+    using StringLikeMixin ::StringLikeMixin;
+    using TypeWrapper::TypeWrapper;
 
     explicit ByteString(std::string_view str)
-        : StringWrapper(detail::allocNativeString(str)) {}
+        : TypeWrapper(detail::allocNativeString(str)) {}
 
     explicit ByteString(const char* str)  // required to avoid ambiguity
         : ByteString(std::string_view(str)) {}
 
     explicit ByteString(Span<const uint8_t> bytes)
-        : StringWrapper(bytes.begin(), bytes.end()) {}
+        : StringLikeMixin(bytes.begin(), bytes.end()) {}
 
     /// Parse ByteString from Base64 encoded string.
     /// @note Supported since open62541 v1.1
@@ -543,12 +558,15 @@ inline bool operator!=(std::string_view lhs, const ByteString& rhs) noexcept {
  * UA_XmlElement wrapper class.
  * @ingroup Wrapper
  */
-class XmlElement : public detail::StringWrapper<UA_XmlElement, UA_TYPES_XMLELEMENT, char> {
+class XmlElement
+    : public TypeWrapper<UA_String, UA_TYPES_STRING>,
+      public detail::StringLikeMixin<XmlElement, char> {
 public:
-    using StringWrapper::StringWrapper;  // inherit constructors
+    using StringLikeMixin ::StringLikeMixin;
+    using TypeWrapper::TypeWrapper;
 
     explicit XmlElement(std::string_view str)
-        : StringWrapper(detail::allocNativeString(str)) {}
+        : TypeWrapper(detail::allocNativeString(str)) {}
 
     /// Implicit conversion to std::string_view.
     operator std::string_view() const noexcept {  // NOLINT(hicpp-explicit-conversions)

--- a/tests/types_builtin.cpp
+++ b/tests/types_builtin.cpp
@@ -46,9 +46,7 @@ TEST_CASE("StatusCode") {
     }
 }
 
-using StringWrapper = detail::StringWrapper<UA_String, UA_TYPES_STRING, char>;
-
-TEST_CASE_TEMPLATE("StringWrapper constructors", T, StringWrapper, const StringWrapper) {
+TEST_CASE_TEMPLATE("StringLikeMixin constructors", T, String, const String) {
     SUBCASE("Default") {
         T str;
         CHECK(str.size() == 0);
@@ -79,7 +77,7 @@ TEST_CASE_TEMPLATE("StringWrapper constructors", T, StringWrapper, const StringW
     SUBCASE("From iterator pair (input iterator, single-pass)") {
         std::istringstream ss("abc");  // allows only single-pass reading
         std::istream_iterator<char> first(ss), last;
-        StringWrapper str(first, last);
+        T str(first, last);
         CHECK(str.size() == 3);
         CHECK(str.length() == 3);
         CHECK_FALSE(str.empty());
@@ -97,7 +95,7 @@ TEST_CASE_TEMPLATE("StringWrapper constructors", T, StringWrapper, const StringW
     }
 }
 
-TEST_CASE_TEMPLATE("StringWrapper element access", T, StringWrapper, const StringWrapper) {
+TEST_CASE_TEMPLATE("StringLikeMixin element access", T, String, const String) {
     T str{'a', 'b', 'c'};
 
     SUBCASE("operator[]") {
@@ -112,7 +110,7 @@ TEST_CASE_TEMPLATE("StringWrapper element access", T, StringWrapper, const Strin
     }
 }
 
-TEST_CASE_TEMPLATE("StringWrapper iterators", T, StringWrapper, const StringWrapper) {
+TEST_CASE_TEMPLATE("StringLikeMixin iterators", T, String, const String) {
     T str{'a', 'b', 'c'};
 
     SUBCASE("begin(), end() iterators") {


### PR DESCRIPTION
Replace inheritance from `StringWrapper` with CRTP mixin class `StringLikeMixin`.