### PR TITLE
feat!: create Subscription via constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Universal `ExtensionObject` constructor (#504)
 - `ValueCallback` as abstract base class (#522)
 - `DataSource` as abstract base class (#525)
+- Create `Subscription` via constructor (#533)
 
 ### Fixed
 

--- a/examples/client_subscription.cpp
+++ b/examples/client_subscription.cpp
@@ -12,7 +12,7 @@ int main() {
     // items are deleted. This approach with the state callback assures, that the subscriptions are
     // recreated whenever the client reconnects to the server.
     client.onSessionActivated([&] {
-        auto sub = client.createSubscription();
+        opcua::Subscription sub(client);
 
         // Modify and delete the subscription via the returned Subscription<T> object
         opcua::SubscriptionParameters subscriptionParameters{};

--- a/examples/client_subscription.cpp
+++ b/examples/client_subscription.cpp
@@ -3,6 +3,7 @@
 #include <thread>
 
 #include <open62541pp/client.hpp>
+#include <open62541pp/subscription.hpp>
 
 int main() {
     opcua::Client client;

--- a/examples/events/client_eventfilter.cpp
+++ b/examples/events/client_eventfilter.cpp
@@ -5,6 +5,7 @@
 
 #include <open62541pp/client.hpp>
 #include <open62541pp/node.hpp>
+#include <open62541pp/subscription.hpp>
 
 int main() {
     opcua::Client client;

--- a/examples/events/client_eventfilter.cpp
+++ b/examples/events/client_eventfilter.cpp
@@ -42,7 +42,7 @@ int main() {
         filterCombined
     );
 
-    auto sub = client.createSubscription();
+    opcua::Subscription sub(client);
     sub.subscribeEvent(
         opcua::ObjectId::Server,
         eventFilter,

--- a/include/open62541pp/client.hpp
+++ b/include/open62541pp/client.hpp
@@ -13,7 +13,7 @@
 #include "open62541pp/detail/client_utils.hpp"
 #include "open62541pp/detail/open62541/client.h"
 #include "open62541pp/span.hpp"
-#include "open62541pp/subscription.hpp"
+#include "open62541pp/subscription.hpp"  // TODO: remove with Client::createSubscription
 #include "open62541pp/types.hpp"
 #include "open62541pp/ua/types.hpp"
 #include "open62541pp/wrapper.hpp"

--- a/include/open62541pp/client.hpp
+++ b/include/open62541pp/client.hpp
@@ -253,6 +253,8 @@ public:
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
     /// Create a subscription to monitor data changes and events.
+    /// @deprecated Use Subscription constructor
+    [[deprecated("use Subscription constructor")]]
     Subscription<Client> createSubscription(const SubscriptionParameters& parameters = {});
 
     /// Get all active subscriptions

--- a/include/open62541pp/server.hpp
+++ b/include/open62541pp/server.hpp
@@ -240,6 +240,8 @@ public:
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
     /// Create a (pseudo) subscription to monitor local data changes and events.
+    /// @deprecated Use Subscription constructor
+    [[deprecated("use Subscription constructor")]]
     Subscription<Server> createSubscription() noexcept;
 #endif
 

--- a/include/open62541pp/server.hpp
+++ b/include/open62541pp/server.hpp
@@ -15,7 +15,7 @@
 #include "open62541pp/event.hpp"
 #include "open62541pp/session.hpp"
 #include "open62541pp/span.hpp"
-#include "open62541pp/subscription.hpp"
+#include "open62541pp/subscription.hpp"  // TODO: remove with Server::createSubscription
 #include "open62541pp/types.hpp"
 #include "open62541pp/ua/nodeids.hpp"
 #include "open62541pp/wrapper.hpp"

--- a/include/open62541pp/subscription.hpp
+++ b/include/open62541pp/subscription.hpp
@@ -41,6 +41,11 @@ using EventNotificationCallback = services::EventNotificationCallback;
 template <typename Connection>
 class Subscription {
 public:
+    /// Create a new subscription.
+    /// The subscription is not automatically deleted by the destructor.
+    /// You must delete it manually with @ref deleteSubscription or services::deleteSubscription.
+    explicit Subscription(Connection& connection, const SubscriptionParameters& parameters = {});
+
     /// Wrap an existing subscription.
     /// The `subscriptionId` is ignored and set to `0U` for servers.
     Subscription(Connection& connection, IntegerId subscriptionId) noexcept

--- a/src/subscription.cpp
+++ b/src/subscription.cpp
@@ -9,6 +9,22 @@
 
 namespace opcua {
 
+static auto createSubscription(Client& connection, const SubscriptionParameters& parameters) {
+    const auto response = services::createSubscription(connection, parameters, true, {}, {});
+    response.responseHeader().serviceResult().throwIfBad();
+    return response.subscriptionId();
+}
+
+template <>
+Subscription<Client>::Subscription(Client& connection, const SubscriptionParameters& parameters)
+    : Subscription(connection, createSubscription(connection, parameters)) {}
+
+template <>
+Subscription<Server>::Subscription(
+    Server& connection, [[maybe_unused]] const SubscriptionParameters& parameters
+)
+    : Subscription(connection, 0U) {}
+
 template <typename T>
 std::vector<MonitoredItem<T>> Subscription<T>::monitoredItems() {
     std::vector<MonitoredItem<T>> result;

--- a/tests/subscription_monitoreditem.cpp
+++ b/tests/subscription_monitoreditem.cpp
@@ -28,7 +28,8 @@ TEST_CASE("Subscription & MonitoredItem (server)") {
     }
 
     SUBCASE("Create & delete subscription") {
-        auto sub = server.createSubscription();
+        Subscription sub(server);
+        CHECK(sub.subscriptionId() == 0U);
         CHECK(sub.monitoredItems().empty());
 
         MonitoringParametersEx monitoringParameters{};
@@ -71,8 +72,8 @@ TEST_CASE("Subscription & MonitoredItem (client)") {
         CHECK(client.subscriptions().empty());
 
         const SubscriptionParameters parameters{};
-        auto sub = client.createSubscription(parameters);
-        CAPTURE(sub.subscriptionId());
+        Subscription sub(client, parameters);
+        CHECK(sub.subscriptionId() > 0U);
 
         CHECK(client.subscriptions().size() == 1);
         CHECK(client.subscriptions().at(0) == sub);
@@ -85,10 +86,11 @@ TEST_CASE("Subscription & MonitoredItem (client)") {
     }
 
     SUBCASE("Modify subscription") {
-        auto sub = client.createSubscription();
+        SubscriptionParameters parameters{};
+        Subscription sub(client, parameters);
+
         sub.setPublishingMode(false);
 
-        SubscriptionParameters parameters{};
         parameters.priority = 10;
         sub.setSubscriptionParameters(parameters);
     }
@@ -97,7 +99,7 @@ TEST_CASE("Subscription & MonitoredItem (client)") {
         const SubscriptionParameters subscriptionParameters{};
         MonitoringParametersEx monitoringParameters{};
 
-        auto sub = client.createSubscription(subscriptionParameters);
+        Subscription sub(client, subscriptionParameters);
         sub.setPublishingMode(false);  // enable later
 
         size_t notificationCount = 0;
@@ -127,7 +129,7 @@ TEST_CASE("Subscription & MonitoredItem (client)") {
     }
 
     SUBCASE("Monitor data change with multiple monitored items") {
-        auto sub = client.createSubscription();
+        Subscription sub(client);
 
         IntegerId monId1 = 0;
         auto monItem1 = sub.subscribeDataChange(
@@ -152,7 +154,7 @@ TEST_CASE("Subscription & MonitoredItem (client)") {
     }
 
     SUBCASE("Modify monitored item") {
-        auto sub = client.createSubscription();
+        Subscription sub(client);
         auto mon = sub.subscribeDataChange(
             VariableId::Server_ServerStatus_CurrentTime,
             AttributeId::Value,
@@ -168,7 +170,7 @@ TEST_CASE("Subscription & MonitoredItem (client)") {
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS_EVENTS
     SUBCASE("Monitor event") {
-        auto sub = client.createSubscription();
+        Subscription sub(client);
 
         EventFilter eventFilter(
             {


### PR DESCRIPTION
Decouple `Client`/`Server` from `Subscription` class.
Simplify subscription creation with `Subscription` constructor:

```diff
opcua::SubscriptionParameters subscriptionParameters{};
- opcua::Subscription sub = client.createSubscription(subscriptionParameters);
+ opcua::Subscription sub(client, subscriptionParameters);
```

Following functions are marked deprecated and will be removed in the future:
- `Client::createSubscription`
- `Server::createSubscription`