### PR TITLE
feat!: remove Variant::setValueCopy overload with iterator pair

### DIFF
--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -1153,13 +1153,13 @@ public:
     /// Create Variant from a range of elements (copy required).
     template <typename InputIt>
     Variant(InputIt first, InputIt last) {
-        setValueCopy(first, last);
+        setArrayCopy(first, last);
     }
 
     /// Create Variant from a range of elements with a custom data type (copy required).
     template <typename InputIt>
     Variant(InputIt first, InputIt last, const UA_DataType& type) {
-        setValueCopy(first, last, type);
+        setArrayCopy(first, last, type);
     }
 
     /// Create Variant from scalar value.
@@ -1455,18 +1455,6 @@ public:
         setValueCopyImpl(std::forward<T>(value), type);
     }
 
-    /// Copy range of elements as array to variant.
-    template <typename InputIt>
-    void setValueCopy(InputIt first, InputIt last) {
-        setArrayCopy(first, last);
-    }
-
-    /// Copy range of elements with custom data type as array to variant.
-    template <typename InputIt>
-    void setValueCopy(InputIt first, InputIt last, const UA_DataType& type) {
-        setArrayCopy(first, last, type);
-    }
-
     /// Assign scalar value to variant (no copy).
     template <typename T>
     void setScalar(T& value) noexcept {
@@ -1667,7 +1655,7 @@ private:
     template <typename T, typename... Args>
     void setValueCopyImpl(T&& value, Args&&... args) {
         if constexpr (isArrayType<std::remove_reference_t<T>>()) {
-            setArrayCopy(value.begin(), value.end(), std::forward<Args>(args)...);
+            setArrayCopy(std::forward<T>(value), std::forward<Args>(args)...);
         } else {
             setScalarCopy(std::forward<T>(value), std::forward<Args>(args)...);
         }

--- a/tests/types_builtin.cpp
+++ b/tests/types_builtin.cpp
@@ -712,6 +712,9 @@ TEST_CASE("Variant") {
         SUBCASE("setArrayCopy") {
             var.setArrayCopy(array);
         }
+        SUBCASE("setArrayCopy (iterator pair)") {
+            var.setArrayCopy(array.begin(), array.end());
+        }
         SUBCASE("setValueCopy") {
             var.setValueCopy(array);
         }
@@ -748,9 +751,6 @@ TEST_CASE("Variant") {
         }
         SUBCASE("setValueCopy") {
             var.setValueCopy(array);
-        }
-        SUBCASE("setValueCopy (iterator pair)") {
-            var.setValueCopy(array.begin(), array.end());
         }
 
         CHECK(var.arrayLength() == array.size());
@@ -811,6 +811,9 @@ TEST_CASE("Variant") {
         SUBCASE("Array (copy)") {
             SUBCASE("setArrayCopy") {
                 var.setArrayCopy(array, type);
+            }
+            SUBCASE("setArrayCopy (iterator pair)") {
+                var.setArrayCopy(array.begin(), array.end(), type);
             }
             SUBCASE("setValueCopy") {
                 var.setValueCopy(array, type);


### PR DESCRIPTION
Use `Variant::setArrayCopy` instead.

`Variant::setValue*` is mainly used as a universal setter interface. The type category scalar/array is determined by the template type. If a iterator pair is passed, it's clearly an array type. In this case, the user should just the `Variant::setArrayCopy` member function.