### PR TITLE
test: increase robustness of tests using `runIterate`

### DIFF
--- a/tests/helper/server_client_setup.hpp
+++ b/tests/helper/server_client_setup.hpp
@@ -46,12 +46,13 @@ bool runIterateUntil(
     const auto now = [] { return std::chrono::steady_clock::now(); };
     const auto startTime = now();
 
-    while (!predicate()) {
+    do {
         connection.runIterate();
-        if ((now() - startTime) > std::chrono::milliseconds(timeoutMilliseconds)) {
-            INFO("Timeout during runIterateUntil");
-            break;
+        if (predicate()) {
+            return true;
         }
-    }
-    return predicate();
+    } while ((now() - startTime) <= std::chrono::milliseconds(timeoutMilliseconds));
+
+    INFO("Timeout during runIterateUntil");
+    return false;
 }

--- a/tests/helper/server_client_setup.hpp
+++ b/tests/helper/server_client_setup.hpp
@@ -50,8 +50,8 @@ bool runIterateUntil(
         connection.runIterate();
         if ((now() - startTime) > std::chrono::milliseconds(timeoutMilliseconds)) {
             INFO("Timeout during runIterateUntil");
-            break;
+            return false;
         }
     }
-    return predicate();
+    return true;
 }

--- a/tests/helper/server_client_setup.hpp
+++ b/tests/helper/server_client_setup.hpp
@@ -50,8 +50,8 @@ bool runIterateUntil(
         connection.runIterate();
         if ((now() - startTime) > std::chrono::milliseconds(timeoutMilliseconds)) {
             INFO("Timeout during runIterateUntil");
-            return false;
+            break;
         }
     }
-    return true;
+    return predicate();
 }

--- a/tests/helper/server_client_setup.hpp
+++ b/tests/helper/server_client_setup.hpp
@@ -36,14 +36,14 @@ struct ServerClientSetup {
     static constexpr std::string_view endpointUrl = "opc.tcp://localhost:4840";
 };
 
