### PR TITLE
feat!: deprecate fromScalar/fromArray in favor of Variant's new universal constructor

### DIFF
--- a/examples/method/client_method.cpp
+++ b/examples/method/client_method.cpp
@@ -14,8 +14,6 @@ int main() {
     const opcua::Node greetMethodNode = objectsNode.browseChild({{1, "Greet"}});
 
     // Call method from parent node (Objects)
-    const auto result = objectsNode.callMethod(
-        greetMethodNode.id(), {opcua::Variant::fromScalar("World")}
-    );
+    const auto result = objectsNode.callMethod(greetMethodNode.id(), {opcua::Variant("World")});
     std::cout << result.outputArguments()[0].scalar<opcua::String>() << std::endl;
 }

--- a/examples/method/client_method_async.cpp
+++ b/examples/method/client_method_async.cpp
@@ -20,7 +20,7 @@ int main() {
     // Asynchronously call method (future variant - default)
     {
         auto future = objectsNode.callMethodAsync(
-            greetMethodNode.id(), {opcua::Variant::fromScalar("Future World")}, opcua::useFuture
+            greetMethodNode.id(), {opcua::Variant("Future World")}, opcua::useFuture
         );
         std::cout << "Waiting for asynchronous operation to complete\n";
         future.wait();
@@ -35,7 +35,7 @@ int main() {
     {
         objectsNode.callMethodAsync(
             greetMethodNode.id(),
-            {opcua::Variant::fromScalar("Callback World")},
+            {opcua::Variant("Callback World")},
             [](opcua::CallMethodResult& result) {
                 std::cout << "Callback with status code: " << result.statusCode() << std::endl;
                 std::cout << result.outputArguments()[0].scalar<opcua::String>() << std::endl;

--- a/examples/server_accesscontrol.cpp
+++ b/examples/server_accesscontrol.cpp
@@ -26,7 +26,7 @@ public:
         const auto* token = userIdentityToken.decodedData<UserNameIdentityToken>();
         const bool isAdmin = (token != nullptr && token->userName() == "admin");
         std::cout << "User has admin rights: " << isAdmin << std::endl;
-        session.setSessionAttribute({0, "isAdmin"}, Variant::fromScalar(isAdmin));
+        session.setSessionAttribute({0, "isAdmin"}, Variant(isAdmin));
 
         return AccessControlDefault::activateSession(
             session, endpointDescription, secureChannelRemoteCertificate, userIdentityToken

--- a/include/open62541pp/node.hpp
+++ b/include/open62541pp/node.hpp
@@ -1167,10 +1167,10 @@ public:
     template <typename T>
     Node& writeValueScalar(const T& value) {
         if constexpr (detail::isRegisteredType<T>) {
-            // NOLINTNEXTLINE(*-const-cast), variant isn't modified, try to avoid copy
-            writeValue(Variant::fromScalar<VariantPolicy::Reference>(const_cast<T&>(value)));
+            // NOLINTNEXTLINE(*-const-cast), variant isn't modified, avoid copy
+            writeValue(Variant(reference, const_cast<T&>(value)));
         } else {
-            writeValue(Variant::fromScalar<VariantPolicy::Copy>(value));
+            writeValue(Variant(value));
         }
 
         return *this;
@@ -1179,15 +1179,19 @@ public:
     /// Write array value to variable node.
     template <typename ArrayLike>
     Node& writeValueArray(const ArrayLike& array) {
-        // NOLINTNEXTLINE(*-const-cast), variant isn't modified, try to avoid copy
-        writeValue(Variant::fromArray<VariantPolicy::Reference>(const_cast<ArrayLike&>(array)));
+        if constexpr (detail::isRegisteredType<typename ArrayLike::value_type>) {
+            // NOLINTNEXTLINE(*-const-cast), variant isn't modified, avoid copy
+            writeValue(Variant(reference, const_cast<ArrayLike&>(array)));
+        } else {
+            writeValue(Variant(array));
+        }
         return *this;
     }
 
     /// Write range of elements as array value to variable node.
     template <typename InputIt>
     Node& writeValueArray(InputIt first, InputIt last) {
-        writeValue(Variant::fromArray<VariantPolicy::Copy>(first, last));
+        writeValue(Variant(first, last));
         return *this;
     }
 

--- a/include/open62541pp/services/detail/attribute_handler.hpp
+++ b/include/open62541pp/services/detail/attribute_handler.hpp
@@ -60,7 +60,7 @@ struct AttributeHandlerScalar {
 
     template <typename U>
     static DataValue toDataValue(U&& value) {
-        return DataValue::fromScalar(std::forward<U>(value));
+        return DataValue(Variant(std::forward<U>(value)));
     }
 };
 
@@ -166,7 +166,7 @@ struct AttributeHandler<AttributeId::ArrayDimensions> {
     }
 
     static DataValue toDataValue(Span<const uint32_t> dimensions) {
-        return DataValue::fromArray(dimensions);
+        return DataValue(Variant(dimensions));
     }
 };
 

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -1164,60 +1164,37 @@ public:
 
     /// Create Variant from scalar value.
     /// @tparam Policy Policy (@ref VariantPolicy) how to store the scalar inside the variant
-    template <VariantPolicy Policy = VariantPolicy::Copy, typename T>
-    [[nodiscard]] static Variant fromScalar(T&& value) {
+    /// @deprecated Use new unified Variant constructor instead
+    template <VariantPolicy Policy = VariantPolicy::Copy, typename... Args>
+    [[deprecated("use new unified Variant constructor instead")]]
+    [[nodiscard]] static Variant fromScalar(Args&&... args) {
         if constexpr (Policy == VariantPolicy::Copy) {
-            return Variant{std::forward<T>(value)};
+            return Variant{std::forward<Args>(args)...};
         } else {
-            return Variant{reference, std::forward<T>(value)};
-        }
-    }
-
-    /// Create Variant from scalar value with custom data type.
-    /// @tparam Policy Policy (@ref VariantPolicy) how to store the scalar inside the variant
-    template <VariantPolicy Policy = VariantPolicy::Copy, typename T>
-    [[nodiscard]] static Variant fromScalar(T&& value, const UA_DataType& type) {
-        if constexpr (Policy == VariantPolicy::Copy) {
-            return Variant{std::forward<T>(value), type};
-        } else {
-            return Variant{reference, std::forward<T>(value), type};
+            return Variant{reference, std::forward<Args>(args)...};
         }
     }
 
     /// Create Variant from array.
     /// @tparam Policy Policy (@ref VariantPolicy) how to store the array inside the variant
-    template <VariantPolicy Policy = VariantPolicy::Copy, typename ArrayLike>
-    [[nodiscard]] static Variant fromArray(ArrayLike&& array) {
+    /// @deprecated Use new unified Variant constructor instead
+    template <VariantPolicy Policy = VariantPolicy::Copy, typename... Args>
+    [[deprecated("use new unified Variant constructor instead")]]
+    [[nodiscard]] static Variant fromArray(Args&&... args) {
         if constexpr (Policy == VariantPolicy::Copy) {
-            return Variant{std::forward<ArrayLike>(array)};
+            return Variant{std::forward<Args>(args)...};
         } else {
-            return Variant{reference, std::forward<ArrayLike>(array)};
-        }
-    }
-
-    /// Create Variant from array with custom data type.
-    /// @tparam Policy Policy (@ref VariantPolicy) how to store the array inside the variant
-    template <VariantPolicy Policy = VariantPolicy::Copy, typename ArrayLike>
-    [[nodiscard]] static Variant fromArray(ArrayLike&& array, const UA_DataType& type) {
-        if constexpr (Policy == VariantPolicy::Copy) {
-            return Variant{std::forward<ArrayLike>(array), type};
-        } else {
-            return Variant{reference, std::forward<ArrayLike>(array), type};
+            return Variant{reference, std::forward<Args>(args)...};
         }
     }
 
     /// Create Variant from range of elements (copy required).
     /// @tparam Policy Policy (@ref VariantPolicy) how to store the array inside the variant
-    template <VariantPolicy Policy = VariantPolicy::Copy, typename InputIt>
-    [[nodiscard]] static Variant fromArray(InputIt first, InputIt last) {
-        return Variant{first, last};
-    }
-
-    /// Create Variant from range of elements with custom data type (copy required).
-    /// @tparam Policy Policy (@ref VariantPolicy) how to store the array inside the variant
-    template <VariantPolicy Policy = VariantPolicy::Copy, typename InputIt>
-    [[nodiscard]] static Variant fromArray(InputIt first, InputIt last, const UA_DataType& type) {
-        return Variant{first, last, type};
+    /// @deprecated Use new unified Variant constructor instead
+    template <VariantPolicy Policy = VariantPolicy::Copy, typename InputIt, typename... Args>
+    [[deprecated("use new unified Variant constructor instead")]]
+    [[nodiscard]] static Variant fromArray(InputIt first, InputIt last, Args&&... args) {
+        return Variant{first, last, std::forward<Args>(args)...};
     }
 
     /**
@@ -1825,15 +1802,20 @@ public:
     }
 
     /// Create DataValue from scalar value.
-    /// @see Variant::fromScalar
+    /// @deprecated Use constructor with new unified Variant constructor instead:
+    ///             `opcua::DataValue dv(opcua::Variant(value))`
     template <VariantPolicy Policy = VariantPolicy::Copy, typename... Args>
+    [[deprecated("use constructor with new universal Variant constructor instead")]]
     [[nodiscard]] static DataValue fromScalar(Args&&... args) {
         return DataValue(Variant::fromScalar<Policy>(std::forward<Args>(args)...));
     }
 
     /// Create DataValue from array.
     /// @see Variant::fromArray
+    /// @deprecated Use constructor with new unified Variant constructor instead:
+    ///             `opcua::DataValue dv(opcua::Variant(array))`
     template <VariantPolicy Policy = VariantPolicy::Copy, typename... Args>
+    [[deprecated("use constructor with new universal Variant constructor instead")]]
     [[nodiscard]] static DataValue fromArray(Args&&... args) {
         return DataValue(Variant::fromArray<Policy>(std::forward<Args>(args)...));
     }

--- a/include/open62541pp/ua/types.hpp
+++ b/include/open62541pp/ua/types.hpp
@@ -445,16 +445,16 @@ public:
     UAPP_NODEATTR_COMMON
     UAPP_NODEATTR_WRAPPER(Variant, Value, value, UA_NODEATTRIBUTESMASK_VALUE)
 
-    /// @see Variant::fromScalar
+    /// @see Variant::Variant
     template <typename... Args>
     auto& setValueScalar(Args&&... args) {
-        return setValue(Variant::fromScalar(std::forward<Args>(args)...));
+        return setValue(Variant(std::forward<Args>(args)...));
     }
 
-    /// @see Variant::fromArray
+    /// @see Variant::Variant
     template <typename... Args>
     auto& setValueArray(Args&&... args) {
-        return setValue(Variant::fromArray(std::forward<Args>(args)...));
+        return setValue(Variant(std::forward<Args>(args)...));
     }
 
     UAPP_NODEATTR_WRAPPER(NodeId, DataType, dataType, UA_NODEATTRIBUTESMASK_DATATYPE)
@@ -542,16 +542,16 @@ public:
     UAPP_NODEATTR_COMMON
     UAPP_NODEATTR_WRAPPER(Variant, Value, value, UA_NODEATTRIBUTESMASK_VALUE)
 
-    /// @see Variant::fromScalar
+    /// @see Variant::Variant
     template <typename... Args>
     auto& setValueScalar(Args&&... args) {
-        return setValue(Variant::fromScalar(std::forward<Args>(args)...));
+        return setValue(Variant(std::forward<Args>(args)...));
     }
 
-    /// @see Variant::fromArray
+    /// @see Variant::Variant
     template <typename... Args>
     auto& setValueArray(Args&&... args) {
-        return setValue(Variant::fromArray(std::forward<Args>(args)...));
+        return setValue(Variant(std::forward<Args>(args)...));
     }
 
     UAPP_NODEATTR_WRAPPER(NodeId, DataType, dataType, UA_NODEATTRIBUTESMASK_DATATYPE)
@@ -1732,7 +1732,7 @@ public:
 
     template <typename T, typename = EnableIfLiteral<T>>
     explicit LiteralOperand(T&& literal)
-        : LiteralOperand(Variant::fromScalar(std::forward<T>(literal))) {}
+        : LiteralOperand(Variant(std::forward<T>(literal))) {}
 
     UAPP_GETTER_WRAPPER(Variant, getValue, value)
 };

--- a/src/event.cpp
+++ b/src/event.cpp
@@ -20,19 +20,19 @@ Event::~Event() {
 }
 
 Event& Event::writeSourceName(std::string_view sourceName) {
-    return writeProperty({0, "SourceName"}, Variant::fromScalar(sourceName));
+    return writeProperty({0, "SourceName"}, Variant(sourceName));
 }
 
 Event& Event::writeTime(DateTime time) {  // NOLINT(performance-unnecessary-value-param)
-    return writeProperty({0, "Time"}, Variant::fromScalar(time));
+    return writeProperty({0, "Time"}, Variant(time));
 }
 
 Event& Event::writeSeverity(uint16_t severity) {
-    return writeProperty({0, "Severity"}, Variant::fromScalar(severity));
+    return writeProperty({0, "Severity"}, Variant(severity));
 }
 
 Event& Event::writeMessage(const LocalizedText& message) {
-    return writeProperty({0, "Message"}, Variant::fromScalar(message));
+    return writeProperty({0, "Message"}, Variant(message));
 }
 
 Event& Event::writeProperty(const QualifiedName& propertyName, const Variant& value) {

--- a/tests/node.cpp
+++ b/tests/node.cpp
@@ -368,7 +368,7 @@ TEST_CASE_TEMPLATE("Node", T, Server, Client, Async<Client>) {
 
     SUBCASE("writeValue/readValue") {
         const double value = 11.11;
-        const auto variant = Variant::fromScalar(value);
+        const auto variant = Variant(value);
         if constexpr (isAsync<T>) {
             CHECK(await(varNode.writeValueAsync(variant)).isGood());
             CHECK(await(varNode.readValueAsync()).value().template scalar<double>() == value);
@@ -540,7 +540,7 @@ TEST_CASE_TEMPLATE("Node", T, Server, Client, Async<Client>) {
                 .setValueScalar(11.11)
         );
         CHECK(objNode.readObjectProperty({1, "Property"}).template scalar<double>() == 11.11);
-        CHECK_NOTHROW(objNode.writeObjectProperty({1, "Property"}, Variant::fromScalar(22.22)));
+        CHECK_NOTHROW(objNode.writeObjectProperty({1, "Property"}, Variant(22.22)));
         CHECK(objNode.readObjectProperty({1, "Property"}).template scalar<double>() == 22.22);
     }
 

--- a/tests/services_attribute.cpp
+++ b/tests/services_attribute.cpp
@@ -282,7 +282,7 @@ TEST_CASE("Attribute service set (highlevel)") {
     //     services::addDataType(server, {0, UA_NS0ID_ENUMERATION}, id, "MyEnum");
 
     //     const EnumDefinition definition{{0, "Zero"}, {1, "One"}};
-    //     services::writeDataTypeDefinition(server, id, Variant::fromScalar(definition)).value();
+    //     services::writeDataTypeDefinition(server, id, Variant(definition)).value();
 
     //     const auto definitionRead = services::readDataTypeDefinition(server, id);
     //     CHECK(definitionRead.value().isType<EnumDefinition>());
@@ -315,7 +315,7 @@ TEST_CASE("Attribute service set (highlevel, async)") {
 
         // write
         {
-            auto variant = Variant::fromScalar(11.11);
+            auto variant = Variant(11.11);
             auto future = services::writeValueAsync(client, id, variant, useFuture);
             client.runIterate();
             future.get().throwIfBad();
@@ -356,12 +356,12 @@ TEST_CASE_TEMPLATE("Attribute service set write/read", T, Server, Client, Async<
     // write
     if constexpr (isAsync<T>) {
         auto future = services::writeAttributeAsync(
-            connection, id, AttributeId::Value, DataValue::fromScalar(value), useFuture
+            connection, id, AttributeId::Value, DataValue(Variant(value)), useFuture
         );
         client.runIterate();
         future.get().throwIfBad();
     } else {
-        services::writeAttribute(connection, id, AttributeId::Value, DataValue::fromScalar(value))
+        services::writeAttribute(connection, id, AttributeId::Value, DataValue(Variant(value)))
             .throwIfBad();
     }
 

--- a/tests/services_method.cpp
+++ b/tests/services_method.cpp
@@ -58,8 +58,8 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
             objectsId,
             methodId,
             Span<const Variant>{
-                Variant::fromScalar(int32_t{1}),
-                Variant::fromScalar(int32_t{2}),
+                Variant(int32_t{1}),
+                Variant(int32_t{2}),
             }
         );
         CHECK(result.statusCode().isGood());
@@ -74,8 +74,8 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
             objectsId,
             methodId,
             Span<const Variant>{
-                Variant::fromScalar(int32_t{1}),
-                Variant::fromScalar(int32_t{2}),
+                Variant(int32_t{1}),
+                Variant(int32_t{2}),
             }
         );
         CHECK(result.statusCode() == UA_STATUSCODE_BADUNEXPECTEDERROR);
@@ -87,8 +87,8 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
             objectsId,
             methodId,
             Span<const Variant>{
-                Variant::fromScalar(true),
-                Variant::fromScalar(11.11f),
+                Variant(true),
+                Variant(11.11f),
             }
         );
         CHECK(result.statusCode() == UA_STATUSCODE_BADINVALIDARGUMENT);
@@ -107,9 +107,9 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
             objectsId,
             methodId,
             Span<const Variant>{
-                Variant::fromScalar(int32_t{1}),
-                Variant::fromScalar(int32_t{2}),
-                Variant::fromScalar(int32_t{3}),
+                Variant(int32_t{1}),
+                Variant(int32_t{2}),
+                Variant(int32_t{3}),
             }
         );
         CHECK(result.statusCode() == UA_STATUSCODE_BADTOOMANYARGUMENTS);

--- a/tests/services_monitoreditem.cpp
+++ b/tests/services_monitoreditem.cpp
@@ -88,7 +88,7 @@ TEST_CASE_TEMPLATE("MonitoredItem service set", T, Client, Async<Client>) {
         CHECK(result.statusCode().isGood());
         CAPTURE(result.monitoredItemId());
 
-        services::writeValue(server, id, Variant::fromScalar(11.11)).throwIfBad();
+        services::writeValue(server, id, Variant(11.11)).throwIfBad();
         setup.client.runIterate();
         CHECK(notificationCount > 0);
         CHECK(changedValue.value().scalar<double>() == 11.11);
@@ -345,7 +345,7 @@ TEST_CASE("MonitoredItem service set (server)") {
                 .monitoredItemId();
         CAPTURE(monId);
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
-        services::writeValue(server, id, Variant::fromScalar(11.11)).throwIfBad();
+        services::writeValue(server, id, Variant(11.11)).throwIfBad();
         server.runIterate();
         CHECK(notificationCount > 0);
     }

--- a/tests/session.cpp
+++ b/tests/session.cpp
@@ -35,7 +35,7 @@ TEST_CASE("Session") {
 
 #if UAPP_OPEN62541_VER_LE(1, 3)
         // TODO: fails with v1.4: https://github.com/open62541/open62541/issues/6724
-        CHECK_NOTHROW(session.setSessionAttribute(key, Variant::fromScalar(11.11)));
+        CHECK_NOTHROW(session.setSessionAttribute(key, Variant(11.11)));
         CHECK(session.getSessionAttribute(key).scalar<double>() == 11.11);
 
         // retry with newly created session object

--- a/tests/types_builtin.cpp
+++ b/tests/types_builtin.cpp
@@ -502,12 +502,6 @@ TEST_CASE("Variant") {
             SUBCASE("Constructor with type") {
                 var = Variant(value, type);
             }
-            SUBCASE("fromScalar") {
-                var = Variant::fromScalar(value);
-            }
-            SUBCASE("fromScalar with type") {
-                var = Variant::fromScalar(value, type);
-            }
             CHECK(var.isScalar());
             CHECK(var.type() == &type);
             CHECK(var.data() != &value);
@@ -546,18 +540,6 @@ TEST_CASE("Variant") {
             SUBCASE("Constructor with iterator pair and type") {
                 var = Variant(array.begin(), array.end(), type);
             }
-            SUBCASE("fromArray") {
-                var = Variant::fromArray(array);
-            }
-            SUBCASE("fromArray with type") {
-                var = Variant::fromArray(array, type);
-            }
-            SUBCASE("fromArray with iterator pair") {
-                var = Variant::fromArray(array.begin(), array.end());
-            }
-            SUBCASE("fromArray with iterator pair and type") {
-                var = Variant::fromArray(array.begin(), array.end(), type);
-            }
             CHECK(var.isArray());
             CHECK(var.type() == &type);
             CHECK(var.data() != array.data());
@@ -570,12 +552,6 @@ TEST_CASE("Variant") {
             }
             SUBCASE("Constructor with type") {
                 var = Variant(reference, array, type);
-            }
-            SUBCASE("fromArray") {
-                var = Variant::fromArray<VariantPolicy::Reference>(array);
-            }
-            SUBCASE("fromArray with type") {
-                var = Variant::fromArray<VariantPolicy::Reference>(array, type);
             }
             CHECK(var.isArray());
             CHECK(var.type() == &type);
@@ -852,12 +828,12 @@ TEST_CASE("Variant") {
 
 TEST_CASE("DataValue") {
     SUBCASE("Create from scalar") {
-        CHECK(DataValue::fromScalar(5).value().to<int>() == 5);
+        CHECK(DataValue(Variant(5)).value().to<int>() == 5);
     }
 
     SUBCASE("Create from array") {
         std::vector<int> vec{1, 2, 3};
-        CHECK(DataValue::fromArray(vec).value().to<std::vector<int>>() == vec);
+        CHECK(DataValue(Variant(vec)).value().to<std::vector<int>>() == vec);
     }
 
     SUBCASE("Empty") {
@@ -882,7 +858,7 @@ TEST_CASE("DataValue") {
 
     SUBCASE("Constructor with all optional parameter specified") {
         DataValue dv(
-            Variant::fromScalar(5),
+            Variant{5},
             DateTime{1},
             DateTime{2},
             uint16_t{3},
@@ -950,7 +926,7 @@ TEST_CASE("DataValue") {
     }
 
     SUBCASE("getValue (lvalue & rvalue)") {
-        DataValue dv(Variant::fromScalar(11));
+        DataValue dv(Variant(11));
         void* data = dv.value().data();
 
         Variant var;
@@ -1004,7 +980,7 @@ TEST_CASE("ExtensionObject") {
 
     SUBCASE("fromDecodedCopy") {
         ExtensionObject obj;
-        const auto value = Variant::fromScalar(11.11);
+        const auto value = Variant(11.11);
         SUBCASE("Deduce data type") {
             obj = ExtensionObject::fromDecodedCopy(value);
         }

--- a/tests/ua_types.cpp
+++ b/tests/ua_types.cpp
@@ -273,7 +273,7 @@ TEST_CASE("ReadRequest") {
 }
 
 TEST_CASE("WriteValue") {
-    const WriteValue wv({1, 1000}, AttributeId::Value, {}, DataValue::fromScalar(11.11));
+    const WriteValue wv({1, 1000}, AttributeId::Value, {}, DataValue(Variant(11.11)));
     CHECK(wv.nodeId() == NodeId(1, 1000));
     CHECK(wv.attributeId() == AttributeId::Value);
     CHECK(wv.indexRange().empty());
@@ -284,7 +284,7 @@ TEST_CASE("WriteRequest") {
     const WriteRequest request(
         {},
         {
-            {{1, 1000}, AttributeId::Value, {}, DataValue::fromScalar(11.11)},
+            {{1, 1000}, AttributeId::Value, {}, DataValue(Variant(11.11))},
         }
     );
     CHECK_NOTHROW(request.requestHeader());
@@ -334,7 +334,7 @@ TEST_CASE("Argument") {
 }
 
 TEST_CASE("CallMethodRequest / CallRequest") {
-    const CallMethodRequest item({1, 1000}, {1, 1001}, {Variant::fromScalar(11)});
+    const CallMethodRequest item({1, 1000}, {1, 1001}, {Variant(11)});
     const CallRequest request({}, {item});
     CHECK(request.methodsToCall().size() == 1);
     CHECK(request.methodsToCall()[0].objectId() == NodeId(1, 1000));
@@ -351,7 +351,7 @@ TEST_CASE("ElementOperand") {
 }
 
 TEST_CASE("LiteralOperand") {
-    CHECK(LiteralOperand(Variant::fromScalar(11)).value().scalar<int>() == 11);
+    CHECK(LiteralOperand(Variant(11)).value().scalar<int>() == 11);
     CHECK(LiteralOperand(11).value().scalar<int>() == 11);
 }
 


### PR DESCRIPTION
The factory functions `fromScalar`/`fromArray` are now deprecated in favor Variant's new universal constructor from #384:
- `Variant::fromScalar(...)` -> use `Variant(...)` instead
- `Variant::fromArray(...)` -> use `Variant(...)` instead
- `DataValue::fromScalar(...)` -> use `DataValue(Variant(...))` instead
- `DataValue::fromArray(...)` -> use `DataValue(Variant(...))` instead