### PR TITLE
feat!: pass optional range as pointer to DataSource functions

### DIFF
--- a/examples/server_datasource.cpp
+++ b/examples/server_datasource.cpp
@@ -26,7 +26,7 @@ int main() {
     // Define data source with its read and write callbacks
     opcua::ValueBackendDataSource dataSource;
     dataSource.read =
-        [&](const opcua::NodeId&, opcua::DataValue& dv, const opcua::NumericRange&, bool timestamp) {
+        [&](const opcua::NodeId&, opcua::DataValue& dv, const opcua::NumericRange*, bool timestamp) {
             // Increment counter before every read
             counter++;
             dv.value() = counter;
@@ -37,7 +37,7 @@ int main() {
             return UA_STATUSCODE_GOOD;
         };
     dataSource.write =
-        [&](const opcua::NodeId&, const opcua::DataValue& dv, const opcua::NumericRange&) {
+        [&](const opcua::NodeId&, const opcua::DataValue& dv, const opcua::NumericRange*) {
             counter = dv.value().scalar<int>();
             std::cout << "Write counter to data source: " << counter << "\n";
             return UA_STATUSCODE_GOOD;

--- a/include/open62541pp/plugin/nodestore.hpp
+++ b/include/open62541pp/plugin/nodestore.hpp
@@ -57,13 +57,13 @@ struct ValueBackendDataSource {
      *
      * @param id The identifier of the node being read from
      * @param value The DataValue that is returned to the reader
-     * @param range If not empty, then the data source shall return only a selection of the
-     *              (nonscalar) data.
-     *              Set `UA_STATUSCODE_BADINDEXRANGEINVALID` in `value` if this does not apply
+     * @param range If not `nullptr`, then the data source shall return only a selection of the
+     *              (non-scalar) data.
+     *              Set `UA_STATUSCODE_BADINDEXRANGEINVALID` in `value` if this does not apply.
      * @param timestamp Set the source timestamp of `value` if `true`
      * @return StatusCode
      */
-    std::function<StatusCode(const NodeId& id, DataValue& value, const NumericRange& range, bool timestamp)> read;
+    std::function<StatusCode(const NodeId& id, DataValue& value, const NumericRange* range, bool timestamp)> read;
 
     /**
      * Callback to write the value into a data source.
@@ -71,11 +71,11 @@ struct ValueBackendDataSource {
      *
      * @param id The identifier of the node being written to
      * @param value The DataValue that has been written by the writer
-     * @param range If not empty, then only this selection of (non-scalar) data should be written
-     *              into the data source
+     * @param range If not `nullptr`, then only this selection of (non-scalar) data should be
+     *              written into the data source.
      * @return StatusCode
      */
-    std::function<StatusCode(const NodeId& id, const DataValue& value, const NumericRange& range)> write;
+    std::function<StatusCode(const NodeId& id, const DataValue& value, const NumericRange* range)> write;
 };
 
 }  // namespace opcua

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -377,10 +377,6 @@ void Server::setVariableNodeValueCallback(const NodeId& id, ValueCallback callba
     throwIfBad(UA_Server_setVariableNode_valueCallback(handle(), id, callbackNative));
 }
 
-static NumericRange asRange(const UA_NumericRange* range) noexcept {
-    return range == nullptr ? NumericRange() : NumericRange(*range);
-}
-
 static UA_StatusCode valueSourceRead(
     [[maybe_unused]] UA_Server* server,
     [[maybe_unused]] const UA_NodeId* sessionId,
@@ -398,7 +394,7 @@ static UA_StatusCode valueSourceRead(
             callback,
             asWrapper<NodeId>(*nodeId),
             asWrapper<DataValue>(*value),
-            asRange(range),
+            asWrapper<NumericRange>(range),
             includeSourceTimestamp
         );
         return result.code();
@@ -419,7 +415,10 @@ static UA_StatusCode valueSourceWrite(
     auto& callback = static_cast<detail::NodeContext*>(nodeContext)->dataSource.write;
     if (callback) {
         auto result = detail::tryInvoke(
-            callback, asWrapper<NodeId>(*nodeId), asWrapper<DataValue>(*value), asRange(range)
+            callback,
+            asWrapper<NodeId>(*nodeId),
+            asWrapper<DataValue>(*value),
+            asWrapper<NumericRange>(range)
         );
         return result.code();
     }

--- a/tests/server.cpp
+++ b/tests/server.cpp
@@ -206,14 +206,14 @@ TEST_CASE("DataSource") {
 
     ValueBackendDataSource dataSource;
     dataSource.read =
-        [&](const NodeId&, DataValue& dv, const NumericRange&, bool includeSourceTimestamp) {
+        [&](const NodeId&, DataValue& dv, const NumericRange*, bool includeSourceTimestamp) {
             dv.value() = data;
             if (includeSourceTimestamp) {
                 dv.setSourceTimestamp(DateTime::now());
             }
             return UA_STATUSCODE_GOOD;
         };
-    dataSource.write = [&](const NodeId&, const DataValue& dv, const NumericRange&) {
+    dataSource.write = [&](const NodeId&, const DataValue& dv, const NumericRange*) {
         data = dv.value().scalar<int>();
         return UA_STATUSCODE_GOOD;
     };
@@ -244,7 +244,7 @@ TEST_CASE("DataSource with exception in callback") {
 
     SUBCASE("BadStatus exception") {
         ValueBackendDataSource dataSource;
-        dataSource.read = [&](const NodeId&, DataValue&, const NumericRange&, bool) -> StatusCode {
+        dataSource.read = [&](const NodeId&, DataValue&, const NumericRange*, bool) -> StatusCode {
             throw BadStatus(UA_STATUSCODE_BADUNEXPECTEDERROR);
         };
         server.setVariableNodeValueBackend(id, dataSource);
@@ -254,7 +254,7 @@ TEST_CASE("DataSource with exception in callback") {
 
     SUBCASE("Other exception types") {
         ValueBackendDataSource dataSource;
-        dataSource.read = [&](const NodeId&, DataValue&, const NumericRange&, bool) -> StatusCode {
+        dataSource.read = [&](const NodeId&, DataValue&, const NumericRange*, bool) -> StatusCode {
             throw std::runtime_error("test");
         };
         server.setVariableNodeValueBackend(id, dataSource);


### PR DESCRIPTION
The parameter range is optional, therefore it should be passed by pointer, not by reference.
As discussed in #515.