### PR TITLE
fix!: Avoid redefinition of NOMINMAX macro for Windows systems

### DIFF
--- a/include/open62541pp/detail/open62541/push_options.h
+++ b/include/open62541pp/detail/open62541/push_options.h
@@ -14,6 +14,8 @@
 #endif
 
 #ifdef _WIN32
+#ifndef NOMINMAX
 // don't define min/max macros, that break the STL
 #define NOMINMAX
+#endif
 #endif


### PR DESCRIPTION
If open62541pp is imported in a project which relies on such a macro, and it is not the first header to be imported, STL code may break.

If `NOMINMAX` is defined globally, then redefinition warning may be raised.
For instance with Visual Studio 2022 with MSVC compiler the following warning appears:
`warning C4005: 'NOMINMAX': macro redefinition`