### PR TITLE
feat: Variant assignment operator for scalars/arrays

### DIFF
--- a/examples/method/server_method.cpp
+++ b/examples/method/server_method.cpp
@@ -15,7 +15,7 @@ int main() {
         [](opcua::Span<const opcua::Variant> input, opcua::Span<opcua::Variant> output) {
             const auto& name = input.at(0).scalar<opcua::String>();
             const auto greeting = std::string("Hello ").append(name);
-            output.at(0).assign(greeting);
+            output.at(0) = greeting;
         },
         {{"name", {"en-US", "your name"}, opcua::DataTypeId::String, opcua::ValueRank::Scalar}},
         {{"greeting", {"en-US", "greeting"}, opcua::DataTypeId::String, opcua::ValueRank::Scalar}}
@@ -33,7 +33,7 @@ int main() {
             std::transform(values.begin(), values.end(), incremented.begin(), [&](auto v) {
                 return v + delta;
             });
-            output.at(0).assign(incremented);
+            output.at(0) = incremented;
         },
         {
             opcua::Argument(

--- a/examples/server_datasource.cpp
+++ b/examples/server_datasource.cpp
@@ -28,7 +28,7 @@ int main() {
     dataSource.read = [&](opcua::DataValue& dv, const opcua::NumericRange&, bool timestamp) {
         // Increment counter before every read
         counter++;
-        dv.value().assign(counter);
+        dv.value() = counter;
         if (timestamp) {
             dv.setSourceTimestamp(opcua::DateTime::now());
         }

--- a/examples/typeconversion.cpp
+++ b/examples/typeconversion.cpp
@@ -37,6 +37,8 @@ int main() {
 
     // Write std::byte to variant
     variant.assign(std::byte{11});
+    // Use assignment operator
+    variant = std::byte{11};
 
     // Read UA_Byte from variant (reference possible)
     const auto& valueNative = variant.scalar<UA_Byte>();

--- a/tests/server.cpp
+++ b/tests/server.cpp
@@ -206,7 +206,7 @@ TEST_CASE("DataSource") {
 
     ValueBackendDataSource dataSource;
     dataSource.read = [&](DataValue& dv, const NumericRange&, bool includeSourceTimestamp) {
-        dv.value().assign(data);
+        dv.value() = data;
         if (includeSourceTimestamp) {
             dv.setSourceTimestamp(DateTime::now());
         }

--- a/tests/services_method.cpp
+++ b/tests/services_method.cpp
@@ -29,7 +29,7 @@ TEST_CASE_TEMPLATE("Method service set", T, Server, Client, Async<Client>) {
             }
             const auto a = inputs.at(0).scalar<int32_t>();
             const auto b = inputs.at(1).scalar<int32_t>();
-            outputs.at(0).assign(a + b);
+            outputs.at(0) = a + b;
         },
         {
             Argument("a", {"en-US", "first number"}, DataTypeId::Int32, ValueRank::Scalar),


### PR DESCRIPTION
Use assignment operator to assign scalars/arrays to `Variant` as discussed in #489:

```cpp
opcua::Variant var;
int value = 5;
var.assign(value);   // Old way with copy
var.assign(&value);  // Old way without copy
var = value;         // New way with copy
var = &value;        // New way without copy

std::array<int> array{1, 2, 3};
var.assign(array);   // Old way with copy
var.assign(&array);  // Old way without copy
var = array;         // New way with copy
var = &array;        // New way without copy
```