### PR TITLE
feat: move ownership of ValueCallback and DataSource to server

### DIFF
--- a/include/open62541pp/detail/ptr.hpp
+++ b/include/open62541pp/detail/ptr.hpp
@@ -45,7 +45,7 @@ public:
         return get();
     }
 
-    constexpr T* get() noexcept {
+    constexpr T* get() noexcept {  // NOLINT(*exception-escape)
         return std::visit(
             Overload{
                 [](T* ptr) { return ptr; },

--- a/include/open62541pp/detail/ptr.hpp
+++ b/include/open62541pp/detail/ptr.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <variant>
+
+#include "open62541pp/detail/traits.hpp"
+
+namespace opcua::detail {
+
+template <typename T>
+class UniqueOrRawPtr {
+public:
+    constexpr UniqueOrRawPtr() = default;
+
+    explicit constexpr UniqueOrRawPtr(std::unique_ptr<T>&& ptr) noexcept
+        : ptr_(std::move(ptr)) {}
+
+    explicit constexpr UniqueOrRawPtr(T* ptr) noexcept
+        : ptr_(ptr) {}
+
+    constexpr UniqueOrRawPtr& operator=(std::unique_ptr<T>&& ptr) noexcept {
+        ptr_ = std::move(ptr);
+        return *this;
+    }
+
+    constexpr UniqueOrRawPtr& operator=(T* ptr) noexcept {
+        ptr_ = ptr;
+        return *this;
+    }
+
+    constexpr T operator*() noexcept {
+        return *get();
+    }
+
+    constexpr T operator*() const noexcept {
+        return *get();
+    }
+
+    constexpr T* operator->() noexcept {
+        return get();
+    }
+
+    constexpr const T* operator->() const noexcept {
+        return get();
+    }
+
+    constexpr T* get() noexcept {
+        return std::visit(
+            Overload{
+                [](T* ptr) { return ptr; },
+                [](std::unique_ptr<T>& ptr) { return ptr.get(); },
+            },
+            ptr_
+        );
+    }
+
+    constexpr const T* get() const noexcept {
+        return (const_cast<UniqueOrRawPtr*>(this)->get());  // NOLINT(*const-cast)
+    }
+
+    constexpr bool operator==(T* ptr) const noexcept {
+        return get() == ptr;
+    }
+
+    constexpr bool operator!=(T* ptr) const noexcept {
+        return get() != ptr;
+    }
+
+private:
+    std::variant<T*, std::unique_ptr<T>> ptr_{nullptr};
+};
+
+}  // namespace opcua::detail

--- a/include/open62541pp/detail/ptr.hpp
+++ b/include/open62541pp/detail/ptr.hpp
@@ -29,11 +29,11 @@ public:
         return *this;
     }
 
-    constexpr T operator*() noexcept {
+    constexpr T& operator*() noexcept {
         return *get();
     }
 
-    constexpr T operator*() const noexcept {
+    constexpr const T& operator*() const noexcept {
         return *get();
     }
 

--- a/include/open62541pp/detail/server_context.hpp
+++ b/include/open62541pp/detail/server_context.hpp
@@ -13,6 +13,7 @@
 #include "open62541pp/detail/contextmap.hpp"
 #include "open62541pp/detail/exceptioncatcher.hpp"
 #include "open62541pp/detail/open62541/common.h"  // UA_AccessControl
+#include "open62541pp/detail/ptr.hpp"
 #include "open62541pp/plugin/nodestore.hpp"
 #include "open62541pp/services/detail/monitoreditem_context.hpp"
 #include "open62541pp/types.hpp"  // NodeId, Variant
@@ -21,13 +22,12 @@
 namespace opcua::detail {
 
 struct NodeContext {
-    ValueCallbackBase* valueCallback{nullptr};
-    DataSourceBase* dataSource{nullptr};
+    UniqueOrRawPtr<ValueCallbackBase> valueCallback;
+    UniqueOrRawPtr<DataSourceBase> dataSource;
 #ifdef UA_ENABLE_METHODCALLS
     std::function<void(Span<const Variant> input, Span<Variant> output)> methodCallback;
 #endif
 };
-
 
 struct SessionRegistry {
     using Context = void*;

--- a/include/open62541pp/server.hpp
+++ b/include/open62541pp/server.hpp
@@ -233,10 +233,14 @@ public:
     /// Register namespace. The new namespace index will be returned.
     [[nodiscard]] NamespaceIndex registerNamespace(std::string_view uri);
 
-    /// Set value callbacks to execute before every read and after every write operation.
+    /// Set value callback for variable node.
     void setVariableNodeValueCallback(const NodeId& id, ValueCallbackBase& callback);
+    /// Set value callback for variable node (move ownership to server).
+    void setVariableNodeValueCallback(const NodeId& id, std::unique_ptr<ValueCallbackBase>&& callback);
     /// Set data source for variable node.
     void setVariableNodeDataSource(const NodeId& id, DataSourceBase& source);
+    /// Set data source for variable node (move ownership to server).
+    void setVariableNodeDataSource(const NodeId& id, std::unique_ptr<DataSourceBase>&& source);
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
     /// Create a (pseudo) subscription to monitor local data changes and events.

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -330,18 +330,39 @@ NamespaceIndex Server::registerNamespace(std::string_view uri) {
     return UA_Server_addNamespace(handle(), std::string(uri).c_str());
 }
 
+static void setVariableNodeValueCallbackImpl(
+    Server& server, const NodeId& id, detail::UniqueOrRawPtr<ValueCallbackBase>&& callback
+) {
+    auto* nodeContext = detail::getContext(server).nodeContexts[id];
+    nodeContext->valueCallback = std::move(callback);
+    throwIfBad(UA_Server_setNodeContext(server.handle(), id, nodeContext));
+    throwIfBad(UA_Server_setVariableNode_valueCallback(server.handle(), id, callback->create(false))
+    );
+}
+
 void Server::setVariableNodeValueCallback(const NodeId& id, ValueCallbackBase& callback) {
-    auto* nodeContext = detail::getContext(*this).nodeContexts[id];
-    nodeContext->valueCallback = &callback;
-    throwIfBad(UA_Server_setNodeContext(handle(), id, nodeContext));
-    throwIfBad(UA_Server_setVariableNode_valueCallback(handle(), id, callback.create(false)));
+    setVariableNodeValueCallbackImpl(*this, id, detail::UniqueOrRawPtr{&callback});
+}
+
+void Server::setVariableNodeValueCallback(const NodeId& id, std::unique_ptr<ValueCallbackBase>&& callback) {
+    setVariableNodeValueCallbackImpl(*this, id, detail::UniqueOrRawPtr{std::move(callback)});
+}
+
+static void setVariableNodeDataSourceImpl(
+    Server& server, const NodeId& id, detail::UniqueOrRawPtr<DataSourceBase>&& source
+) {
+    auto* nodeContext = detail::getContext(server).nodeContexts[id];
+    nodeContext->dataSource = std::move(source);
+    throwIfBad(UA_Server_setNodeContext(server.handle(), id, nodeContext));
+    throwIfBad(UA_Server_setVariableNode_dataSource(server.handle(), id, source->create(false)));
 }
 
 void Server::setVariableNodeDataSource(const NodeId& id, DataSourceBase& source) {
-    auto* nodeContext = detail::getContext(*this).nodeContexts[id];
-    nodeContext->dataSource = &source;
-    throwIfBad(UA_Server_setNodeContext(handle(), id, nodeContext));
-    throwIfBad(UA_Server_setVariableNode_dataSource(handle(), id, source.create(false)));
+    setVariableNodeDataSourceImpl(*this, id, detail::UniqueOrRawPtr{&source});
+}
+
+void Server::setVariableNodeDataSource(const NodeId& id, std::unique_ptr<DataSourceBase>&& source) {
+    setVariableNodeDataSourceImpl(*this, id, detail::UniqueOrRawPtr{std::move(source)});
 }
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -336,15 +336,18 @@ static void setVariableNodeValueCallbackImpl(
     auto* nodeContext = detail::getContext(server).nodeContexts[id];
     nodeContext->valueCallback = std::move(callback);
     throwIfBad(UA_Server_setNodeContext(server.handle(), id, nodeContext));
-    throwIfBad(UA_Server_setVariableNode_valueCallback(server.handle(), id, callback->create(false))
-    );
+    throwIfBad(UA_Server_setVariableNode_valueCallback(
+        server.handle(), id, nodeContext->valueCallback->create(false)
+    ));
 }
 
 void Server::setVariableNodeValueCallback(const NodeId& id, ValueCallbackBase& callback) {
     setVariableNodeValueCallbackImpl(*this, id, detail::UniqueOrRawPtr{&callback});
 }
 
-void Server::setVariableNodeValueCallback(const NodeId& id, std::unique_ptr<ValueCallbackBase>&& callback) {
+void Server::setVariableNodeValueCallback(
+    const NodeId& id, std::unique_ptr<ValueCallbackBase>&& callback
+) {
     setVariableNodeValueCallbackImpl(*this, id, detail::UniqueOrRawPtr{std::move(callback)});
 }
 
@@ -354,7 +357,9 @@ static void setVariableNodeDataSourceImpl(
     auto* nodeContext = detail::getContext(server).nodeContexts[id];
     nodeContext->dataSource = std::move(source);
     throwIfBad(UA_Server_setNodeContext(server.handle(), id, nodeContext));
-    throwIfBad(UA_Server_setVariableNode_dataSource(server.handle(), id, source->create(false)));
+    throwIfBad(UA_Server_setVariableNode_dataSource(
+        server.handle(), id, nodeContext->dataSource->create(false)
+    ));
 }
 
 void Server::setVariableNodeDataSource(const NodeId& id, DataSourceBase& source) {

--- a/tests/server.cpp
+++ b/tests/server.cpp
@@ -194,8 +194,13 @@ TEST_CASE("ValueCallback") {
     auto node = Node(server, ObjectId::ObjectsFolder).addVariable(id, "TestVariable");
     node.writeValueScalar<int>(1);
 
-    ValueCallbackTest callback;
+    auto callbackPtr = std::make_unique<ValueCallbackTest>();
+    auto& callback = *callbackPtr;
     server.setVariableNodeValueCallback(id, callback);
+
+    SUBCASE("move ownership") {
+        server.setVariableNodeValueCallback(id, std::move(callbackPtr));
+    }
 
     SUBCASE("trigger onRead callback with read operation") {
         CHECK(node.readValueScalar<int>() == 1);
@@ -254,8 +259,12 @@ TEST_CASE("DataSource") {
     const NodeId id{1, 1000};
     auto node = Node(server, ObjectId::ObjectsFolder).addVariable(id, "TestVariable");
 
-    DataSourceTest source;
+    auto sourcePtr = std::make_unique<DataSourceTest>();
+    auto& source = *sourcePtr;
     server.setVariableNodeDataSource(id, source);
+    SUBCASE("move ownership") {
+        server.setVariableNodeDataSource(id, std::move(sourcePtr));
+    }
 
     SUBCASE("read") {
         source.data = 1;


### PR DESCRIPTION
Add overloads to optionally move ownership of the plugins to the server:

```diff
void Server::setVariableNodeValueCallback(const NodeId& id, ValueCallbackBase& callback);
+ void Server::setVariableNodeValueCallback(const NodeId& id, std::unique_ptr<ValueCallbackBase>&& callback);
void Server::setVariableNodeDataSource(const NodeId& id, DataSourceBase& source);
+ void Server::setVariableNodeDataSource(const NodeId& id, std::unique_ptr<DataSourceBase>&& source);
```

Closes #539.