### PR TITLE
feat: String/XmlElement assignment operator for const char* and string_view

### DIFF
--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -269,6 +269,19 @@ public:
         init(values.begin(), values.end());
     }
 
+    /// Assign null-termined character string.
+    String& operator=(const char* str) {
+        *this = String(str);
+        return *this;
+    }
+
+    /// Assign std::string_view.
+    template <typename Traits>
+    String& operator=(std::basic_string_view<char, Traits> str) {
+        *this = String(str);
+        return *this;
+    }
+
     /// Implicit conversion to std::string_view.
     template <typename Traits>
     operator std::basic_string_view<char, Traits>() const noexcept {  // NOLINT(*-conversions)
@@ -579,6 +592,19 @@ public:
     template <typename InputIt>
     XmlElement(InputIt first, InputIt last) {
         init(first, last);
+    }
+
+    /// Assign null-termined character string.
+    XmlElement& operator=(const char* str) {
+        *this = XmlElement(str);
+        return *this;
+    }
+
+    /// Assign std::string_view.
+    template <typename Traits>
+    XmlElement& operator=(std::basic_string_view<char, Traits> str) {
+        *this = XmlElement(str);
+        return *this;
     }
 
     /// Implicit conversion to std::string_view.

--- a/tests/types_builtin.cpp
+++ b/tests/types_builtin.cpp
@@ -169,6 +169,18 @@ TEST_CASE_TEMPLATE("StringLike constructors", T, String, XmlElement) {
     }
 }
 
+TEST_CASE_TEMPLATE("StringLike assign const char*", T, String, XmlElement) {
+    T str;
+    str = "test123";
+    CHECK(str == T{"test123"});
+}
+
+TEST_CASE_TEMPLATE("StringLike assign string_view", T, String, XmlElement) {
+    T str;
+    str = std::string_view{"test123"};
+    CHECK(str == T{"test123"});
+}
+
 TEST_CASE_TEMPLATE("StringLike implicit conversion to string_view", T, String, XmlElement) {
     T str("test123");
     std::string_view view = str;


### PR DESCRIPTION
Add assignment operators for `String` and `XmlElement` to assign string literals (`const char*`) and `std::string_view` (or anything that is convertible to, e.g. `std::string`).

```cpp
opcua::String str;
str = "test123";
str = std::string_view("test123");
str = std::string("test123");
```