### PR TITLE
feat!: rename getNamespace -> namespaceOf

### DIFF
--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -598,7 +598,7 @@ template <typename T, typename = void>
 struct IsNodeIdEnum : std::false_type {};
 
 template <typename T>
-struct IsNodeIdEnum<T, std::void_t<decltype(getNamespace(std::declval<T>()))>> : std::true_type {};
+struct IsNodeIdEnum<T, std::void_t<decltype(namespaceOf(std::declval<T>()))>> : std::is_enum<T> {};
 }  // namespace detail
 
 /**
@@ -652,11 +652,11 @@ public:
     }
 
     /// Create NodeId from enum class with numeric identifiers like `opcua::ObjectId`.
-    /// The namespace is retrieved by calling e.g. `getNamespace(opcua::ObjectId)`.
+    /// The namespace is retrieved by calling e.g. `namespaceOf(opcua::ObjectId)`.
     /// Make sure to provide an overload for custom enum types.
     template <typename T, typename = std::enable_if_t<detail::IsNodeIdEnum<T>::value>>
     NodeId(T identifier) noexcept  // NOLINT(hicpp-explicit-conversions)
-        : NodeId(getNamespace(identifier).index, static_cast<uint32_t>(identifier)) {}
+        : NodeId(namespaceOf(identifier).index, static_cast<uint32_t>(identifier)) {}
 
     bool isNull() const noexcept {
         return UA_NodeId_isNull(handle());

--- a/include/open62541pp/ua/nodeids.hpp
+++ b/include/open62541pp/ua/nodeids.hpp
@@ -445,7 +445,7 @@ enum class DataTypeId : int32_t {
  * Get namespace of DataTypeId.
  * @ingroup NodeIds
  */
-constexpr Namespace getNamespace(DataTypeId /* unused */) noexcept {
+constexpr Namespace namespaceOf(DataTypeId /* unused */) noexcept {
     return {0, "http://opcfoundation.org/UA/"};
 }
 
@@ -507,7 +507,7 @@ enum class ReferenceTypeId : int32_t {
  * Get namespace of ReferenceTypeId.
  * @ingroup NodeIds
  */
-constexpr Namespace getNamespace(ReferenceTypeId /* unused */) noexcept {
+constexpr Namespace namespaceOf(ReferenceTypeId /* unused */) noexcept {
     return {0, "http://opcfoundation.org/UA/"};
 }
 
@@ -756,7 +756,7 @@ enum class ObjectTypeId : int32_t {
  * Get namespace of ObjectTypeId.
  * @ingroup NodeIds
  */
-constexpr Namespace getNamespace(ObjectTypeId /* unused */) noexcept {
+constexpr Namespace namespaceOf(ObjectTypeId /* unused */) noexcept {
     return {0, "http://opcfoundation.org/UA/"};
 }
 
@@ -831,7 +831,7 @@ enum class VariableTypeId : int32_t {
  * Get namespace of VariableTypeId.
  * @ingroup NodeIds
  */
-constexpr Namespace getNamespace(VariableTypeId /* unused */) noexcept {
+constexpr Namespace namespaceOf(VariableTypeId /* unused */) noexcept {
     return {0, "http://opcfoundation.org/UA/"};
 }
 
@@ -2216,7 +2216,7 @@ enum class ObjectId : int32_t {
  * Get namespace of ObjectId.
  * @ingroup NodeIds
  */
-constexpr Namespace getNamespace(ObjectId /* unused */) noexcept {
+constexpr Namespace namespaceOf(ObjectId /* unused */) noexcept {
     return {0, "http://opcfoundation.org/UA/"};
 }
 
@@ -13450,7 +13450,7 @@ enum class VariableId : int32_t {
  * Get namespace of VariableId.
  * @ingroup NodeIds
  */
-constexpr Namespace getNamespace(VariableId /* unused */) noexcept {
+constexpr Namespace namespaceOf(VariableId /* unused */) noexcept {
     return {0, "http://opcfoundation.org/UA/"};
 }
 
@@ -14636,7 +14636,7 @@ enum class MethodId : int32_t {
  * Get namespace of MethodId.
  * @ingroup NodeIds
  */
-constexpr Namespace getNamespace(MethodId /* unused */) noexcept {
+constexpr Namespace namespaceOf(MethodId /* unused */) noexcept {
     return {0, "http://opcfoundation.org/UA/"};
 }
 

--- a/tools/gen_nodeids.py
+++ b/tools/gen_nodeids.py
@@ -62,7 +62,7 @@ enum class {enum_name} : int32_t {{
  * Get namespace of {enum_name}.
  * @ingroup NodeIds
  */
-constexpr Namespace getNamespace({enum_name} /* unused */) noexcept {{
+constexpr Namespace namespaceOf({enum_name} /* unused */) noexcept {{
     return {{0, "http://opcfoundation.org/UA/"}};
 }}
 """.strip()


### PR DESCRIPTION
Rename `getNamespace` -> `namespaceOf` to remove `get` prefix.
See #459.

The function is used internally to retrieve the namespace index of a `enum class` of numeric node ids, e.g. `ObjectNodeId`. This shouldn't break existing code, still it's in the public API so we mark is as a breaking change.