### PR TITLE
feat!: rename isEmpty -> empty

### DIFF
--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -1189,21 +1189,27 @@ public:
      */
 
     /// Check if the variant is empty.
-    bool isEmpty() const noexcept {
+    bool empty() const noexcept {
         return handle()->type == nullptr;
+    }
+
+    /// @deprecated Use empty() instead
+    [[deprecated("use empty() instead")]]
+    bool isEmpty() const noexcept {
+        return empty();
     }
 
     /// Check if the variant is a scalar.
     bool isScalar() const noexcept {
         return (
-            !isEmpty() && handle()->arrayLength == 0 &&
+            !empty() && handle()->arrayLength == 0 &&
             handle()->data > UA_EMPTY_ARRAY_SENTINEL  // NOLINT
         );
     }
 
     /// Check if the variant is an array.
     bool isArray() const noexcept {
-        return !isEmpty() && !isScalar();
+        return !empty() && !isScalar();
     }
 
     /// Check if the variant type is equal to the provided data type.
@@ -2044,8 +2050,14 @@ public:
     }
 
     /// Check if the ExtensionObject is empty
-    bool isEmpty() const noexcept {
+    bool empty() const noexcept {
         return (handle()->encoding == UA_EXTENSIONOBJECT_ENCODED_NOBODY);
+    }
+
+    /// @deprecated Use empty() instead
+    [[deprecated("use empty() instead")]]
+    bool isEmpty() const noexcept {
+        return empty();
     }
 
     /// Check if the ExtensionObject is encoded (usually if the data type is unknown).

--- a/src/plugin/accesscontrol_default.cpp
+++ b/src/plugin/accesscontrol_default.cpp
@@ -49,7 +49,7 @@ StatusCode AccessControlDefault::activateSession(
     // https://github.com/open62541/open62541/blob/v1.3.6/plugins/ua_accesscontrol_default.c#L38-L134
 
     // empty token
-    if (userIdentityToken.isEmpty()) {
+    if (userIdentityToken.empty()) {
         if (allowAnonymous_) {
             return UA_STATUSCODE_GOOD;
         }

--- a/tests/client.cpp
+++ b/tests/client.cpp
@@ -26,7 +26,7 @@ TEST_CASE("ClientConfig") {
 
     SUBCASE("setUserIdentityToken") {
         const auto& token = asWrapper<ExtensionObject>(config->userIdentityToken);
-        CHECK(token.isEmpty());
+        CHECK(token.empty());
 
         config.setUserIdentityToken(AnonymousIdentityToken{});
         CHECK(token.decodedData<AnonymousIdentityToken>() != nullptr);
@@ -40,7 +40,7 @@ TEST_CASE("ClientConfig") {
         config.setUserIdentityToken(IssuedIdentityToken{});
         CHECK(token.decodedData<IssuedIdentityToken>() != nullptr);
 
-        CHECK_FALSE(token.isEmpty());
+        CHECK_FALSE(token.empty());
     }
 
     SUBCASE("setSecurityMode") {

--- a/tests/types_builtin.cpp
+++ b/tests/types_builtin.cpp
@@ -478,7 +478,7 @@ TEST_CASE("ExpandedNodeId") {
 TEST_CASE("Variant") {
     SUBCASE("Empty") {
         Variant var;
-        CHECK(var.isEmpty());
+        CHECK(var.empty());
         CHECK_FALSE(var.isScalar());
         CHECK_FALSE(var.isArray());
         CHECK(var.type() == nullptr);
@@ -581,7 +581,7 @@ TEST_CASE("Variant") {
         float* ptr{nullptr};
         var.assign(ptr);
         var.assign(ptr, UA_TYPES[UA_TYPES_FLOAT]);
-        CHECK(var.isEmpty());
+        CHECK(var.empty());
         CHECK(var.type() == nullptr);
         CHECK(var.data() == nullptr);
     }
@@ -905,7 +905,7 @@ TEST_CASE("DataValue") {
 TEST_CASE("ExtensionObject") {
     SUBCASE("Empty") {
         ExtensionObject obj;
-        CHECK(obj.isEmpty());
+        CHECK(obj.empty());
         CHECK_FALSE(obj.isEncoded());
         CHECK_FALSE(obj.isDecoded());
         CHECK(obj.encoding() == ExtensionObjectEncoding::EncodedNoBody);

--- a/tests/ua_types.cpp
+++ b/tests/ua_types.cpp
@@ -20,7 +20,7 @@ TEST_CASE("RequestHeader") {
     CHECK(header.requestHandle() == 1);
     CHECK(header.returnDiagnostics() == 2);
     CHECK(header.auditEntryId() == String("auditEntryId"));
-    CHECK(header.additionalHeader().isEmpty());
+    CHECK(header.additionalHeader().empty());
 }
 
 TEST_CASE("UserTokenPolicy") {
@@ -528,7 +528,7 @@ TEST_CASE("AggregateFilter") {
 TEST_CASE("MonitoringParameters") {
     const MonitoringParameters params(11.11, {}, 10, false);
     CHECK(params.samplingInterval() == 11.11);
-    CHECK(params.filter().isEmpty());
+    CHECK(params.filter().empty());
     CHECK(params.queueSize() == 10);
     CHECK(params.discardOldest() == false);
 }


### PR DESCRIPTION
Rename `isEmpty` member functions to `empty()` for consistency:
- `Variant::isEmpty()` -> `Variant::empty()`
- `ExtensionObject::isEmpty()` -> `ExtensionObject::empty()`

The old functions are deprecated and will be removed in the future.