### PR TITLE
feat: NodeId::parse, ExpandedNodeId::parse

### DIFF
--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -508,7 +508,7 @@ public:
 
 #if UAPP_HAS_PARSING
     /// Parse Guid from its string representation.
-    /// Format: C496578A-0DFE-4B8F-870A-745238C6AEAE.
+    /// Format: `C496578A-0DFE-4B8F-870A-745238C6AEAE`.
     static Guid parse(std::string_view str) {
         Guid guid;
         throwIfBad(UA_Guid_parse(guid.handle(), detail::toNativeString(str)));
@@ -715,6 +715,17 @@ public:
     template <typename T, typename = std::enable_if_t<detail::IsNodeIdEnum<T>::value>>
     NodeId(T identifier) noexcept  // NOLINT(hicpp-explicit-conversions)
         : NodeId(namespaceOf(identifier).index, static_cast<uint32_t>(identifier)) {}
+
+#if UAPP_HAS_PARSING
+    /// Parse NodeId from its string representation.
+    /// Format: `ns=<namespaceindex>;<type>=<value>`, e.g. `i=13` or `ns=10;s=HelloWorld`
+    /// @see https://reference.opcfoundation.org/Core/Part6/v104/docs/5.3.1.10
+    static NodeId parse(std::string_view str) {
+        NodeId id;
+        throwIfBad(UA_NodeId_parse(id.handle(), detail::toNativeString(str)));
+        return id;
+    }
+#endif
 
     bool isNull() const noexcept {
         return UA_NodeId_isNull(handle());
@@ -925,6 +936,18 @@ public:
         handle()->namespaceUri = detail::allocNativeString(namespaceUri);
         handle()->serverIndex = serverIndex;
     }
+
+#if UAPP_HAS_PARSING
+    /// Parse ExpandedNodeId from its string representation.
+    /// Format: `svr=<serverindex>;ns=<namespaceindex>;<type>=<value>` or
+    ///         `svr=<serverindex>;nsu=<uri>;<type>=<value>`
+    /// @see https://reference.opcfoundation.org/Core/Part6/v104/docs/5.3.1.11
+    static ExpandedNodeId parse(std::string_view str) {
+        ExpandedNodeId id;
+        throwIfBad(UA_ExpandedNodeId_parse(id.handle(), detail::toNativeString(str)));
+        return id;
+    }
+#endif
 
     bool isLocal() const noexcept {
         return handle()->serverIndex == 0;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -83,31 +83,6 @@ std::ostream& operator<<(std::ostream& os, const XmlElement& xmlElement) {
     return os;
 }
 
-/* ---------------------------------------- NumericRange ---------------------------------------- */
-
-NumericRange::NumericRange(std::string_view encodedRange) {
-    const auto encodedRangeNative = detail::toNativeString(encodedRange);
-#if UAPP_OPEN62541_VER_GE(1, 1)
-    throwIfBad(UA_NumericRange_parse(handle(), encodedRangeNative));
-#else
-    throwIfBad(UA_NumericRange_parseFromString(handle(), &encodedRangeNative));
-#endif
-}
-
-std::string NumericRange::toString() const {
-    std::ostringstream ss;
-    for (const auto& dimension : dimensions()) {
-        ss << dimension.min;
-        if (dimension.min != dimension.max) {
-            ss << ':' << dimension.max;
-        }
-        ss << ',';
-    }
-    auto str = ss.str();
-    str.pop_back();  // remove last comma
-    return str;
-}
-
 /* ------------------------------------------- NodeId ------------------------------------------- */
 
 std::string NodeId::toString() const {
@@ -146,6 +121,31 @@ std::string ExpandedNodeId::toString() const {
     }
     result.append(nodeId().toString());
     return result;
+}
+
+/* ---------------------------------------- NumericRange ---------------------------------------- */
+
+NumericRange::NumericRange(std::string_view encodedRange) {
+    const auto encodedRangeNative = detail::toNativeString(encodedRange);
+#if UAPP_OPEN62541_VER_GE(1, 1)
+    throwIfBad(UA_NumericRange_parse(handle(), encodedRangeNative));
+#else
+    throwIfBad(UA_NumericRange_parseFromString(handle(), &encodedRangeNative));
+#endif
+}
+
+std::string NumericRange::toString() const {
+    std::ostringstream ss;
+    for (const auto& dimension : dimensions()) {
+        ss << dimension.min;
+        if (dimension.min != dimension.max) {
+            ss << ':' << dimension.max;
+        }
+        ss << ',';
+    }
+    auto str = ss.str();
+    str.pop_back();  // remove last comma
+    return str;
 }
 
 }  // namespace opcua


### PR DESCRIPTION
Add factory functions `NodeId::parse`/`ExpandedNodeId::parse` to parse node ids from their string representations.

Closes #541.