-// Call the connection's runIterate function until either condition or a timeout occurred.
+// Call the connection's runIterate function until predicate returns `true` or a timeout occurs.
 template <typename Connection, typename UnaryPred>
 bool runIterateUntil(
     Connection& connection, UnaryPred predicate, uint16_t timeoutMilliseconds = 1000
 ) {
     static_assert(std::is_same_v<std::invoke_result_t<UnaryPred>, bool>);
 
-    const auto now = [] { return std::chrono::system_clock::now(); };
+    const auto now = [] { return std::chrono::steady_clock::now(); };
     const auto startTime = now();
 
     while (!predicate()) {

--- a/tests/services_monitoreditem.cpp
+++ b/tests/services_monitoreditem.cpp
@@ -270,9 +270,7 @@ TEST_CASE_TEMPLATE("MonitoredItem service set", T, Client, Async<Client>) {
         CHECK(response.addResults().size() == 1);
         CHECK(response.addResults()[0].isGood());
 
-        CHECK(runIterateUntil(setup.client, [&]() {
-                  return notificationCount > 0;
-              }) == ConditionStatus::occurred);
+        CHECK(runIterateUntil(setup.client, [&] { return notificationCount > 0; }));
     }
 #endif
 

--- a/tests/services_monitoreditem.cpp
+++ b/tests/services_monitoreditem.cpp
@@ -270,11 +270,9 @@ TEST_CASE_TEMPLATE("MonitoredItem service set", T, Client, Async<Client>) {
         CHECK(response.addResults().size() == 1);
         CHECK(response.addResults()[0].isGood());
 
-        setup.client.runIterate();
-#if UAPP_OPEN62541_VER_LE(1, 3)
-        // TODO: fails with v1.4, why?
-        CHECK(notificationCount > 0);
-#endif
+        CHECK(runIterateUntil(setup.client, [&]() {
+                  return notificationCount > 0;
+              }) == ConditionStatus::occurred);
     }
 #endif
 

--- a/tests/services_monitoreditem.cpp
+++ b/tests/services_monitoreditem.cpp
@@ -89,8 +89,7 @@ TEST_CASE_TEMPLATE("MonitoredItem service set", T, Client, Async<Client>) {
         CAPTURE(result.monitoredItemId());
 
         services::writeValue(server, id, Variant(11.11)).throwIfBad();
-        setup.client.runIterate();
-        CHECK(notificationCount > 0);
+        CHECK(runIterateUntil(setup.client, [&] { return notificationCount > 0; }));
         CHECK(changedValue.value().scalar<double>() == 11.11);
     }
 
@@ -141,8 +140,7 @@ TEST_CASE_TEMPLATE("MonitoredItem service set", T, Client, Async<Client>) {
         Event event(server);
         event.writeTime(DateTime::now());
         event.trigger();
-        setup.client.runIterate();
-        CHECK(notificationCount == 1);
+        CHECK(runIterateUntil(setup.client, [&] { return notificationCount == 1; }));
         CHECK(eventFieldsSize == 3);
     }
 #endif
@@ -243,8 +241,7 @@ TEST_CASE_TEMPLATE("MonitoredItem service set", T, Client, Async<Client>) {
                 .monitoredItemId();
         CAPTURE(monId);
 
-        setup.client.runIterate();
-        CHECK(notificationCountTriggering > 0);
+        CHECK(runIterateUntil(setup.client, [&] { return notificationCountTriggering > 0; }));
         CHECK(notificationCount == 0);  // no triggering links yet
 
         const auto setTriggering = [&](auto&&... args) {
@@ -305,8 +302,7 @@ TEST_CASE_TEMPLATE("MonitoredItem service set", T, Client, Async<Client>) {
         };
         const StatusCode result = deleteMonitoredItem(connection, subId, monId);
         CHECK(result.isGood());
-        setup.client.runIterate();
-        CHECK(deleted == true);
+        CHECK(runIterateUntil(setup.client, [&] { return deleted == true; }));
     }
 }
 
@@ -342,8 +338,7 @@ TEST_CASE("MonitoredItem service set (server)") {
         CAPTURE(monId);
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
         services::writeValue(server, id, Variant(11.11)).throwIfBad();
-        server.runIterate();
-        CHECK(notificationCount > 0);
+        CHECK(runIterateUntil(server, [&] { return notificationCount > 0; }));
     }
 
     SUBCASE("deleteMonitoredItem") {

--- a/tests/subscription_monitoreditem.cpp
+++ b/tests/subscription_monitoreditem.cpp
@@ -125,9 +125,7 @@ TEST_CASE("Subscription & MonitoredItem (client)") {
         CHECK(notificationCount == 0);
 
         mon.setMonitoringMode(MonitoringMode::Reporting);  // now we should get a notification
-        CHECK(runIterateUntil(client, [&]() {
-                  return notificationCount > 0;
-              }) == ConditionStatus::occurred);
+        CHECK(runIterateUntil(client, [&] { return notificationCount > 0; }));
 
         mon.deleteMonitoredItem();
         CHECK_THROWS_WITH(mon.deleteMonitoredItem(), "BadMonitoredItemIdInvalid");

--- a/tests/subscription_monitoreditem.cpp
+++ b/tests/subscription_monitoreditem.cpp
@@ -125,11 +125,9 @@ TEST_CASE("Subscription & MonitoredItem (client)") {
         CHECK(notificationCount == 0);
 
         mon.setMonitoringMode(MonitoringMode::Reporting);  // now we should get a notification
-        client.runIterate();
-#if UAPP_OPEN62541_VER_LE(1, 3)
-        // TODO: fails sporadically with v1.4, why?
-        CHECK(notificationCount > 0);
-#endif
+        CHECK(runIterateUntil(client, [&]() {
+                  return notificationCount > 0;
+              }) == ConditionStatus::occurred);
 
         mon.deleteMonitoredItem();
         CHECK_THROWS_WITH(mon.deleteMonitoredItem(), "BadMonitoredItemIdInvalid");

--- a/tests/subscription_monitoreditem.cpp
+++ b/tests/subscription_monitoreditem.cpp
@@ -1,6 +1,3 @@
-#include <chrono>
-#include <thread>
-
 #include <doctest/doctest.h>
 
 #include "open62541pp/client.hpp"
@@ -47,9 +44,7 @@ TEST_CASE("Subscription & MonitoredItem (server)") {
         );
         CHECK(sub.monitoredItems().size() == 1);
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(200));
-        server.runIterate();
-        CHECK(notificationCount > 0);
+        CHECK(runIterateUntil(server, [&] { return notificationCount > 0; }));
 
         mon.deleteMonitoredItem();
         CHECK(sub.monitoredItems().empty());


### PR DESCRIPTION
Introduce a helper function that keeps calling a client's or server's `runIterate` function until a condition or a timeout occurs.

Draft status with demo code related to https://github.com/open62541pp/open62541pp/issues/511