### PR TITLE
feat!: universal ExtensionObject constructor

### DIFF
--- a/include/open62541pp/services/detail/request_handling.hpp
+++ b/include/open62541pp/services/detail/request_handling.hpp
@@ -39,7 +39,7 @@ auto* getNativePointer(Span<T> array) noexcept {
 template <typename T>
 ExtensionObject wrapNodeAttributes(const T& attributes) noexcept {
     // NOLINTNEXTLINE(*-const-cast), won't be modified
-    return ExtensionObject::fromDecoded(const_cast<T&>(attributes));
+    return ExtensionObject(const_cast<T*>(&attributes));
 }
 
 inline UA_AddNodesItem createAddNodesItem(

--- a/include/open62541pp/subscription.hpp
+++ b/include/open62541pp/subscription.hpp
@@ -149,7 +149,7 @@ public:
         const NodeId& id, const EventFilter& eventFilter, EventNotificationCallback onEvent
     ) {
         MonitoringParametersEx parameters;
-        parameters.filter = ExtensionObject::fromDecodedCopy(eventFilter);
+        parameters.filter = ExtensionObject(eventFilter);
         return subscribeEvent(id, MonitoringMode::Reporting, parameters, std::move(onEvent));
     }
 

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -1201,6 +1201,7 @@ public:
 
     /**
      * Assign pointer to scalar/array to variant (no copy).
+     * The object will *not* be deleted when the Variant is destructed.
      * @param ptr Non-const pointer to a value to assign to the variant. This can be:
      *            - A pointer to a scalar native or wrapper value.
      *            - A pointer to a contiguous container such as `std::array` or `std::vector`
@@ -2016,52 +2017,71 @@ enum class ExtensionObjectEncoding {
  * @ingroup Wrapper
  */
 class ExtensionObject : public TypeWrapper<UA_ExtensionObject, UA_TYPES_EXTENSIONOBJECT> {
+private:
+    template <typename T>
+    static constexpr bool isExtensionObject =
+        std::is_same_v<std::remove_cv_t<std::remove_reference_t<T>>, ExtensionObject> ||
+        std::is_same_v<std::remove_cv_t<std::remove_reference_t<T>>, UA_ExtensionObject>;
+
 public:
     using TypeWrapper::TypeWrapper;
 
-    /// Create an ExtensionObject from a decoded object (reference).
-    /// The data will *not* be deleted when the ExtensionObject is destructed.
-    /// @param data Decoded data
+    /**
+     * Create ExtensionObject from a pointer to a decoded object (no copy).
+     * The object will *not* be deleted when the ExtensionObject is destructed.
+     * @param ptr Pointer to decoded object (native or wrapper).
+     */
     template <typename T>
-    [[nodiscard]] static ExtensionObject fromDecoded(T& data) noexcept {
-        return fromDecoded(data, getDataType<T>());
-    }
+    explicit ExtensionObject(T* ptr) noexcept
+        : ExtensionObject(ptr, getDataType<T>()) {}
 
-    /// Create an ExtensionObject from a decoded object (reference) with a custom data type.
-    /// The data will *not* be deleted when the ExtensionObject is destructed.
-    /// @param data Decoded data
-    /// @param type Data type of the decoded data
+    /**
+     * Create ExtensionObject from a pointer to a decoded object with a custom data type (no copy).
+     * The object will *not* be deleted when the ExtensionObject is destructed.
+     * @param ptr Pointer to decoded object (native or wrapper).
+     * @param type Data type of the decoded object.
+     */
     template <typename T>
-    [[nodiscard]] static ExtensionObject fromDecoded(T& data, const UA_DataType& type) noexcept {
+    ExtensionObject(T* ptr, const UA_DataType& type) noexcept {
+        if (ptr == nullptr) {
+            return;
+        }
         assert(sizeof(T) == type.memSize);
-        ExtensionObject obj;
-        obj->encoding = UA_EXTENSIONOBJECT_DECODED_NODELETE;
-        obj->content.decoded.type = &type;  // NOLINT
-        obj->content.decoded.data = &data;  // NOLINT
-        return obj;
+        handle()->encoding = UA_EXTENSIONOBJECT_DECODED_NODELETE;
+        handle()->content.decoded.type = &type;  // NOLINT
+        handle()->content.decoded.data = ptr;  // NOLINT
     }
 
-    /// Create an ExtensionObject from a decoded object (copy).
-    /// @param data Decoded data
-    template <typename T>
-    [[nodiscard]] static ExtensionObject fromDecodedCopy(const T& data) {
-        return fromDecodedCopy(data, getDataType<T>());
+    /**
+     * Create ExtensionObject from a decoded object (copy).
+     * @param decoded Decoded object (native or wrapper).
+     */
+    template <typename T, typename = std::enable_if_t<!isExtensionObject<T>>>
+    explicit ExtensionObject(const T& decoded)
+        : ExtensionObject(decoded, getDataType<T>()) {}
+
+    /**
+     * Create ExtensionObject from a decoded object with a custom data type (copy).
+     * @param decoded Decoded object (native or wrapper).
+     * @param type Data type of the decoded object.
+     */
+    template <typename T, typename = std::enable_if_t<!isExtensionObject<T>>>
+    explicit ExtensionObject(const T& decoded, const UA_DataType& type) {
+        auto ptr = detail::allocateUniquePtr<T>(type);
+        *ptr = detail::copy(decoded, type);
+        handle()->encoding = UA_EXTENSIONOBJECT_DECODED;
+        handle()->content.decoded.type = &type;  // NOLINT
+        handle()->content.decoded.data = ptr.release();  // NOLINT
     }
 
-    /// Create an ExtensionObject from a decoded object (copy) with a custom data type.
-    /// @param data Decoded data
-    /// @param type Data type of the decoded data
-    template <typename T>
-    [[nodiscard]] static ExtensionObject fromDecodedCopy(const T& data, const UA_DataType& type) {
-        // manual implementation instead of UA_ExtensionObject_setValueCopy to support open62541
-        // v1.0 https://github.com/open62541/open62541/blob/v1.3.5/src/ua_types.c#L503-L524
-        assert(sizeof(T) == type.memSize);
-        ExtensionObject obj;
-        obj->encoding = UA_EXTENSIONOBJECT_DECODED;
-        obj->content.decoded.data = detail::allocate<void>(type);  // NOLINT
-        obj->content.decoded.type = &type;  // NOLINT
-        throwIfBad(UA_copy(&data, obj->content.decoded.data, &type));  // NOLINT
-        return obj;
+    template <typename T, typename... Args>
+    [[nodiscard]] static ExtensionObject fromDecoded(T& data, Args&&... args) noexcept {
+        return ExtensionObject(&data, std::forward<Args>(args)...);
+    }
+
+    template <typename T, typename... Args>
+    [[nodiscard]] static ExtensionObject fromDecodedCopy(const T& data, Args&&... args) {
+        return ExtensionObject(data, std::forward<Args>(args)...);
     }
 
     /// Check if the ExtensionObject is empty
@@ -2148,19 +2168,19 @@ public:
         return isDecodedType<T>() ? static_cast<T*>(decodedData()) : nullptr;
     }
 
-    /// @deprecated Use decodedData<T>() instead
-    template <typename T>
-    [[deprecated("use decodedData<T>() instead")]]
-    T* getDecodedData() noexcept {
-        return decodedData<T>();
-    }
-
     /// Get const pointer to the decoded data with given template type.
     /// Returns `nullptr` if the ExtensionObject is either not decoded or the decoded data is not of
     /// type `T`.
     template <typename T>
     const T* decodedData() const noexcept {
         return isDecodedType<T>() ? static_cast<const T*>(decodedData()) : nullptr;
+    }
+
+    /// @deprecated Use decodedData<T>() instead
+    template <typename T>
+    [[deprecated("use decodedData<T>() instead")]]
+    T* getDecodedData() noexcept {
+        return decodedData<T>();
     }
 
     /// @deprecated Use decodedData<T>() instead
@@ -2179,12 +2199,6 @@ public:
             : nullptr;
     }
 
-    /// @deprecated Use decodedData() instead
-    [[deprecated("use decodedData() instead")]]
-    void* getDecodedData() noexcept {
-        return decodedData();
-    }
-
     /// Get pointer to the decoded data.
     /// Returns `nullptr` if the ExtensionObject is not decoded.
     /// @warning Type erased version, use with caution.
@@ -2192,6 +2206,12 @@ public:
         return isDecoded()
             ? handle()->content.decoded.data  // NOLINT
             : nullptr;
+    }
+
+    /// @deprecated Use decodedData() instead
+    [[deprecated("use decodedData() instead")]]
+    void* getDecodedData() noexcept {
+        return decodedData();
     }
 
     /// @deprecated Use decodedData() instead

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -1165,8 +1165,8 @@ public:
 
     /// @deprecated Use new universal Variant constructor instead
     template <VariantPolicy Policy = VariantPolicy::Copy, typename T, typename... Args>
-    [[deprecated("use new universal Variant constructor instead")]] [[nodiscard]] static Variant
-    fromScalar(T&& value, Args&&... args) {
+    [[deprecated("use new universal Variant constructor instead")]] [[nodiscard]]
+    static Variant fromScalar(T&& value, Args&&... args) {
         if constexpr (Policy == VariantPolicy::Copy) {
             return Variant{std::forward<T>(value), std::forward<Args>(args)...};
         } else {
@@ -1176,8 +1176,8 @@ public:
 
     /// @deprecated Use new universal Variant constructor instead
     template <VariantPolicy Policy = VariantPolicy::Copy, typename T, typename... Args>
-    [[deprecated("use new universal Variant constructor instead")]] [[nodiscard]] static Variant
-    fromArray(T&& array, Args&&... args) {
+    [[deprecated("use new universal Variant constructor instead")]] [[nodiscard]]
+    static Variant fromArray(T&& array, Args&&... args) {
         if constexpr (Policy == VariantPolicy::Copy) {
             return Variant{std::forward<T>(array), std::forward<Args>(args)...};
         } else {
@@ -1187,8 +1187,8 @@ public:
 
     /// @deprecated Use new universal Variant constructor instead
     template <VariantPolicy Policy = VariantPolicy::Copy, typename InputIt, typename... Args>
-    [[deprecated("use new universal Variant constructor instead")]] [[nodiscard]] static Variant
-    fromArray(InputIt first, InputIt last, Args&&... args) {
+    [[deprecated("use new universal Variant constructor instead")]] [[nodiscard]]
+    static Variant fromArray(InputIt first, InputIt last, Args&&... args) {
         return Variant{first, last, std::forward<Args>(args)...};
     }
 
@@ -1806,9 +1806,8 @@ public:
     /// @deprecated Use constructor with new universal Variant constructor instead:
     ///             `opcua::DataValue dv(opcua::Variant(value))`
     template <VariantPolicy Policy = VariantPolicy::Copy, typename... Args>
-    [[deprecated("use constructor with new universal Variant constructor instead"
-    )]] [[nodiscard]] static DataValue
-    fromScalar(Args&&... args) {
+    [[deprecated("use constructor with new universal Variant constructor instead")]] [[nodiscard]]
+    static DataValue fromScalar(Args&&... args) {
         return DataValue(Variant::fromScalar<Policy>(std::forward<Args>(args)...));
     }
 
@@ -1817,9 +1816,8 @@ public:
     /// @deprecated Use constructor with new universal Variant constructor instead:
     ///             `opcua::DataValue dv(opcua::Variant(array))`
     template <VariantPolicy Policy = VariantPolicy::Copy, typename... Args>
-    [[deprecated("use constructor with new universal Variant constructor instead"
-    )]] [[nodiscard]] static DataValue
-    fromArray(Args&&... args) {
+    [[deprecated("use constructor with new universal Variant constructor instead")]] [[nodiscard]]
+    static DataValue fromArray(Args&&... args) {
         return DataValue(Variant::fromArray<Policy>(std::forward<Args>(args)...));
     }
 
@@ -2074,13 +2072,17 @@ public:
         handle()->content.decoded.data = ptr.release();  // NOLINT
     }
 
+    /// @deprecated Use new universal ExtensionObject constructor instead
     template <typename T, typename... Args>
-    [[nodiscard]] static ExtensionObject fromDecoded(T& data, Args&&... args) noexcept {
+    [[deprecated("use new universal ExtensionObject constructor instead")]] [[nodiscard]]
+    static ExtensionObject fromDecoded(T& data, Args&&... args) noexcept {
         return ExtensionObject(&data, std::forward<Args>(args)...);
     }
 
+    /// @deprecated Use new universal ExtensionObject constructor instead
     template <typename T, typename... Args>
-    [[nodiscard]] static ExtensionObject fromDecodedCopy(const T& data, Args&&... args) {
+    [[deprecated("use new universal ExtensionObject constructor instead")]] [[nodiscard]]
+    static ExtensionObject fromDecodedCopy(const T& data, Args&&... args) {
         return ExtensionObject(data, std::forward<Args>(args)...);
     }
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -118,7 +118,7 @@ void ClientConfig::setTimeout(uint32_t milliseconds) noexcept {
 
 template <typename T>
 static void setUserIdentityTokenHelper(UA_ClientConfig& config, const T& token) {
-    asWrapper<ExtensionObject>(config.userIdentityToken) = ExtensionObject::fromDecodedCopy(token);
+    asWrapper<ExtensionObject>(config.userIdentityToken) = ExtensionObject(token);
 }
 
 void ClientConfig::setUserIdentityToken(const AnonymousIdentityToken& token) {

--- a/src/ua_types.cpp
+++ b/src/ua_types.cpp
@@ -22,9 +22,7 @@ ContentFilterElement::ContentFilterElement(
         operands.end(),
         asWrapper<ExtensionObject>(handle()->filterOperands),
         [](auto&& variant) {
-            return std::visit(
-                [](auto&& operand) { return ExtensionObject::fromDecodedCopy(operand); }, variant
-            );
+            return std::visit([](auto&& operand) { return ExtensionObject(operand); }, variant);
         }
     );
 }

--- a/tests/plugin_accesscontrol.cpp
+++ b/tests/plugin_accesscontrol.cpp
@@ -50,7 +50,7 @@ TEST_CASE("AccessControlDefault") {
             SUBCASE("Unknown token") {
                 IssuedIdentityToken token;
                 CHECK_EQ(
-                    activateSessionWithToken(ExtensionObject::fromDecoded(token)),
+                    activateSessionWithToken(ExtensionObject(token)),
                     UA_STATUSCODE_BADIDENTITYTOKENINVALID
                 );
             }
@@ -59,7 +59,7 @@ TEST_CASE("AccessControlDefault") {
                 AnonymousIdentityToken token;
                 token.policyId() = String("open62541-anonymous-policy");
                 CHECK_EQ(
-                    activateSessionWithToken(ExtensionObject::fromDecoded(token)),
+                    activateSessionWithToken(ExtensionObject(token)),
                     allowAnonymous ? UA_STATUSCODE_GOOD : UA_STATUSCODE_BADIDENTITYTOKENINVALID
                 );
             }
@@ -67,26 +67,26 @@ TEST_CASE("AccessControlDefault") {
             SUBCASE("Username and password") {
                 UserNameIdentityToken token;
                 CHECK_EQ(
-                    activateSessionWithToken(ExtensionObject::fromDecoded(token)),
+                    activateSessionWithToken(ExtensionObject(token)),
                     UA_STATUSCODE_BADIDENTITYTOKENINVALID
                 );
 
                 token.policyId() = String("open62541-username-policy");
                 CHECK_EQ(
-                    activateSessionWithToken(ExtensionObject::fromDecoded(token)),
+                    activateSessionWithToken(ExtensionObject(token)),
                     UA_STATUSCODE_BADIDENTITYTOKENINVALID
                 );
 
                 token.userName() = String("username");
                 token.password() = ByteString("wrongpassword");
                 CHECK_EQ(
-                    activateSessionWithToken(ExtensionObject::fromDecoded(token)),
+                    activateSessionWithToken(ExtensionObject(token)),
                     UA_STATUSCODE_BADUSERACCESSDENIED
                 );
 
                 token.password() = ByteString("password");
                 CHECK_EQ(
-                    activateSessionWithToken(ExtensionObject::fromDecoded(token)),
+                    activateSessionWithToken(ExtensionObject(token)),
                     UA_STATUSCODE_GOOD
                 );
             }

--- a/tests/services_monitoreditem.cpp
+++ b/tests/services_monitoreditem.cpp
@@ -106,7 +106,7 @@ TEST_CASE_TEMPLATE("MonitoredItem service set", T, Client, Async<Client>) {
             // where clause
             {}
         );
-        monitoringParameters.filter = ExtensionObject::fromDecodedCopy(eventFilter);
+        monitoringParameters.filter = ExtensionObject(eventFilter);
 
         size_t notificationCount = 0;
         size_t eventFieldsSize = 0;

--- a/tests/types_builtin.cpp
+++ b/tests/types_builtin.cpp
@@ -981,14 +981,20 @@ TEST_CASE("ExtensionObject") {
         CHECK(obj.decodedData() == nullptr);
     }
 
-    SUBCASE("fromDecoded") {
+    SUBCASE("From nullptr") {
+        int* value{nullptr};
+        ExtensionObject obj(value);
+        CHECK(obj.empty());
+    }
+
+    SUBCASE("From decoded (pointer)") {
         ExtensionObject obj;
         String value("test123");
         SUBCASE("Deduce data type") {
-            obj = ExtensionObject::fromDecoded(value);
+            obj = ExtensionObject(&value);
         }
         SUBCASE("Custom data type") {
-            obj = ExtensionObject::fromDecoded(value, UA_TYPES[UA_TYPES_STRING]);
+            obj = ExtensionObject(&value, UA_TYPES[UA_TYPES_STRING]);
         }
         CHECK(obj.encoding() == ExtensionObjectEncoding::DecodedNoDelete);
         CHECK(obj.isDecoded());
@@ -996,25 +1002,26 @@ TEST_CASE("ExtensionObject") {
         CHECK(obj.decodedData() == value.handle());
     }
 
-    SUBCASE("fromDecodedCopy") {
+    SUBCASE("From decoded (copy)") {
         ExtensionObject obj;
         const auto value = Variant(11.11);
         SUBCASE("Deduce data type") {
-            obj = ExtensionObject::fromDecodedCopy(value);
+            obj = ExtensionObject(value);
         }
         SUBCASE("Custom data type") {
-            obj = ExtensionObject::fromDecodedCopy(value, UA_TYPES[UA_TYPES_VARIANT]);
+            obj = ExtensionObject(value, UA_TYPES[UA_TYPES_VARIANT]);
         }
         CHECK(obj.encoding() == ExtensionObjectEncoding::Decoded);
         CHECK(obj.isDecoded());
         CHECK(obj.decodedType() == &UA_TYPES[UA_TYPES_VARIANT]);
+        CHECK(obj.decodedData() != nullptr);
         CHECK(obj.decodedData<Variant>() != nullptr);
         CHECK(obj.decodedData<Variant>()->scalar<double>() == 11.11);
     }
 
     SUBCASE("decodedData") {
         double value = 11.11;
-        auto obj = ExtensionObject::fromDecoded(value);
+        ExtensionObject obj(&value);
         CHECK(obj.decodedData() == &value);
         CHECK(obj.decodedData<int>() == nullptr);
         CHECK(obj.decodedData<double>() == &value);

--- a/tests/ua_types.cpp
+++ b/tests/ua_types.cpp
@@ -111,7 +111,7 @@ TEST_CASE("AddNodesItem / AddNodesRequest") {
         ExpandedNodeId({1, 1002}),
         {1, "item"},
         NodeClass::Object,
-        ExtensionObject::fromDecodedCopy(ObjectAttributes{}),
+        ExtensionObject(ObjectAttributes{}),
         ExpandedNodeId({1, 1003})
     );
     CHECK(item.parentNodeId().nodeId() == NodeId(1, 1000));


### PR DESCRIPTION
Add universal `ExtensionObject` constructors that replace the factory functions `fromDecoded`/`fromDecodedCopy`.
It uses the same approach as in #497 with pointer semantics to distinguish between owning and non-owning storage mechanisms:

```cpp
opcua::String str("test");

// Old way
auto obj1 = opcua::ExtensionObject::fromDecoded(str);      // No copy
auto obj2 = opcua::ExtensionObject::fromDecodedCopy(str);  // Copy

// New way
opcua::ExtensionObject obj3(&str);  // No copy
opcua::ExtensionObject obj4(str);   // Copy
```

The factory functions `ExtensionObject::fromDecoded` and `ExtensionObject::fromDecodedCopy` are marked deprecated now and will be removed in the future.