### PR TITLE
add session and node id parameter to methodCallback functions

### DIFF
--- a/include/open62541pp/detail/server_context.hpp
+++ b/include/open62541pp/detail/server_context.hpp
@@ -17,6 +17,7 @@
 #include "open62541pp/services/detail/monitoreditem_context.hpp"
 #include "open62541pp/types.hpp"  // NodeId, Variant
 #include "open62541pp/ua/types.hpp"  // IntegerId
+#include "open62541pp/services/nodemanagement.hpp"
 
 namespace opcua::detail {
 
@@ -24,7 +25,7 @@ struct NodeContext {
     ValueCallbackBase* valueCallback{nullptr};
     ValueBackendDataSource dataSource;
 #ifdef UA_ENABLE_METHODCALLS
-    std::function<void(Span<const Variant> input, Span<Variant> output)> methodCallback;
+    opcua::services::MethodCallback methodCallback;
 #endif
 };
 

--- a/include/open62541pp/services/nodemanagement.hpp
+++ b/include/open62541pp/services/nodemanagement.hpp
@@ -18,6 +18,7 @@
 #include "open62541pp/types.hpp"
 #include "open62541pp/ua/nodeids.hpp"  // *TypeId
 #include "open62541pp/ua/types.hpp"
+#include "open62541pp/session.hpp"
 
 namespace opcua {
 class Client;
@@ -570,7 +571,7 @@ auto addPropertyAsync(
  * @param input Input parameters
  * @param output Output parameters
  */
-using MethodCallback = std::function<void(Span<const Variant> input, Span<Variant> output)>;
+using MethodCallback = std::function<void(Session& session, const NodeId& methodID, Span<const Variant> input, Span<Variant> output)>;
 
 /**
  * Add method.


### PR DESCRIPTION
Recently, we found that in many scenarios, it is necessary to obtain the context information of the method node, such as obtaining the value of the corresponding variable of the object node, so we added session and node ID information to the methodcallback function.