### PR TITLE
feat: NumericRange as wrapper

### DIFF
--- a/include/open62541pp/detail/types_handling.hpp
+++ b/include/open62541pp/detail/types_handling.hpp
@@ -166,6 +166,13 @@ template <typename T>
 }
 
 template <typename T>
+[[nodiscard]] T* copyArray(const T* src, size_t size) {
+    T* dst = allocateArray<T>(size);
+    std::memcpy(dst, src, size * sizeof(T));
+    return dst;
+}
+
+template <typename T>
 [[nodiscard]] T* copyArray(const T* src, size_t size, const UA_DataType& type) {
     T* dst = allocateArray<T>(size, type);
     if constexpr (!isPointerFree<T>) {

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -86,30 +86,23 @@ std::ostream& operator<<(std::ostream& os, const XmlElement& xmlElement) {
 /* ---------------------------------------- NumericRange ---------------------------------------- */
 
 NumericRange::NumericRange(std::string_view encodedRange) {
-    const UA_String encodedRangeNative = detail::toNativeString(encodedRange);
-    UA_NumericRange native{};
+    const auto encodedRangeNative = detail::toNativeString(encodedRange);
 #if UAPP_OPEN62541_VER_GE(1, 1)
-    const auto status = UA_NumericRange_parse(&native, encodedRangeNative);
+    throwIfBad(UA_NumericRange_parse(handle(), encodedRangeNative));
 #else
-    const auto status = UA_NumericRange_parseFromString(&native, &encodedRangeNative);
+    throwIfBad(UA_NumericRange_parseFromString(handle(), &encodedRangeNative));
 #endif
-    dimensions_.assign(
-        native.dimensions,
-        native.dimensions + native.dimensionsSize  // NOLINT
-    );
-    UA_free(native.dimensions);  // NOLINT
-    throwIfBad(status);
 }
 
 std::string NumericRange::toString() const {
     std::ostringstream ss;
-    for (size_t i = 0; i < dimensions_.size(); ++i) {
-        const auto& dimension = dimensions_.at(i);
+    for (size_t i = 0; i < dimensions().size(); ++i) {
+        const auto& dimension = dimensions()[i];
         ss << dimension.min;
         if (dimension.min != dimension.max) {
             ss << ":" << dimension.max;
         }
-        if (i < dimensions_.size() - 1) {
+        if (i < dimensions().size() - 1) {
             ss << ",";
         }
     }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -96,17 +96,16 @@ NumericRange::NumericRange(std::string_view encodedRange) {
 
 std::string NumericRange::toString() const {
     std::ostringstream ss;
-    for (size_t i = 0; i < dimensions().size(); ++i) {
-        const auto& dimension = dimensions()[i];
+    for (const auto& dimension : dimensions()) {
         ss << dimension.min;
         if (dimension.min != dimension.max) {
-            ss << ":" << dimension.max;
+            ss << ':' << dimension.max;
         }
-        if (i < dimensions().size() - 1) {
-            ss << ",";
-        }
+        ss << ',';
     }
-    return ss.str();
+    auto str = ss.str();
+    str.pop_back();  // remove last comma
+    return str;
 }
 
 /* ------------------------------------------- NodeId ------------------------------------------- */


### PR DESCRIPTION
Implement `NumericRange` as `Wrapper<UA_NumericRange>` to be used with `asWrapper`/`asNative`.
Closes #479.