### PR TITLE
feat!: universal Variant::assign function

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,15 +122,14 @@ opcua::Variant var;
 
 // ✅ will compile
 int number = 5;
-var.setScalar(number);
-var.setArrayCopy<double>({1.1, 2.2, 3.3});
+var.assign(reference, number);
 
 // ❌ won't compile, because std::string can't be assigned without copy (conversion needed)
 std::string str{"test"};
-var.setScalar(str);
+var.assign(reference, str);
 
 // ✅ will compile
-var.setScalarCopy(str);
+var.assign(str);
 ```
 
 You can add template specializations to add conversions for arbitrary types:

--- a/examples/method/server_method.cpp
+++ b/examples/method/server_method.cpp
@@ -15,7 +15,7 @@ int main() {
         [](opcua::Span<const opcua::Variant> input, opcua::Span<opcua::Variant> output) {
             const auto& name = input[0].scalar<opcua::String>();
             const auto greeting = std::string("Hello ").append(name);
-            output[0].setScalarCopy(greeting);
+            output[0].assign(greeting);
         },
         {{"name", {"en-US", "your name"}, opcua::DataTypeId::String, opcua::ValueRank::Scalar}},
         {{"greeting", {"en-US", "greeting"}, opcua::DataTypeId::String, opcua::ValueRank::Scalar}}
@@ -33,7 +33,7 @@ int main() {
             std::transform(values.begin(), values.end(), incremented.begin(), [&](auto v) {
                 return v + delta;
             });
-            output[0].setArrayCopy(incremented);
+            output[0].assign(incremented);
         },
         {
             opcua::Argument(

--- a/examples/server_datasource.cpp
+++ b/examples/server_datasource.cpp
@@ -28,7 +28,7 @@ int main() {
     dataSource.read = [&](opcua::DataValue& dv, const opcua::NumericRange&, bool timestamp) {
         // Increment counter before every read
         counter++;
-        dv.value().setScalarCopy(counter);
+        dv.value().assign(counter);
         if (timestamp) {
             dv.setSourceTimestamp(opcua::DateTime::now());
         }

--- a/examples/typeconversion.cpp
+++ b/examples/typeconversion.cpp
@@ -37,7 +37,7 @@ int main() {
     opcua::Variant variant;
 
     // Write std::byte to variant
-    variant.setScalarCopy(std::byte{11});
+    variant.assign(std::byte{11});
 
     // Read UA_Byte from variant (reference possible)
     const auto& valueNative = variant.scalar<UA_Byte>();
@@ -49,9 +49,9 @@ int main() {
 
     // Write array of bytes to variant
     std::array<std::byte, 3> array{};
-    variant.setArrayCopy(array);  // use array container
-    variant.setArrayCopy(opcua::Span{array.data(), array.size()});  // use raw array and size
-    variant.setArrayCopy(array.begin(), array.end());  // use iterator pair
+    variant.assign(array);  // use array container
+    variant.assign(opcua::Span{array.data(), array.size()});  // use raw array and size
+    variant.assign(array.begin(), array.end());  // use iterator pair
 
     std::cout << "Array size: " << variant.arrayLength() << std::endl;
 }

--- a/include/open62541pp/async.hpp
+++ b/include/open62541pp/async.hpp
@@ -62,7 +62,7 @@ inline constexpr UseFutureToken useFuture;
 template <typename T>
 struct AsyncResult<UseFutureToken, T> {
     template <typename Initiation, typename... Args>
-    static auto initiate(Initiation&& initiation, UseFutureToken /*unused*/, Args&&... args) {
+    static auto initiate(Initiation&& initiation, UseFutureToken /* unused */, Args&&... args) {
         std::promise<T> promise;
         auto future = promise.get_future();
         std::invoke(
@@ -92,7 +92,7 @@ inline constexpr UseDeferredToken useDeferred;
 template <typename T>
 struct AsyncResult<UseDeferredToken, T> {
     template <typename Initiation, typename... Args>
-    static auto initiate(Initiation&& initiation, UseDeferredToken /*unused*/, Args&&... args) {
+    static auto initiate(Initiation&& initiation, UseDeferredToken /* unused */, Args&&... args) {
         return [initiation = std::forward<Initiation>(initiation),
                 argsPack = std::make_tuple(std::forward<Args>(args)...)](auto&& token) mutable {
             return std::apply(
@@ -127,7 +127,7 @@ inline constexpr UseDetachedToken useDetached;
 template <typename T>
 struct AsyncResult<UseDetachedToken, T> {
     template <typename Initiation, typename... Args>
-    static auto initiate(Initiation&& initiation, UseDetachedToken /*unused*/, Args&&... args) {
+    static auto initiate(Initiation&& initiation, UseDetachedToken /* unused */, Args&&... args) {
         std::invoke(
             std::forward<Initiation>(initiation),
             [](auto&&...) {

--- a/include/open62541pp/plugin/nodestore.hpp
+++ b/include/open62541pp/plugin/nodestore.hpp
@@ -51,7 +51,7 @@ struct ValueBackendDataSource {
      * between read callbacks of a data source, as the result is already encoded on the network
      * buffer between each read operation.
      * To use zero-copy reads, set the value of the Variant (DataValue::getValue) without copying,
-     * e.g. with Variant::setScalar or Variant::setArray.
+     * e.g. with Variant::assign.
      *
      * @param value The DataValue that is returned to the reader
      * @param range If not empty, then the data source shall return only a selection of the

--- a/tests/server.cpp
+++ b/tests/server.cpp
@@ -206,7 +206,7 @@ TEST_CASE("DataSource") {
 
     ValueBackendDataSource dataSource;
     dataSource.read = [&](DataValue& dv, const NumericRange&, bool includeSourceTimestamp) {
-        dv.value().setScalar(data);
+        dv.value().assign(data);
         if (includeSourceTimestamp) {
             dv.setSourceTimestamp(DateTime::now());
         }

--- a/tests/services_attribute.cpp
+++ b/tests/services_attribute.cpp
@@ -223,8 +223,7 @@ TEST_CASE("Attribute service set (highlevel)") {
             ReferenceTypeId::HasComponent
         ));
 
-        Variant variantWrite;
-        variantWrite.setScalarCopy(11.11);
+        Variant variantWrite(11.11);
         services::writeValue(server, id, variantWrite).throwIfBad();
 
         Variant variantRead = services::readValue(server, id).value();
@@ -243,8 +242,7 @@ TEST_CASE("Attribute service set (highlevel)") {
             ReferenceTypeId::HasComponent
         ));
 
-        Variant variant;
-        variant.setScalarCopy<int>(11);
+        Variant variant(11);
         DataValue valueWrite(variant, {}, DateTime::now(), {}, uint16_t{1}, UA_STATUSCODE_GOOD);
         services::writeDataValue(server, id, valueWrite).throwIfBad();
 

--- a/tests/services_method.cpp
+++ b/tests/services_method.cpp
@@ -29,7 +29,7 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
             }
             const auto a = inputs[0].scalar<int32_t>();
             const auto b = inputs[1].scalar<int32_t>();
-            outputs[0].setScalarCopy(a + b);
+            outputs[0].assign(a + b);
         },
         {
             Argument("a", {"en-US", "first number"}, DataTypeId::Int32, ValueRank::Scalar),


### PR DESCRIPTION
The new universal `Variant::assign` member function uses the same logic as the universal constructor introduced in #384.
Actually it is the opposite. The universal constructor is using the `assign` function, which was called `setValue` and `setValueCopy` before (introduced by @chandryan).

`Variant::assign` will replace following member functions, which are now marked as deprecated:
- `Variant::setScalar(...)` -> use `Variant::assign(reference, ...)` instead
- `Variant::setScalarCopy(...)` use `Variant::assign(...)` instead
- `Variant::setArray(...)` -> use `Variant::assign(reference, ...)` instead
- `Variant::setArrayCopy(...)` use `Variant::assign(...)` instead

We are currently using the `opcua::ReferenceTag` type or just `opcua::reference` to distinguish between referencing and copying (default) the value. Discussions about more expressive ways are ongoing (see #489).