### PR TITLE
fix: thread-safe session registry

### DIFF
--- a/include/open62541pp/detail/contextmap.hpp
+++ b/include/open62541pp/detail/contextmap.hpp
@@ -96,7 +96,7 @@ public:
 
 private:
     [[nodiscard]] auto acquireLock() const {
-        return std::unique_lock(mutex_);
+        return std::scoped_lock(mutex_);
     }
 
     std::map<Key, std::unique_ptr<Item>> map_;

--- a/include/open62541pp/detail/server_context.hpp
+++ b/include/open62541pp/detail/server_context.hpp
@@ -31,6 +31,7 @@ struct SessionRegistry {
     decltype(UA_AccessControl::activateSession) activateSessionUser{nullptr};
     decltype(UA_AccessControl::closeSession) closeSessionUser{nullptr};
     std::set<NodeId> sessionIds;
+    std::mutex mutex;
 };
 
 /**

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -194,6 +194,7 @@ static UA_StatusCode activateSession(
         sessionContext
     );
     if (detail::isGood(status) && sessionId != nullptr) {
+        const std::scoped_lock lock(context->sessionRegistry.mutex);
         context->sessionRegistry.sessionIds.insert(asWrapper<NodeId>(*sessionId));
     }
     return status;
@@ -209,6 +210,7 @@ static void closeSession(
     // call user-defined function
     context->sessionRegistry.closeSessionUser(server, ac, sessionId, sessionContext);
     if (sessionId != nullptr) {
+        const std::scoped_lock lock(context->sessionRegistry.mutex);
         context->sessionRegistry.sessionIds.erase(asWrapper<NodeId>(*sessionId));
     }
 }
@@ -311,6 +313,7 @@ void Server::setCustomDataTypes(Span<const DataType> dataTypes) {
 
 std::vector<Session> Server::sessions() {
     std::vector<Session> result;
+    const std::scoped_lock lock(context().sessionRegistry.mutex);
     for (auto&& id : context().sessionRegistry.sessionIds) {
         result.emplace_back(*this, id);
     }


### PR DESCRIPTION
Protect session registry container with a mutex to avoid data races.