### PR TITLE
feat: Guid::parse

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -89,6 +89,7 @@ PREDEFINED             = UA_ENABLE_DA \
                          UA_ENABLE_SUBSCRIPTIONS \
                          UA_ENABLE_SUBSCRIPTIONS_EVENTS \
                          UA_ENABLE_TYPEDESCRIPTION \
+                         UAPP_HAS_PARSING=1 \
                          UAPP_HAS_CREATE_CERTIFICATE=1 \
                          UAPP_HAS_ASYNC_SUBSCRIPTIONS=1
 

--- a/include/open62541pp/config.hpp.in
+++ b/include/open62541pp/config.hpp.in
@@ -24,6 +24,12 @@
 #error "open62541 must be compiled with UA_ENABLE_NODEMANAGEMENT"
 #endif
 
+#ifdef UA_ENABLE_PARSING
+#define UAPP_HAS_PARSING UAPP_OPEN62541_VER_GE(1, 1)
+#else
+#define UAPP_HAS_PARSING 0
+#endif
+
 #ifdef UA_ENABLE_DA
 // types like UA_EUInformation added since v1.1
 #define UAPP_HAS_DATAACCESS UAPP_OPEN62541_VER_GE(1, 1)

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -474,6 +474,7 @@ struct TypeConverter<std::chrono::time_point<Clock, Duration>> {
 
 /**
  * UA_Guid wrapper class.
+ * @see https://reference.opcfoundation.org/Core/Part6/v105/docs/5.1.3
  * @ingroup Wrapper
  */
 class Guid : public TypeWrapper<UA_Guid, UA_TYPES_GUID> {
@@ -500,9 +501,20 @@ public:
               {data4[0], data4[1], data4[2], data4[3], data4[4], data4[5], data4[6], data4[7]},
           }) {}
 
+    /// Generate random Guid.
     static Guid random() noexcept {
         return Guid(UA_Guid_random());  // NOLINT
     }
+
+#if UAPP_HAS_PARSING
+    /// Parse Guid from its string representation.
+    /// Format: C496578A-0DFE-4B8F-870A-745238C6AEAE.
+    static Guid parse(std::string_view str) {
+        Guid guid;
+        throwIfBad(UA_Guid_parse(guid.handle(), detail::toNativeString(str)));
+        return guid;
+    }
+#endif
 
     std::string toString() const;
 };

--- a/tests/types_builtin.cpp
+++ b/tests/types_builtin.cpp
@@ -267,9 +267,24 @@ TEST_CASE("Guid") {
         CHECK(wrapper.handle()->data4[7] == 15);
     }
 
-    SUBCASE("Random") {
+    SUBCASE("random") {
         CHECK(Guid::random() != Guid());
         CHECK(Guid::random() != Guid::random());
+    }
+
+    SUBCASE("parse") {
+        const auto guid = Guid::parse("12345678-1234-5678-1234-567890ABCDEF");
+        CHECK(guid->data1 == 0x12345678);
+        CHECK(guid->data2 == 0x1234);
+        CHECK(guid->data3 == 0x5678);
+        CHECK(guid->data4[0] == 0x12);
+        CHECK(guid->data4[1] == 0x34);
+        CHECK(guid->data4[2] == 0x56);
+        CHECK(guid->data4[3] == 0x78);
+        CHECK(guid->data4[4] == 0x90);
+        CHECK(guid->data4[5] == 0xAB);
+        CHECK(guid->data4[6] == 0xCD);
+        CHECK(guid->data4[7] == 0xEF);
     }
 
     SUBCASE("toString") {

--- a/tests/types_builtin.cpp
+++ b/tests/types_builtin.cpp
@@ -272,6 +272,7 @@ TEST_CASE("Guid") {
         CHECK(Guid::random() != Guid::random());
     }
 
+#if UAPP_HAS_PARSING
     SUBCASE("parse") {
         const auto guid = Guid::parse("12345678-1234-5678-1234-567890ABCDEF");
         CHECK(guid->data1 == 0x12345678);
@@ -286,6 +287,7 @@ TEST_CASE("Guid") {
         CHECK(guid->data4[6] == 0xCD);
         CHECK(guid->data4[7] == 0xEF);
     }
+#endif
 
     SUBCASE("toString") {
         {


### PR DESCRIPTION
Add factory function `Guid::parse` to parse `Guid` from its string representation, e.g. `C496578A-0DFE-4B8F-870A-745238C6AEAE`.