### PR TITLE
feat: mark Result class as nodiscard

### DIFF
--- a/include/open62541pp/result.hpp
+++ b/include/open62541pp/result.hpp
@@ -50,7 +50,7 @@ private:
  * - [Swift's `Result` enumeration](https://developer.apple.com/documentation/swift/result)
  */
 template <typename T>
-class Result {
+class [[nodiscard]] Result {
 public:
     using ValueType = T;
 
@@ -339,7 +339,7 @@ private:
  * Result<void> contains only a StatusCode.
  */
 template <>
-class Result<void> {
+class [[nodiscard]] Result<void> {
 public:
     /**
      * Create a default Result (good StatusCode).

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -340,9 +340,9 @@ static void valueCallbackOnRead(
     const UA_DataValue* value
 ) noexcept {
     assert(nodeContext != nullptr && value != nullptr);
-    auto& cb = static_cast<detail::NodeContext*>(nodeContext)->valueCallback.onBeforeRead;
-    if (cb) {
-        detail::tryInvoke([&] { cb(asWrapper<DataValue>(*value)); });
+    auto& callback = static_cast<detail::NodeContext*>(nodeContext)->valueCallback.onBeforeRead;
+    if (callback) {
+        [[maybe_unused]] auto result = detail::tryInvoke(callback, asWrapper<DataValue>(*value));
     }
 }
 
@@ -356,9 +356,9 @@ static void valueCallbackOnWrite(
     const UA_DataValue* value
 ) noexcept {
     assert(nodeContext != nullptr && value != nullptr);
-    auto& cb = static_cast<detail::NodeContext*>(nodeContext)->valueCallback.onAfterWrite;
-    if (cb) {
-        detail::tryInvoke([&] { cb(asWrapper<DataValue>(*value)); });
+    auto& callback = static_cast<detail::NodeContext*>(nodeContext)->valueCallback.onAfterWrite;
+    if (callback) {
+        [[maybe_unused]] auto result = detail::tryInvoke(callback, asWrapper<DataValue>(*value));
     }
 }
 


### PR DESCRIPTION
Arthur O’Dwyer convinced me with his excellent blog post:
https://quuxplusone.github.io/blog/2024/12/08/should-expected-be-nodiscard/

> Discarding a result is usually OK. Discarding an error, on the other hand, can be very bad, and should always be done explicitly!