### PR TITLE
feat!: remove get prefix of MonitoredItem getters

### DIFF
--- a/examples/client_subscription.cpp
+++ b/examples/client_subscription.cpp
@@ -31,8 +31,8 @@ int main() {
                     << "Data change notification:\n"
                     << "- subscription id:   " << item.subscriptionId() << "\n"
                     << "- monitored item id: " << item.monitoredItemId() << "\n"
-                    << "- node id:           " << item.getNodeId().toString() << "\n"
-                    << "- attribute id:      " << static_cast<int>(item.getAttributeId()) << "\n";
+                    << "- node id:           " << item.nodeId().toString() << "\n"
+                    << "- attribute id:      " << static_cast<int>(item.attributeId()) << "\n";
 
                 const auto dt = dv.value().getScalarCopy<opcua::DateTime>();
                 std::cout << "Current server time (UTC): " << dt.format("%H:%M:%S") << std::endl;

--- a/examples/events/client_eventfilter.cpp
+++ b/examples/events/client_eventfilter.cpp
@@ -54,8 +54,8 @@ int main() {
                 << "Event notification:\n"
                 << "- subscription id:   " << item.subscriptionId() << "\n"
                 << "- monitored item id: " << item.monitoredItemId() << "\n"
-                << "- node id:           " << item.getNodeId().toString() << "\n"
-                << "- attribute id:      " << static_cast<int>(item.getAttributeId()) << "\n";
+                << "- node id:           " << item.nodeId().toString() << "\n"
+                << "- attribute id:      " << static_cast<int>(item.attributeId()) << "\n";
 
             const auto& time = eventFields[0].getScalar<opcua::DateTime>();
             const auto& severity = eventFields[1].getScalar<uint16_t>();

--- a/include/open62541pp/monitoreditem.hpp
+++ b/include/open62541pp/monitoreditem.hpp
@@ -58,10 +58,22 @@ public:
     }
 
     /// Get the monitored NodeId.
-    const NodeId& getNodeId();
+    const NodeId& nodeId();
+
+    /// @deprecated Use nodeId() instead
+    [[deprecated("use nodeId() instead")]]
+    const NodeId& getNodeId() {
+        return nodeId();
+    }
 
     /// Get the monitored AttributeId.
-    AttributeId getAttributeId();
+    AttributeId attributeId();
+
+    /// @deprecated Use attributeId() instead
+    [[deprecated("use attributeId() instead")]]
+    AttributeId getAttributeId() {
+        return attributeId();
+    }
 
     /// Modify this monitored item.
     /// @note Not implemented for Server.

--- a/src/monitoreditem.cpp
+++ b/src/monitoreditem.cpp
@@ -24,22 +24,22 @@ static auto& getMonitoredItemContext(
 }
 
 template <typename T>
-const NodeId& MonitoredItem<T>::getNodeId() {
+const NodeId& MonitoredItem<T>::nodeId() {
     return getMonitoredItemContext(connection(), subscriptionId(), monitoredItemId())
         .itemToMonitor.nodeId();
 }
 
 template <typename T>
-AttributeId MonitoredItem<T>::getAttributeId() {
+AttributeId MonitoredItem<T>::attributeId() {
     return getMonitoredItemContext(connection(), subscriptionId(), monitoredItemId())
         .itemToMonitor.attributeId();
 }
 
 // explicit template instantiations
-template const NodeId& MonitoredItem<Client>::getNodeId();
-template const NodeId& MonitoredItem<Server>::getNodeId();
-template AttributeId MonitoredItem<Client>::getAttributeId();
-template AttributeId MonitoredItem<Server>::getAttributeId();
+template const NodeId& MonitoredItem<Client>::nodeId();
+template const NodeId& MonitoredItem<Server>::nodeId();
+template AttributeId MonitoredItem<Client>::attributeId();
+template AttributeId MonitoredItem<Server>::attributeId();
 
 }  // namespace opcua
 


### PR DESCRIPTION
Remove `get` prefix of `MonitoredItem` getters:
- `MonitoredItem::getNodeId()` -> `MonitoredItem::nodeId()`
- `MonitoredItem::getAttributeId()` -> `MonitoredItem::attributeId()`

See #459.