### PR TITLE
feat: ClientConfig::setApplicationUri

### DIFF
--- a/include/open62541pp/client.hpp
+++ b/include/open62541pp/client.hpp
@@ -94,6 +94,9 @@ public:
 
     /// Set message security mode.
     void setSecurityMode(MessageSecurityMode mode) noexcept;
+
+    /// Set the application URI, e.g. `urn:open62541.client.application`.
+    void setApplicationUri(std::string_view uri);
 };
 
 /* ------------------------------------------- Client ------------------------------------------- */

--- a/include/open62541pp/client.hpp
+++ b/include/open62541pp/client.hpp
@@ -95,7 +95,8 @@ public:
     /// Set message security mode.
     void setSecurityMode(MessageSecurityMode mode) noexcept;
 
-    /// Set the application URI, e.g. `urn:open62541.client.application`.
+    /// Set the application URI to filter servers in the FindServers and GetEndpoints service.
+    /// If empty the applicationURI is not used to filter.
     void setApplicationUri(std::string_view uri);
 };
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -141,8 +141,10 @@ void ClientConfig::setSecurityMode(MessageSecurityMode mode) noexcept {
     native().securityMode = static_cast<UA_MessageSecurityMode>(mode);
 }
 
-void ClientConfig::setApplicationUri(std::string_view uri) {
+void ClientConfig::setApplicationUri([[maybe_unused]] std::string_view uri) {
+#if UAPP_OPEN62541_VER_GE(1, 3)
     asWrapper<String>(native().applicationUri) = String(uri);
+#endif
 }
 
 /* --------------------------------------- State callbacks -------------------------------------- */

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -141,6 +141,10 @@ void ClientConfig::setSecurityMode(MessageSecurityMode mode) noexcept {
     native().securityMode = static_cast<UA_MessageSecurityMode>(mode);
 }
 
+void ClientConfig::setApplicationUri(std::string_view uri) {
+    asWrapper<String>(native().applicationUri) = String(uri);
+}
+
 /* --------------------------------------- State callbacks -------------------------------------- */
 
 // State changes in open62541.

--- a/tests/client.cpp
+++ b/tests/client.cpp
@@ -47,6 +47,11 @@ TEST_CASE("ClientConfig") {
         config.setSecurityMode(MessageSecurityMode::Sign);
         CHECK(config->securityMode == UA_MESSAGESECURITYMODE_SIGN);
     }
+
+    SUBCASE("setApplicationUri") {
+        config.setApplicationUri("uri");
+        CHECK(detail::toString(config->applicationUri) == "uri");
+    }
 }
 
 TEST_CASE("Client discovery") {


### PR DESCRIPTION
Add missing function to set client's ApplicationURI.
See #484.