### PR TITLE
fix: undefined behavior in array handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           - name: Linux GCC 14
             os: ubuntu-24.04
             compiler: g++-14
-            coverage: true
+            coverage: false # TODO: gcovr processing errors
             gcov: gcov-14
 
           - name: Linux Clang 13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Result` constructor with value and bad status code (#460)
 - Thread-safe session registry (#486)
 - Avoid redefinition of `NOMINMAX` macro for Windows systems (#523)
+- Fix undefined behavior in `detail::copyArray` (#532)
 
 ## [0.16.0] - 2024-11-13
 

--- a/include/open62541pp/detail/types_handling.hpp
+++ b/include/open62541pp/detail/types_handling.hpp
@@ -168,6 +168,9 @@ template <typename T>
 template <typename T>
 [[nodiscard]] T* copyArray(const T* src, size_t size) {
     T* dst = allocateArray<T>(size);
+    if (src == nullptr) {
+        return dst;
+    }
     std::memcpy(dst, src, size * sizeof(T));
     return dst;
 }
@@ -175,6 +178,9 @@ template <typename T>
 template <typename T>
 [[nodiscard]] T* copyArray(const T* src, size_t size, const UA_DataType& type) {
     T* dst = allocateArray<T>(size, type);
+    if (src == nullptr) {
+        return dst;
+    }
     if constexpr (!isPointerFree<T>) {
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         std::transform(src, src + size, dst, [&](const T& item) { return copy(item, type); });
@@ -186,7 +192,7 @@ template <typename T>
 
 template <typename T>
 void resizeArray(T*& array, size_t& size, size_t newSize, const UA_DataType& type) {
-    if (newSize == size) {
+    if (array == nullptr || newSize == size) {
         return;
     }
     T* newArray = allocateArray<T>(newSize, type);

--- a/tests/types_handling.cpp
+++ b/tests/types_handling.cpp
@@ -58,6 +58,12 @@ TEST_CASE("Array handling") {
     }
 
     SUBCASE("Copy") {
+        SUBCASE("Empty array") {
+            UA_Int32* src = nullptr;
+            CHECK(detail::copyArray(src, 0) == UA_EMPTY_ARRAY_SENTINEL);
+            CHECK(detail::copyArray(src, 0, UA_TYPES[UA_TYPES_INT32]) == UA_EMPTY_ARRAY_SENTINEL);
+        }
+
         SUBCASE("Without pointers") {
             const size_t size = 2;
             const auto& type = UA_TYPES[UA_TYPES_INT32];


### PR DESCRIPTION
Fix undefined behavior in `detail::copyArray` with `src = nullptr` passed to `std::memcpy`.