### PR TITLE
feat!: remove get prefix of Client::getNamespaceArray, Server::getNamespaceArray

### DIFF
--- a/include/open62541pp/client.hpp
+++ b/include/open62541pp/client.hpp
@@ -243,7 +243,13 @@ public:
     bool isConnected() noexcept;
 
     /// Get all defined namespaces.
-    std::vector<std::string> getNamespaceArray();
+    std::vector<std::string> namespaceArray();
+
+    /// @deprecated Use namespaceArray() instead
+    [[deprecated("use namespaceArray() instead")]]
+    std::vector<std::string> getNamespaceArray() {
+        return namespaceArray();
+    }
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
     /// Create a subscription to monitor data changes and events.

--- a/include/open62541pp/server.hpp
+++ b/include/open62541pp/server.hpp
@@ -222,7 +222,14 @@ public:
     }
 
     /// Get all defined namespaces.
-    std::vector<std::string> getNamespaceArray();
+    std::vector<std::string> namespaceArray();
+
+    /// @deprecated Use namespaceArray() instead
+    [[deprecated("use namespaceArray() instead")]]
+    std::vector<std::string> getNamespaceArray() {
+        return namespaceArray();
+    }
+
     /// Register namespace. The new namespace index will be returned.
     [[nodiscard]] NamespaceIndex registerNamespace(std::string_view uri);
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -449,7 +449,7 @@ bool Client::isConnected() noexcept {
 #endif
 }
 
-std::vector<std::string> Client::getNamespaceArray() {
+std::vector<std::string> Client::namespaceArray() {
     return services::readValue(*this, {0, UA_NS0ID_SERVER_NAMESPACEARRAY})
         .value()
         .getArrayCopy<std::string>();

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -317,7 +317,7 @@ std::vector<Session> Server::sessions() {
     return result;
 }
 
-std::vector<std::string> Server::getNamespaceArray() {
+std::vector<std::string> Server::namespaceArray() {
     return services::readValue(*this, {0, UA_NS0ID_SERVER_NAMESPACEARRAY})
         .value()
         .getArrayCopy<std::string>();

--- a/tests/client.cpp
+++ b/tests/client.cpp
@@ -268,7 +268,7 @@ TEST_CASE("Client methods") {
     client.connect(localServerUrl);
 
     SUBCASE("getNamespaceArray") {
-        const auto namespaces = client.getNamespaceArray();
+        const auto namespaces = client.namespaceArray();
         CHECK(namespaces.size() == 2);
         CHECK(namespaces.at(0) == "http://opcfoundation.org/UA/");
         CHECK(namespaces.at(1) == "urn:open62541.server.application");

--- a/tests/server.cpp
+++ b/tests/server.cpp
@@ -144,7 +144,7 @@ TEST_CASE("Server methods") {
     Server server;
 
     SUBCASE("getNamespaceArray") {
-        const auto namespaces = server.getNamespaceArray();
+        const auto namespaces = server.namespaceArray();
         CHECK(namespaces.size() == 2);
         CHECK(namespaces.at(0) == "http://opcfoundation.org/UA/");
         CHECK(namespaces.at(1) == "urn:open62541.server.application");
@@ -152,10 +152,10 @@ TEST_CASE("Server methods") {
 
     SUBCASE("registerNamespace") {
         CHECK(server.registerNamespace("test1") == 2);
-        CHECK(server.getNamespaceArray().at(2) == "test1");
+        CHECK(server.namespaceArray().at(2) == "test1");
 
         CHECK(server.registerNamespace("test2") == 3);
-        CHECK(server.getNamespaceArray().at(3) == "test2");
+        CHECK(server.namespaceArray().at(3) == "test2");
     }
 }
 


### PR DESCRIPTION
Remove `get` prefix of `Client/Server::getNamespaceArray()` -> `Client/Server::namespaceArray()`.
See #459.