### PR TITLE
feat!: remove get prefix of Client::getSubscriptions

### DIFF
--- a/include/open62541pp/client.hpp
+++ b/include/open62541pp/client.hpp
@@ -248,8 +248,15 @@ public:
 #ifdef UA_ENABLE_SUBSCRIPTIONS
     /// Create a subscription to monitor data changes and events.
     Subscription<Client> createSubscription(const SubscriptionParameters& parameters = {});
+
     /// Get all active subscriptions
-    std::vector<Subscription<Client>> getSubscriptions();
+    std::vector<Subscription<Client>> subscriptions();
+
+    /// @deprecated Use subscriptions() instead
+    [[deprecated("use subscriptions() instead")]]
+    std::vector<Subscription<Client>> getSubscriptions() {
+        return subscriptions();
+    }
 #endif
 
     /**

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -462,7 +462,7 @@ Subscription<Client> Client::createSubscription(const SubscriptionParameters& pa
     return {*this, response.subscriptionId()};
 }
 
-std::vector<Subscription<Client>> Client::getSubscriptions() {
+std::vector<Subscription<Client>> Client::subscriptions() {
     std::vector<Subscription<Client>> result;
     auto& subscriptions = context().subscriptions;
     subscriptions.eraseStale();

--- a/tests/subscription_monitoreditem.cpp
+++ b/tests/subscription_monitoreditem.cpp
@@ -73,19 +73,19 @@ TEST_CASE("Subscription & MonitoredItem (client)") {
     }
 
     SUBCASE("Create & delete subscription") {
-        CHECK(client.getSubscriptions().empty());
+        CHECK(client.subscriptions().empty());
 
         const SubscriptionParameters parameters{};
         auto sub = client.createSubscription(parameters);
         CAPTURE(sub.subscriptionId());
 
-        CHECK(client.getSubscriptions().size() == 1);
-        CHECK(client.getSubscriptions().at(0) == sub);
+        CHECK(client.subscriptions().size() == 1);
+        CHECK(client.subscriptions().at(0) == sub);
 
         CHECK(sub.monitoredItems().empty());
 
         sub.deleteSubscription();
-        CHECK(client.getSubscriptions().empty());
+        CHECK(client.subscriptions().empty());
         CHECK_THROWS_WITH(sub.deleteSubscription(), "BadSubscriptionIdInvalid");
     }
 


### PR DESCRIPTION
Remove `get` prefix of `Client::getSubscriptions()` -> `Client::subscriptions()`.
See #459.