### PR TITLE
feat!: remove get prefix of Subscription::getMonitoredItems

### DIFF
--- a/include/open62541pp/subscription.hpp
+++ b/include/open62541pp/subscription.hpp
@@ -63,7 +63,13 @@ public:
     }
 
     /// Get all local monitored items.
-    std::vector<MonitoredItem<Connection>> getMonitoredItems();
+    std::vector<MonitoredItem<Connection>> monitoredItems();
+
+    /// @deprecated Use monitoredItems() instead
+    [[deprecated("use monitoredItems() instead")]]
+    std::vector<MonitoredItem<Connection>> getMonitoredItems() {
+        return monitoredItems();
+    }
 
     /// Modify this subscription.
     /// @note Not implemented for Server.

--- a/src/subscription.cpp
+++ b/src/subscription.cpp
@@ -10,7 +10,7 @@
 namespace opcua {
 
 template <typename T>
-std::vector<MonitoredItem<T>> Subscription<T>::getMonitoredItems() {
+std::vector<MonitoredItem<T>> Subscription<T>::monitoredItems() {
     std::vector<MonitoredItem<T>> result;
     auto& monitoredItems = opcua::detail::getContext(connection()).monitoredItems;
     monitoredItems.eraseStale();
@@ -24,8 +24,8 @@ std::vector<MonitoredItem<T>> Subscription<T>::getMonitoredItems() {
 }
 
 // explicit template instantiation
-template std::vector<MonitoredItem<Client>> Subscription<Client>::getMonitoredItems();
-template std::vector<MonitoredItem<Server>> Subscription<Server>::getMonitoredItems();
+template std::vector<MonitoredItem<Client>> Subscription<Client>::monitoredItems();
+template std::vector<MonitoredItem<Server>> Subscription<Server>::monitoredItems();
 
 }  // namespace opcua
 

--- a/tests/subscription_monitoreditem.cpp
+++ b/tests/subscription_monitoreditem.cpp
@@ -32,7 +32,7 @@ TEST_CASE("Subscription & MonitoredItem (server)") {
 
     SUBCASE("Create & delete subscription") {
         auto sub = server.createSubscription();
-        CHECK(sub.getMonitoredItems().empty());
+        CHECK(sub.monitoredItems().empty());
 
         MonitoringParametersEx monitoringParameters{};
         monitoringParameters.samplingInterval = 0.0;  // = fastest practical
@@ -45,14 +45,14 @@ TEST_CASE("Subscription & MonitoredItem (server)") {
             monitoringParameters,
             [&](IntegerId, IntegerId, const DataValue&) { notificationCount++; }
         );
-        CHECK(sub.getMonitoredItems().size() == 1);
+        CHECK(sub.monitoredItems().size() == 1);
 
         std::this_thread::sleep_for(std::chrono::milliseconds(200));
         server.runIterate();
         CHECK(notificationCount > 0);
 
         mon.deleteMonitoredItem();
-        CHECK(sub.getMonitoredItems().empty());
+        CHECK(sub.monitoredItems().empty());
     }
 }
 
@@ -82,7 +82,7 @@ TEST_CASE("Subscription & MonitoredItem (client)") {
         CHECK(client.getSubscriptions().size() == 1);
         CHECK(client.getSubscriptions().at(0) == sub);
 
-        CHECK(sub.getMonitoredItems().empty());
+        CHECK(sub.monitoredItems().empty());
 
         sub.deleteSubscription();
         CHECK(client.getSubscriptions().empty());
@@ -114,8 +114,8 @@ TEST_CASE("Subscription & MonitoredItem (client)") {
             [&](IntegerId, IntegerId, const DataValue&) { notificationCount++; }
         );
 
-        CHECK(sub.getMonitoredItems().size() == 1);
-        CHECK(sub.getMonitoredItems().at(0) == mon);
+        CHECK(sub.monitoredItems().size() == 1);
+        CHECK(sub.monitoredItems().at(0) == mon);
 
         client.runIterate();
         CHECK(notificationCount == 0);
@@ -197,8 +197,8 @@ TEST_CASE("Subscription & MonitoredItem (client)") {
             }
         );
 
-        CHECK(sub.getMonitoredItems().size() == 1);
-        CHECK(sub.getMonitoredItems().at(0) == mon);
+        CHECK(sub.monitoredItems().size() == 1);
+        CHECK(sub.monitoredItems().at(0) == mon);
     }
 #endif
 }


### PR DESCRIPTION
Remove `get` prefix of `Subscription::getMonitoredItems()` -> `Subscription::monitoredItems()`.
See #459.