### PR TITLE
feat!: remove get prefix of Server::getSessions

### DIFF
--- a/include/open62541pp/server.hpp
+++ b/include/open62541pp/server.hpp
@@ -212,8 +212,14 @@ public:
     /// All data types provided are automatically considered for decoding of received messages.
     void setCustomDataTypes(Span<const DataType> dataTypes);
 
-    /// Get active server session.
-    std::vector<Session> getSessions();
+    /// Get active sessions.
+    std::vector<Session> sessions();
+
+    /// @deprecated Use sessions() instead
+    [[deprecated("use sessions() instead")]]
+    std::vector<Session> getSessions() {
+        return sessions();
+    }
 
     /// Get all defined namespaces.
     std::vector<std::string> getNamespaceArray();

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -309,12 +309,12 @@ void Server::setCustomDataTypes(Span<const DataType> dataTypes) {
     config()->customDataTypes = context().dataTypeArray.get();
 }
 
-std::vector<Session> Server::getSessions() {
-    std::vector<Session> sessions;
+std::vector<Session> Server::sessions() {
+    std::vector<Session> result;
     for (auto&& id : context().sessionRegistry.sessionIds) {
-        sessions.emplace_back(*this, id);
+        result.emplace_back(*this, id);
     }
-    return sessions;
+    return result;
 }
 
 std::vector<std::string> Server::getNamespaceArray() {

--- a/tests/session.cpp
+++ b/tests/session.cpp
@@ -19,16 +19,16 @@ TEST_CASE("Session") {
 
 #if UAPP_OPEN62541_VER_GE(1, 3)
     SUBCASE("Get active session") {
-        CHECK(server.getSessions().empty());
+        CHECK(server.sessions().empty());
         client.connect(localServerUrl);
-        CHECK(server.getSessions().size() == 1);
+        CHECK(server.sessions().size() == 1);
         client.disconnect();
-        CHECK(server.getSessions().empty());
+        CHECK(server.sessions().empty());
     }
 
     SUBCASE("Session attributes") {
         client.connect(localServerUrl);
-        auto session = server.getSessions().at(0);
+        auto session = server.sessions().at(0);
 
         const QualifiedName key(0, "testAttribute");
         CHECK_THROWS_WITH(session.getSessionAttribute(key), "BadNotFound");
@@ -39,7 +39,7 @@ TEST_CASE("Session") {
         CHECK(session.getSessionAttribute(key).getScalar<double>() == 11.11);
 
         // retry with newly created session object
-        CHECK(server.getSessions().at(0).getSessionAttribute(key).getScalar<double>() == 11.11);
+        CHECK(server.sessions().at(0).getSessionAttribute(key).getScalar<double>() == 11.11);
 
         // delete session attribute
         CHECK_NOTHROW(session.deleteSessionAttribute(key));
@@ -52,7 +52,7 @@ TEST_CASE("Session") {
         // false? bug in open62541?
 #ifndef UAPP_TSAN_ENABLED
         client.connect(localServerUrl);
-        auto session = server.getSessions().at(0);
+        auto session = server.sessions().at(0);
         CHECK_NOTHROW(session.close());
         CHECK_THROWS_WITH(session.close(), "BadSessionIdInvalid");
 #endif


### PR DESCRIPTION
Remove `get` prefix of `Server::getSessions()` -> `Server::sessions()`.
See #459.