### PR TITLE
feat!: add Variant::to<T> to retrieve/convert scalar and array values

### DIFF
--- a/examples/client_subscription.cpp
+++ b/examples/client_subscription.cpp
@@ -34,7 +34,7 @@ int main() {
                     << "- node id:           " << item.nodeId().toString() << "\n"
                     << "- attribute id:      " << static_cast<int>(item.attributeId()) << "\n";
 
-                const auto dt = dv.value().scalarCopy<opcua::DateTime>();
+                const auto dt = dv.value().scalar<opcua::DateTime>();
                 std::cout << "Current server time (UTC): " << dt.format("%H:%M:%S") << std::endl;
             }
         );

--- a/examples/method/server_method.cpp
+++ b/examples/method/server_method.cpp
@@ -27,10 +27,13 @@ int main() {
         {1, 1001},
         "IncInt32ArrayValues",
         [](opcua::Span<const opcua::Variant> input, opcua::Span<opcua::Variant> output) {
-            auto array = input[0].arrayCopy<int32_t>();
-            const auto delta = input[1].scalarCopy<int32_t>();
-            std::for_each(array.begin(), array.end(), [&](auto& v) { v += delta; });
-            output[0].setArrayCopy(array);
+            auto values = input[0].array<int32_t>();
+            const auto delta = input[1].scalar<int32_t>();
+            std::vector<int32_t> incremented(values.size());
+            std::transform(values.begin(), values.end(), incremented.begin(), [&](auto& v) {
+                return v + delta;
+            });
+            output[0].setArrayCopy(incremented);
         },
         {
             opcua::Argument(

--- a/examples/method/server_method.cpp
+++ b/examples/method/server_method.cpp
@@ -27,10 +27,10 @@ int main() {
         {1, 1001},
         "IncInt32ArrayValues",
         [](opcua::Span<const opcua::Variant> input, opcua::Span<opcua::Variant> output) {
-            auto values = input[0].array<int32_t>();
+            const auto values = input[0].array<int32_t>();
             const auto delta = input[1].scalar<int32_t>();
             std::vector<int32_t> incremented(values.size());
-            std::transform(values.begin(), values.end(), incremented.begin(), [&](auto& v) {
+            std::transform(values.begin(), values.end(), incremented.begin(), [&](auto v) {
                 return v + delta;
             });
             output[0].setArrayCopy(incremented);

--- a/examples/server_datasource.cpp
+++ b/examples/server_datasource.cpp
@@ -36,7 +36,7 @@ int main() {
         return UA_STATUSCODE_GOOD;
     };
     dataSource.write = [&](const opcua::DataValue& dv, const opcua::NumericRange&) {
-        counter = dv.value().scalarCopy<int>();
+        counter = dv.value().scalar<int>();
         std::cout << "Write counter to data source: " << counter << "\n";
         return UA_STATUSCODE_GOOD;
     };

--- a/examples/typeconversion.cpp
+++ b/examples/typeconversion.cpp
@@ -39,13 +39,13 @@ int main() {
     // Write std::byte to variant
     variant.setScalarCopy(std::byte{11});
 
-    // Read std::byte from variant (conversion requires copy)
-    const auto value = variant.scalarCopy<std::byte>();
-    std::cout << "Byte value: " << std::to_integer<int>(value) << std::endl;
-
-    // Read UA_Byte from variant (zero copy possible)
+    // Read UA_Byte from variant (reference possible)
     const auto& valueNative = variant.scalar<UA_Byte>();
     std::cout << "Byte value: " << static_cast<int>(valueNative) << std::endl;
+
+    // Read std::byte from variant (copy and conversion required)
+    const auto value = variant.to<std::byte>();
+    std::cout << "Byte value: " << std::to_integer<int>(value) << std::endl;
 
     // Write array of bytes to variant
     std::array<std::byte, 3> array{};

--- a/include/open62541pp/bitmask.hpp
+++ b/include/open62541pp/bitmask.hpp
@@ -22,7 +22,7 @@ constexpr std::false_type isBitmaskEnum(T);
 /**
  * Trait to define an enum (class) as a bitmask and allow bitwise operations.
  *
- * @code{.cpp}
+ * @code
  * // define enum (class)
  * enum class Access {
  *     Read  = 1 << 0,
@@ -109,7 +109,7 @@ constexpr typename std::enable_if_t<IsBitmaskEnum<T>::value, T> operator^=(T& lh
  * Bitmask using (scoped) enums.
  * Zero-cost abstraction to specify bitmasks with enums/ints or enum classes.
  *
- * @code{.cpp}
+ * @code
  * // construct with scoped enums
  * Bitmask<NodeClass> mask = NodeClass::Variable | NodeClass::Object;
  * // construct with unscoped enums or ints

--- a/include/open62541pp/detail/iterator.hpp
+++ b/include/open62541pp/detail/iterator.hpp
@@ -1,0 +1,142 @@
+#pragma once
+
+#include <functional>  // invoke
+#include <iterator>
+#include <type_traits>
+#include <utility>  // move
+
+namespace opcua::detail {
+
+template <typename Iter, typename F>
+class TransformIterator {
+public:
+    using iterator_type = Iter;
+    using iterator_category = typename std::iterator_traits<Iter>::iterator_category;
+    using value_type =
+        typename std::invoke_result_t<F, typename std::iterator_traits<Iter>::value_type>;
+    using difference_type = typename std::iterator_traits<Iter>::difference_type;
+    using pointer = value_type*;
+    using reference = value_type&;
+
+    constexpr TransformIterator(Iter it, F func)
+        : it_(std::move(it)),
+          func_(std::move(func)) {}
+
+    constexpr const Iter& base() const& noexcept {
+        return it_;
+    }
+
+    constexpr Iter base() && {
+        return it_;
+    }
+
+    constexpr value_type operator*() const {
+        return std::invoke(func_, *it_);
+    }
+
+    constexpr value_type operator[](difference_type n) const {
+        return *(*this + n);
+    }
+
+    constexpr TransformIterator& operator++() {
+        ++it_;
+        return *this;
+    }
+
+    constexpr TransformIterator operator++(int) {  // NOLINT(cert-dcl21-cpp)
+        auto temp = *this;
+        ++(*this);
+        return temp;
+    }
+
+    constexpr TransformIterator operator+(difference_type n) const {
+        return {it_ + n, func_};
+    }
+
+    constexpr TransformIterator& operator+=(difference_type n) {
+        it_ += n;
+        return *this;
+    }
+
+    constexpr TransformIterator& operator--() {
+        --it_;
+        return *this;
+    }
+
+    constexpr TransformIterator operator--(int) {  // NOLINT(cert-dcl21-cpp)
+        auto temp = *this;
+        --(*this);
+        return temp;
+    }
+
+    constexpr TransformIterator operator-(difference_type n) const {
+        return {it_ - n, func_};
+    }
+
+    constexpr TransformIterator& operator-=(difference_type n) {
+        it_ -= n;
+        return *this;
+    }
+
+private:
+    Iter it_;
+    std::decay_t<F> func_;
+};
+
+template <typename Iter1, typename F1, typename Iter2, typename F2>
+constexpr auto operator==(
+    const TransformIterator<Iter1, F1>& lhs, const TransformIterator<Iter2, F2>& rhs
+) {
+    return lhs.base() == rhs.base();
+}
+
+template <typename Iter1, typename F1, typename Iter2, typename F2>
+constexpr auto operator!=(
+    const TransformIterator<Iter1, F1>& lhs, const TransformIterator<Iter2, F2>& rhs
+) {
+    return lhs.base() != rhs.base();
+}
+
+template <typename Iter1, typename F1, typename Iter2, typename F2>
+constexpr auto operator<(
+    const TransformIterator<Iter1, F1>& lhs, const TransformIterator<Iter2, F2>& rhs
+) {
+    return lhs.base() < rhs.base();
+}
+
+template <typename Iter1, typename F1, typename Iter2, typename F2>
+constexpr auto operator<=(
+    const TransformIterator<Iter1, F1>& lhs, const TransformIterator<Iter2, F2>& rhs
+) {
+    return lhs.base() <= rhs.base();
+}
+
+template <typename Iter1, typename F1, typename Iter2, typename F2>
+constexpr auto operator>(
+    const TransformIterator<Iter1, F1>& lhs, const TransformIterator<Iter2, F2>& rhs
+) {
+    return lhs.base() > rhs.base();
+}
+
+template <typename Iter1, typename F1, typename Iter2, typename F2>
+constexpr auto operator>=(
+    const TransformIterator<Iter1, F1>& lhs, const TransformIterator<Iter2, F2>& rhs
+) {
+    return lhs.base() >= rhs.base();
+}
+
+template <typename Iter, typename F>
+constexpr TransformIterator<Iter, F> operator+(
+    const TransformIterator<Iter, F>& it, typename TransformIterator<Iter, F>::difference_type n
+) {
+    return {it.base() + n, it.func_};
+}
+
+template <typename Iter1, typename F1, typename Iter2, typename F2>
+constexpr auto operator-(
+    const TransformIterator<Iter1, F1>& lhs, const TransformIterator<Iter2, F2>& rhs
+) {
+    return lhs.base() - rhs.base();
+}
+
+}  // namespace opcua::detail

--- a/include/open62541pp/node.hpp
+++ b/include/open62541pp/node.hpp
@@ -848,13 +848,13 @@ public:
     /// Read scalar value from variable node.
     template <typename T>
     T readValueScalar() {
-        return readValue().template scalarCopy<T>();
+        return readValue().template to<T>();
     }
 
     /// Read array value from variable node.
     template <typename T>
     std::vector<T> readValueArray() {
-        return readValue().template arrayCopy<T>();
+        return readValue().template to<std::vector<T>>();
     }
 
     /// @wrapper{services::readDataType}

--- a/include/open62541pp/services/detail/attribute_handler.hpp
+++ b/include/open62541pp/services/detail/attribute_handler.hpp
@@ -161,7 +161,7 @@ struct AttributeHandler<AttributeId::ArrayDimensions> {
         return getVariant(std::move(dv)).transform([](Variant&& var) {
             assert(var.isType<uint32_t>());
             assert(var.isArray());
-            return std::move(var).arrayCopy<uint32_t>();
+            return std::move(var).to<Type>();
         });
     }
 

--- a/include/open62541pp/span.hpp
+++ b/include/open62541pp/span.hpp
@@ -81,7 +81,7 @@ public:
      * Implicit constructor from an initializer list.
      *
      * Only safe to use if `std::initializer_list` itself outlives the Span:
-     * @code{.cpp}
+     * @code
      * void takeView(Span<const int> values);
      * // ok
      * takeView({1, 2, 3});

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -1089,14 +1089,14 @@ public:
 
     /// Create Variant from a value with a custom data type (copy).
     template <typename T>
-    Variant(T&& value, const UA_DataType& dataType) {
-        setValueCopy(std::forward<T>(value), dataType);
+    Variant(T&& value, const UA_DataType& type) {
+        setValueCopy(std::forward<T>(value), type);
     }
 
     /// Create Variant from a value with a custom data type (no copy).
     template <typename T>
-    Variant(ReferenceTag /*unused*/, T&& value, const UA_DataType& dataType) {
-        setValue(std::forward<T>(value), dataType);
+    Variant(ReferenceTag /*unused*/, T&& value, const UA_DataType& type) {
+        setValue(std::forward<T>(value), type);
     }
 
     /// Create Variant from a range of elements (copy required).
@@ -1107,8 +1107,8 @@ public:
 
     /// Create Variant from a range of elements with a custom data type (copy required).
     template <typename InputIt>
-    Variant(InputIt first, InputIt last, const UA_DataType& dataType) {
-        setValueCopy(first, last, dataType);
+    Variant(InputIt first, InputIt last, const UA_DataType& type) {
+        setValueCopy(first, last, type);
     }
 
     /// Create Variant from scalar value.
@@ -1125,11 +1125,11 @@ public:
     /// Create Variant from scalar value with custom data type.
     /// @tparam Policy Policy (@ref VariantPolicy) how to store the scalar inside the variant
     template <VariantPolicy Policy = VariantPolicy::Copy, typename T>
-    [[nodiscard]] static Variant fromScalar(T&& value, const UA_DataType& dataType) {
+    [[nodiscard]] static Variant fromScalar(T&& value, const UA_DataType& type) {
         if constexpr (Policy == VariantPolicy::Copy) {
-            return Variant{std::forward<T>(value), dataType};
+            return Variant{std::forward<T>(value), type};
         } else {
-            return Variant{reference, std::forward<T>(value), dataType};
+            return Variant{reference, std::forward<T>(value), type};
         }
     }
 
@@ -1147,11 +1147,11 @@ public:
     /// Create Variant from array with custom data type.
     /// @tparam Policy Policy (@ref VariantPolicy) how to store the array inside the variant
     template <VariantPolicy Policy = VariantPolicy::Copy, typename ArrayLike>
-    [[nodiscard]] static Variant fromArray(ArrayLike&& array, const UA_DataType& dataType) {
+    [[nodiscard]] static Variant fromArray(ArrayLike&& array, const UA_DataType& type) {
         if constexpr (Policy == VariantPolicy::Copy) {
-            return Variant{std::forward<ArrayLike>(array), dataType};
+            return Variant{std::forward<ArrayLike>(array), type};
         } else {
-            return Variant{reference, std::forward<ArrayLike>(array), dataType};
+            return Variant{reference, std::forward<ArrayLike>(array), type};
         }
     }
 
@@ -1165,10 +1165,8 @@ public:
     /// Create Variant from range of elements with custom data type (copy required).
     /// @tparam Policy Policy (@ref VariantPolicy) how to store the array inside the variant
     template <VariantPolicy Policy = VariantPolicy::Copy, typename InputIt>
-    [[nodiscard]] static Variant fromArray(
-        InputIt first, InputIt last, const UA_DataType& dataType
-    ) {
-        return Variant{first, last, dataType};
+    [[nodiscard]] static Variant fromArray(InputIt first, InputIt last, const UA_DataType& type) {
+        return Variant{first, last, type};
     }
 
     /// Check if the variant is empty.
@@ -1190,16 +1188,15 @@ public:
     }
 
     /// Check if the variant type is equal to the provided data type.
-    bool isType(const UA_DataType* dataType) const noexcept {
+    bool isType(const UA_DataType* type) const noexcept {
         return (
-            handle()->type != nullptr && dataType != nullptr &&
-            handle()->type->typeId == dataType->typeId
+            handle()->type != nullptr && type != nullptr && handle()->type->typeId == type->typeId
         );
     }
 
     /// Check if the variant type is equal to the provided data type.
-    bool isType(const UA_DataType& dataType) const noexcept {
-        return isType(&dataType);
+    bool isType(const UA_DataType& type) const noexcept {
+        return isType(&type);
     }
 
     /// Check if the variant type is equal to the provided data type node id.
@@ -1394,8 +1391,8 @@ public:
 
     /// Assign value with custom data type to variant (no copy).
     template <typename T>
-    void setValue(T&& value, const UA_DataType& dataType) {
-        setValueImpl(std::forward<T>(value), dataType);
+    void setValue(T&& value, const UA_DataType& type) {
+        setValueImpl(std::forward<T>(value), type);
     }
 
     /// Copy value to variant.
@@ -1406,8 +1403,8 @@ public:
 
     /// Copy value to variant with custom data type.
     template <typename T>
-    void setValueCopy(T&& value, const UA_DataType& dataType) {
-        setValueCopyImpl(std::forward<T>(value), dataType);
+    void setValueCopy(T&& value, const UA_DataType& type) {
+        setValueCopyImpl(std::forward<T>(value), type);
     }
 
     /// Copy range of elements as array to variant.
@@ -1418,8 +1415,8 @@ public:
 
     /// Copy range of elements with custom data type as array to variant.
     template <typename InputIt>
-    void setValueCopy(InputIt first, InputIt last, const UA_DataType& dataType) {
-        setArrayCopy(first, last, dataType);
+    void setValueCopy(InputIt first, InputIt last, const UA_DataType& type) {
+        setArrayCopy(first, last, type);
     }
 
     /// Assign scalar value to variant (no copy).
@@ -1431,8 +1428,8 @@ public:
 
     /// Assign scalar value to variant with custom data type (no copy).
     template <typename T>
-    void setScalar(T& value, const UA_DataType& dataType) noexcept {
-        setScalarImpl(&value, dataType, UA_VARIANT_DATA_NODELETE);
+    void setScalar(T& value, const UA_DataType& type) noexcept {
+        setScalarImpl(&value, type, UA_VARIANT_DATA_NODELETE);
     }
 
     /// Copy scalar value to variant.
@@ -1448,8 +1445,8 @@ public:
 
     /// Copy scalar value to variant with custom data type.
     template <typename T>
-    void setScalarCopy(const T& value, const UA_DataType& dataType) {
-        setScalarCopyImpl(value, dataType);
+    void setScalarCopy(const T& value, const UA_DataType& type) {
+        setScalarCopyImpl(value, type);
     }
 
     /**
@@ -1468,15 +1465,15 @@ public:
     /**
      * Assign array to variant with custom data type (no copy).
      * @copydetails setArray
-     * @param dataType Custom data type.
+     * @param type Custom data type.
      */
     template <typename ArrayLike>
-    void setArray(ArrayLike&& array, const UA_DataType& dataType) noexcept {
+    void setArray(ArrayLike&& array, const UA_DataType& type) noexcept {
         static_assert(!isTemporaryArray<decltype(array)>());
         setArrayImpl(
             std::data(std::forward<ArrayLike>(array)),
             std::size(std::forward<ArrayLike>(array)),
-            dataType,
+            type,
             UA_VARIANT_DATA_NODELETE
         );
     }
@@ -1494,11 +1491,11 @@ public:
     /**
      * Copy array to variant with custom data type.
      * @copydetails setArrayCopy
-     * @param dataType Custom data type.
+     * @param type Custom data type.
      */
     template <typename ArrayLike>
-    void setArrayCopy(const ArrayLike& array, const UA_DataType& dataType) {
-        setArrayCopy(array.begin(), array.end(), dataType);
+    void setArrayCopy(const ArrayLike& array, const UA_DataType& type) {
+        setArrayCopy(array.begin(), array.end(), type);
     }
 
     /**
@@ -1519,8 +1516,8 @@ public:
      * Copy range of elements as array to variant with custom data type.
      */
     template <typename InputIt>
-    void setArrayCopy(InputIt first, InputIt last, const UA_DataType& dataType) {
-        setArrayCopyImpl(first, last, dataType);
+    void setArrayCopy(InputIt first, InputIt last, const UA_DataType& type) {
+        setArrayCopyImpl(first, last, type);
     }
 
 private:
@@ -1595,18 +1592,18 @@ private:
 
     template <typename T>
     inline void setScalarImpl(
-        T* data, const UA_DataType& dataType, UA_VariantStorageType storageType
+        T* data, const UA_DataType& type, UA_VariantStorageType storageType
     ) noexcept;
     template <typename T>
     inline void setArrayImpl(
-        T* data, size_t arrayLength, const UA_DataType& dataType, UA_VariantStorageType storageType
+        T* data, size_t arrayLength, const UA_DataType& type, UA_VariantStorageType storageType
     ) noexcept;
     template <typename T>
-    inline void setScalarCopyImpl(const T& value, const UA_DataType& dataType);
+    inline void setScalarCopyImpl(const T& value, const UA_DataType& type);
     template <typename T>
     inline void setScalarCopyConvertImpl(const T& value);
     template <typename InputIt>
-    inline void setArrayCopyImpl(InputIt first, InputIt last, const UA_DataType& dataType);
+    inline void setArrayCopyImpl(InputIt first, InputIt last, const UA_DataType& type);
     template <typename InputIt>
     inline void setArrayCopyConvertImpl(InputIt first, InputIt last);
 
@@ -1653,67 +1650,67 @@ T Variant::toArrayImpl() const {
 
 template <typename T>
 void Variant::setScalarImpl(
-    T* data, const UA_DataType& dataType, UA_VariantStorageType storageType
+    T* data, const UA_DataType& type, UA_VariantStorageType storageType
 ) noexcept {
     assertNoVariant<T>();
-    assert(sizeof(T) == dataType.memSize);
+    assert(sizeof(T) == type.memSize);
     clear();
-    handle()->type = &dataType;
+    handle()->type = &type;
     handle()->storageType = storageType;
     handle()->data = data;
 }
 
 template <typename T>
 void Variant::setArrayImpl(
-    T* data, size_t arrayLength, const UA_DataType& dataType, UA_VariantStorageType storageType
+    T* data, size_t arrayLength, const UA_DataType& type, UA_VariantStorageType storageType
 ) noexcept {
     assertNoVariant<T>();
-    assert(sizeof(T) == dataType.memSize);
+    assert(sizeof(T) == type.memSize);
     clear();
-    handle()->type = &dataType;
+    handle()->type = &type;
     handle()->storageType = storageType;
     handle()->data = data;
     handle()->arrayLength = arrayLength;
 }
 
 template <typename T>
-void Variant::setScalarCopyImpl(const T& value, const UA_DataType& dataType) {
-    auto native = detail::allocateUniquePtr<T>(dataType);
-    *native = detail::copy(value, dataType);
-    setScalarImpl(native.release(), dataType, UA_VARIANT_DATA);  // move ownership
+void Variant::setScalarCopyImpl(const T& value, const UA_DataType& type) {
+    auto native = detail::allocateUniquePtr<T>(type);
+    *native = detail::copy(value, type);
+    setScalarImpl(native.release(), type, UA_VARIANT_DATA);  // move ownership
 }
 
 template <typename T>
 void Variant::setScalarCopyConvertImpl(const T& value) {
     using Native = typename TypeConverter<T>::NativeType;
-    const auto& dataType = opcua::getDataType<Native>();
-    auto native = detail::allocateUniquePtr<Native>(dataType);
+    const auto& type = opcua::getDataType<Native>();
+    auto native = detail::allocateUniquePtr<Native>(type);
     TypeConverter<T>::toNative(value, *native);
-    setScalarImpl(native.release(), dataType, UA_VARIANT_DATA);  // move ownership
+    setScalarImpl(native.release(), type, UA_VARIANT_DATA);  // move ownership
 }
 
 template <typename InputIt>
-void Variant::setArrayCopyImpl(InputIt first, InputIt last, const UA_DataType& dataType) {
+void Variant::setArrayCopyImpl(InputIt first, InputIt last, const UA_DataType& type) {
     using ValueType = typename std::iterator_traits<InputIt>::value_type;
     const size_t size = std::distance(first, last);
-    auto native = detail::allocateArrayUniquePtr<ValueType>(size, dataType);
+    auto native = detail::allocateArrayUniquePtr<ValueType>(size, type);
     std::transform(first, last, native.get(), [&](const ValueType& value) {
-        return detail::copy(value, dataType);
+        return detail::copy(value, type);
     });
-    setArrayImpl(native.release(), size, dataType, UA_VARIANT_DATA);  // move ownership
+    setArrayImpl(native.release(), size, type, UA_VARIANT_DATA);  // move ownership
 }
 
 template <typename InputIt>
 void Variant::setArrayCopyConvertImpl(InputIt first, InputIt last) {
     using ValueType = typename std::iterator_traits<InputIt>::value_type;
     using Native = typename TypeConverter<ValueType>::NativeType;
-    const auto& dataType = opcua::getDataType<Native>();
+    const auto& type = opcua::getDataType<Native>();
     const size_t size = std::distance(first, last);
-    auto native = detail::allocateArrayUniquePtr<Native>(size, dataType);
+    auto native = detail::allocateArrayUniquePtr<Native>(size, type);
     for (size_t i = 0; i < size; ++i) {
         TypeConverter<ValueType>::toNative(*first++, native.get()[i]);  // NOLINT
     }
-    setArrayImpl(native.release(), size, dataType, UA_VARIANT_DATA);  // move ownership
+    setArrayImpl(native.release(), size, type, UA_VARIANT_DATA);  // move ownership
 }
 
 template <typename T, typename... Args>

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -1381,7 +1381,7 @@ public:
         } else {
             return toScalarImpl<T>();
         }
-    };
+    }
 
     /// Assign value to variant (no copy).
     template <typename T>

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -1580,14 +1580,14 @@ private:
     }
 
     template <typename ArrayLike>
-    static constexpr bool isTemporaryArray() noexcept {
+    static constexpr bool isTemporaryArray() {
         constexpr bool isTemporary = std::is_rvalue_reference_v<ArrayLike>;
         constexpr bool isView = detail::IsSpan<std::remove_reference_t<ArrayLike>>::value;
         return isTemporary && !isView;
     }
 
     template <typename T>
-    static constexpr void assertIsRegistered() noexcept {
+    static constexpr void assertIsRegistered() {
         static_assert(
             detail::isRegisteredType<T>,
             "Template type must be a native/wrapper type to assign or get scalar/array without copy"
@@ -1595,7 +1595,7 @@ private:
     }
 
     template <typename T>
-    static constexpr void assertIsRegisteredOrConvertible() noexcept {
+    static constexpr void assertIsRegisteredOrConvertible() {
         static_assert(
             detail::isRegisteredOrConvertible<T>,
             "Template type must be either a native/wrapper type (copyable) or a convertible type. "
@@ -1606,7 +1606,7 @@ private:
     }
 
     template <typename T>
-    static constexpr void assertNoVariant() noexcept {
+    static constexpr void assertNoVariant() {
         static_assert(
             !std::is_same_v<T, Variant> && !std::is_same_v<T, UA_Variant>,
             "Variants cannot directly contain another variant"
@@ -1634,9 +1634,9 @@ private:
     }
 
     template <typename T>
-    inline T toScalarImpl() const;
+    T toScalarImpl() const;
     template <typename T>
-    inline T toArrayImpl() const;
+    T toArrayImpl() const;
 
     template <typename T>
     inline void setScalarImpl(
@@ -1655,9 +1655,10 @@ private:
     template <typename InputIt>
     inline void setArrayCopyConvertImpl(InputIt first, InputIt last);
     template <typename T, typename... Args>
-    inline void setValueImpl(T&& value, Args&&... args);
+
+    void setValueImpl(T&& value, Args&&... args);
     template <typename T, typename... Args>
-    inline void setValueCopyImpl(T&& value, Args&&... args);
+    void setValueCopyImpl(T&& value, Args&&... args);
 };
 
 template <typename T>

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -1221,6 +1221,28 @@ public:
         return type();
     }
 
+    /// Get array length or 0 if variant is not an array.
+    size_t arrayLength() const noexcept {
+        return handle()->arrayLength;
+    }
+
+    /// @deprecated Use arrayLength() instead
+    [[deprecated("use arrayLength() instead")]]
+    size_t getArrayLength() const noexcept {
+        return arrayLength();
+    }
+
+    /// Get array dimensions.
+    Span<const uint32_t> arrayDimensions() const noexcept {
+        return {handle()->arrayDimensions, handle()->arrayDimensionsSize};
+    }
+
+    /// @deprecated Use arrayDimensions() instead
+    [[deprecated("use arrayDimensions() instead")]]
+    Span<const uint32_t> getArrayDimensions() const noexcept {
+        return arrayDimensions();
+    }
+
     /// Get pointer to the underlying data.
     /// Check the properties and data type before casting it to the actual type.
     /// Use the methods @ref isScalar, @ref isArray, @ref isType / @ref type.
@@ -1283,28 +1305,6 @@ public:
     [[deprecated("use to<T>() instead")]]
     T getScalarCopy() const {
         return to<T>();
-    }
-
-    /// Get array length or 0 if variant is not an array.
-    size_t arrayLength() const noexcept {
-        return handle()->arrayLength;
-    }
-
-    /// @deprecated Use arrayLength() instead
-    [[deprecated("use arrayLength() instead")]]
-    size_t getArrayLength() const noexcept {
-        return arrayLength();
-    }
-
-    /// Get array dimensions.
-    Span<const uint32_t> arrayDimensions() const noexcept {
-        return {handle()->arrayDimensions, handle()->arrayDimensionsSize};
-    }
-
-    /// @deprecated Use arrayDimensions() instead
-    [[deprecated("use arrayDimensions() instead")]]
-    Span<const uint32_t> getArrayDimensions() const noexcept {
-        return arrayDimensions();
     }
 
     /// Get reference to array with given template type (only native or wrapper types).

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -310,13 +310,13 @@ std::ostream& operator<<(std::ostream& os, const String& str);
 template <>
 struct TypeConverter<std::string_view> {
     using ValueType = std::string_view;
-    using Native = String;
+    using NativeType = String;
 
-    static void fromNative(const Native& src, std::string_view& dst) {
+    static void fromNative(const NativeType& src, std::string_view& dst) {
         dst = static_cast<std::string_view>(src);
     }
 
-    static void toNative(std::string_view src, Native& dst) {
+    static void toNative(std::string_view src, NativeType& dst) {
         dst = String(src);
     }
 };
@@ -324,13 +324,13 @@ struct TypeConverter<std::string_view> {
 template <>
 struct TypeConverter<std::string> {
     using ValueType = std::string;
-    using Native = String;
+    using NativeType = String;
 
-    static void fromNative(const Native& src, ValueType& dst) {
+    static void fromNative(const NativeType& src, ValueType& dst) {
         dst = std::string(src);
     }
 
-    static void toNative(const ValueType& src, Native& dst) {
+    static void toNative(const ValueType& src, NativeType& dst) {
         dst = String(src);
     }
 };
@@ -338,9 +338,9 @@ struct TypeConverter<std::string> {
 template <>
 struct TypeConverter<const char*> {
     using ValueType = const char*;
-    using Native = String;
+    using NativeType =String;
 
-    static void toNative(const char* src, Native& dst) {
+    static void toNative(const char* src, NativeType& dst) {
         dst = String(src);
     }
 };
@@ -348,9 +348,9 @@ struct TypeConverter<const char*> {
 template <size_t N>
 struct TypeConverter<char[N]> {  // NOLINT
     using ValueType = char[N];  // NOLINT
-    using Native = String;
+    using NativeType =String;
 
-    static void toNative(const ValueType& src, Native& dst) {
+    static void toNative(const ValueType& src, NativeType& dst) {
         dst = String({static_cast<const char*>(src), N});
     }
 };
@@ -438,13 +438,13 @@ public:
 template <typename Clock, typename Duration>
 struct TypeConverter<std::chrono::time_point<Clock, Duration>> {
     using ValueType = std::chrono::time_point<Clock, Duration>;
-    using Native = DateTime;
+    using NativeType =DateTime;
 
-    static void fromNative(const Native& src, ValueType& dst) {
+    static void fromNative(const NativeType& src, ValueType& dst) {
         dst = src.toTimePoint<Clock, Duration>();
     }
 
-    static void toNative(const ValueType& src, Native& dst) {
+    static void toNative(const ValueType& src, NativeType& dst) {
         dst = DateTime::fromTimePoint(src);
     }
 };
@@ -1619,7 +1619,7 @@ T Variant::toScalarImpl() const {
     if constexpr (detail::isRegisteredType<T>) {
         return scalar<T>();
     } else {
-        using Native = typename TypeConverter<T>::Native;
+        using Native = typename TypeConverter<T>::NativeType;
         T result{};
         TypeConverter<T>::fromNative(scalar<Native>(), result);
         return result;
@@ -1634,7 +1634,7 @@ T Variant::toArrayImpl() const {
         auto native = array<ValueType>();
         return T(native.begin(), native.end());
     } else {
-        using Native = typename TypeConverter<ValueType>::Native;
+        using Native = typename TypeConverter<ValueType>::NativeType;
         const auto transform = [](const Native& native) {
             ValueType result{};
             TypeConverter<ValueType>::fromNative(native, result);
@@ -1682,7 +1682,7 @@ void Variant::setScalarCopyImpl(const T& value, const UA_DataType& type) {
 
 template <typename T>
 void Variant::setScalarCopyConvertImpl(const T& value) {
-    using Native = typename TypeConverter<T>::Native;
+    using Native = typename TypeConverter<T>::NativeType;
     const auto& type = opcua::getDataType<Native>();
     auto native = detail::allocateUniquePtr<Native>(type);
     TypeConverter<T>::toNative(value, *native);
@@ -1703,7 +1703,7 @@ void Variant::setArrayCopyImpl(InputIt first, InputIt last, const UA_DataType& t
 template <typename InputIt>
 void Variant::setArrayCopyConvertImpl(InputIt first, InputIt last) {
     using ValueType = typename std::iterator_traits<InputIt>::value_type;
-    using Native = typename TypeConverter<ValueType>::Native;
+    using Native = typename TypeConverter<ValueType>::NativeType;
     const auto& type = opcua::getDataType<Native>();
     const size_t size = std::distance(first, last);
     auto native = detail::allocateArrayUniquePtr<Native>(size, type);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -452,7 +452,7 @@ bool Client::isConnected() noexcept {
 std::vector<std::string> Client::namespaceArray() {
     return services::readValue(*this, {0, UA_NS0ID_SERVER_NAMESPACEARRAY})
         .value()
-        .arrayCopy<std::string>();
+        .to<std::vector<std::string>>();
 }
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -323,7 +323,7 @@ std::vector<Session> Server::sessions() {
 std::vector<std::string> Server::namespaceArray() {
     return services::readValue(*this, {0, UA_NS0ID_SERVER_NAMESPACEARRAY})
         .value()
-        .arrayCopy<std::string>();
+        .to<std::vector<std::string>>();
 }
 
 NamespaceIndex Server::registerNamespace(std::string_view uri) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(
     event.cpp
     exception.cpp
     exceptioncatcher.cpp
+    iterator.cpp
     node.cpp
     plugin_accesscontrol.cpp
     plugin_create_certificate.cpp

--- a/tests/iterator.cpp
+++ b/tests/iterator.cpp
@@ -1,0 +1,105 @@
+#include <doctest/doctest.h>
+#include <list>
+#include <vector>
+
+#include "open62541pp/detail/iterator.hpp"
+
+using namespace opcua;
+
+TEST_CASE("TransformIterator") {
+    std::vector<int> vec{1, 2, 3};
+    const auto square = [](auto value) { return value * value; };
+
+    auto first = detail::TransformIterator(vec.begin(), square);
+    auto last = detail::TransformIterator(vec.end() - 1, square);
+
+    CHECK(std::is_same_v<
+          std::iterator_traits<decltype(first)>::iterator_category,
+          std::random_access_iterator_tag>);
+
+    SUBCASE("base") {
+        CHECK(first.base() == vec.begin());
+        CHECK(detail::TransformIterator(vec.begin(), square).base() == vec.begin());
+    }
+
+    SUBCASE("operator*") {
+        CHECK(*first == 1);
+        CHECK(*last == 9);
+    }
+
+    SUBCASE("operator[]") {
+        CHECK(first[0] == 1);
+        CHECK(first[1] == 4);
+        CHECK(first[2] == 9);
+    }
+
+    SUBCASE("Increment") {
+        auto it = first;
+        SUBCASE("Pre") {
+            ++it;
+        }
+        SUBCASE("Post") {
+            it++;
+        }
+        SUBCASE("Add 1") {
+            it += 1;
+        }
+        CHECK(it.base() == (first.base() + 1));
+    }
+
+    SUBCASE("Decrement") {
+        auto it = last;
+        SUBCASE("Pre") {
+            --it;
+        }
+        SUBCASE("Post") {
+            it--;
+        }
+        SUBCASE("Add 1") {
+            it -= 1;
+        }
+        CHECK(it.base() == (last.base() - 1));
+    }
+
+    SUBCASE("Comparison") {
+        CHECK(first == first);
+        CHECK_FALSE(first == last);
+
+        CHECK_FALSE(first != first);
+        CHECK(first != last);
+
+        CHECK(first < last);
+        CHECK_FALSE(first < first);
+        CHECK_FALSE(last < first);
+
+        CHECK(first <= last);
+        CHECK(first <= first);
+        CHECK_FALSE(last <= first);
+
+        CHECK(last > first);
+        CHECK_FALSE(last > last);
+        CHECK_FALSE(first > last);
+
+        CHECK(last >= first);
+        CHECK(last >= last);
+        CHECK_FALSE(first >= last);
+    }
+
+    SUBCASE("Distance") {
+        CHECK(last - first == 2);
+    }
+}
+
+TEST_CASE("TransformIterator list -> vector") {
+    const std::list<int> lst{1, 2, 3};
+    const auto square = [](auto value) { return value * value; };
+    const std::vector vec(
+        detail::TransformIterator(lst.begin(), square),
+        detail::TransformIterator(lst.end(), square)
+    );
+
+    CHECK(vec.size() == 3);
+    CHECK(vec[0] == 1);
+    CHECK(vec[1] == 4);
+    CHECK(vec[2] == 9);
+}

--- a/tests/server.cpp
+++ b/tests/server.cpp
@@ -213,7 +213,7 @@ TEST_CASE("DataSource") {
         return UA_STATUSCODE_GOOD;
     };
     dataSource.write = [&](const DataValue& dv, const NumericRange&) {
-        data = dv.value().scalarCopy<int>();
+        data = dv.value().scalar<int>();
         return UA_STATUSCODE_GOOD;
     };
 

--- a/tests/services_method.cpp
+++ b/tests/services_method.cpp
@@ -27,8 +27,8 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
             if (throwException) {
                 throw BadStatus(UA_STATUSCODE_BADUNEXPECTEDERROR);
             }
-            const auto a = inputs[0].scalarCopy<int32_t>();
-            const auto b = inputs[1].scalarCopy<int32_t>();
+            const auto a = inputs[0].scalar<int32_t>();
+            const auto b = inputs[1].scalar<int32_t>();
             outputs[0].setScalarCopy(a + b);
         },
         {
@@ -64,7 +64,7 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
         );
         CHECK(result.statusCode().isGood());
         CHECK(result.outputArguments().size() == 1);
-        CHECK(result.outputArguments()[0].scalarCopy<int32_t>() == 3);
+        CHECK(result.outputArguments()[0].scalar<int32_t>() == 3);
     }
 
     SUBCASE("Propagate exception") {


### PR DESCRIPTION
As discussed in #491.

`Variant::to<T>` replaces the copy getters:
- `Variant::getScalarCopy<T>()` -> `Variant::to<T>()`
- `Variant::getArrayCopy<T>()` -> `Variant::to<std::vector<T>>()`

### Example

```cpp
opcua::Variant varScalar("test123");
auto str = varScalar.to<std::string>();

std::vector<int> array{1, 2, 3};
opcua::Variant varArray(array);
auto lst = varArray.to<std::list<int>>();
auto vec = varArray.to<std::vector<int>>();
```