### PR TITLE
refactor: simplify traits

### DIFF
--- a/include/open62541pp/detail/types_conversion.hpp
+++ b/include/open62541pp/detail/types_conversion.hpp
@@ -20,7 +20,7 @@ template <typename T, typename = std::enable_if_t<std::is_enum_v<T>>>
     return allocNativeString(value);
 }
 
-template <typename T, typename = std::enable_if_t<isWrapper<T>>>
+template <typename T, typename = std::enable_if_t<IsWrapper<T>::value>>
 [[nodiscard]] auto toNative(T&& value) {
     using NativeType = typename T::NativeType;
     NativeType native{};
@@ -30,7 +30,7 @@ template <typename T, typename = std::enable_if_t<isWrapper<T>>>
 
 template <typename T>
 [[nodiscard]] auto* toNativeArray(Span<const T> array) {
-    if constexpr (isWrapper<T>) {
+    if constexpr (IsWrapper<T>::value) {
         return copyArray(asNative(array.data()), array.size(), getDataType<T>());
     } else {
         return copyArray(array.data(), array.size(), getDataType<T>());

--- a/include/open62541pp/node.hpp
+++ b/include/open62541pp/node.hpp
@@ -1166,7 +1166,7 @@ public:
     /// Write scalar to variable node.
     template <typename T>
     Node& writeValueScalar(const T& value) {
-        if constexpr (detail::isRegisteredType<T>) {
+        if constexpr (detail::IsRegistered<T>::value) {
             // NOLINTNEXTLINE(*-const-cast), variant isn't modified, avoid copy
             writeValue(Variant(const_cast<T*>(&value)));
         } else {
@@ -1180,7 +1180,7 @@ public:
     template <typename ArrayLike>
     Node& writeValueArray(const ArrayLike& array) {
         if constexpr (detail::IsContiguousRange<ArrayLike>::value &&
-                      detail::isRegisteredType<detail::RangeValueT<ArrayLike>>) {
+                      detail::IsRegistered<detail::RangeValueT<ArrayLike>>::value) {
             // NOLINTNEXTLINE(*-const-cast), variant isn't modified, avoid copy
             writeValue(Variant(const_cast<ArrayLike*>(&array)));
         } else {

--- a/include/open62541pp/services/detail/response_handling.hpp
+++ b/include/open62541pp/services/detail/response_handling.hpp
@@ -9,13 +9,13 @@
 #include "open62541pp/result.hpp"
 #include "open62541pp/span.hpp"
 #include "open62541pp/types.hpp"  // StatusCode
-#include "open62541pp/wrapper.hpp"  // asNative, asWrapper, isWrapper
+#include "open62541pp/wrapper.hpp"  // asNative, asWrapper, IsWrapper
 
 namespace opcua::services::detail {
 
 template <typename WrapperType>
 struct Wrap {
-    static_assert(opcua::detail::isWrapper<WrapperType>);
+    static_assert(opcua::detail::IsWrapper<WrapperType>::value);
     using NativeType = typename WrapperType::NativeType;
 
     [[nodiscard]] constexpr WrapperType operator()(const NativeType& native) noexcept {
@@ -33,7 +33,7 @@ struct Wrap {
 
 template <typename Response>
 const UA_ResponseHeader& getResponseHeader(const Response& response) noexcept {
-    if constexpr (opcua::detail::isWrapper<Response>) {
+    if constexpr (opcua::detail::IsWrapper<Response>::value) {
         return asNative(response).responseHeader;
     } else {
         return response.responseHeader;
@@ -48,7 +48,7 @@ StatusCode getServiceResult(const Response& response) noexcept {
 template <typename Response>
 auto getSingleResultRef(Response& response) noexcept {
     auto* native = [&] {
-        if constexpr (opcua::detail::isWrapper<Response>) {
+        if constexpr (opcua::detail::IsWrapper<Response>::value) {
             return asNative(&response);
         } else {
             return &response;

--- a/include/open62541pp/typeconverter.hpp
+++ b/include/open62541pp/typeconverter.hpp
@@ -36,22 +36,19 @@ struct TypeConverter;
 namespace detail {
 
 template <typename T, typename = void>
-struct IsConvertibleType : std::false_type {};
+struct IsConvertible : std::false_type {};
 
 template <typename T>
-struct IsConvertibleType<T, std::void_t<decltype(TypeConverter<T>{})>> : std::true_type {};
+struct IsConvertible<T, std::void_t<decltype(TypeConverter<T>{})>> : std::true_type {};
 
-template <typename T>
-constexpr bool isConvertibleType = IsConvertibleType<T>::value;
-
-template <typename T, typename = std::enable_if_t<detail::isConvertibleType<T>>>
+template <typename T, typename = std::enable_if_t<detail::IsConvertible<T>::value>>
 [[nodiscard]] constexpr T fromNative(const typename TypeConverter<T>::NativeType& src) {
     T dst{};
     TypeConverter<T>::fromNative(src, dst);
     return dst;
 }
 
-template <typename T, typename = std::enable_if_t<detail::isConvertibleType<T>>>
+template <typename T, typename = std::enable_if_t<detail::IsConvertible<T>::value>>
 [[nodiscard]] constexpr auto toNative(const T& src) -> typename TypeConverter<T>::NativeType {
     using NativeType = typename TypeConverter<T>::NativeType;
     NativeType dst{};

--- a/include/open62541pp/typeregistry.hpp
+++ b/include/open62541pp/typeregistry.hpp
@@ -32,13 +32,10 @@ struct TypeRegistry;
 namespace detail {
 
 template <typename T, typename = void>
-struct IsRegisteredType : std::false_type {};
+struct IsRegistered : std::false_type {};
 
 template <typename T>
-struct IsRegisteredType<T, std::void_t<decltype(TypeRegistry<T>{})>> : std::true_type {};
-
-template <typename T>
-constexpr bool isRegisteredType = IsRegisteredType<T>::value;
+struct IsRegistered<T, std::void_t<decltype(TypeRegistry<T>{})>> : std::true_type {};
 
 }  // namespace detail
 
@@ -46,7 +43,7 @@ template <typename T>
 const UA_DataType& getDataType() noexcept {
     using ValueType = typename std::remove_cv_t<T>;
     static_assert(
-        detail::isRegisteredType<ValueType>,
+        detail::IsRegistered<ValueType>::value,
         "The provided template type is not registered. "
         "Specify the data type manually or add a template specialization for TypeRegistry."
     );

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -1344,7 +1344,7 @@ public:
             assign(std::begin(value), std::end(value));
         } else {
             assertIsRegisteredOrConvertible<T>();
-            if constexpr (detail::isRegisteredType<T>) {
+            if constexpr (detail::IsRegistered<T>::value) {
                 setScalarCopyImpl(value, opcua::getDataType<T>());
             } else {
                 setScalarCopyConvertImpl(value);
@@ -1379,7 +1379,7 @@ public:
     void assign(InputIt first, InputIt last) {
         using ValueType = typename std::iterator_traits<InputIt>::value_type;
         assertIsRegisteredOrConvertible<ValueType>();
-        if constexpr (detail::isRegisteredType<ValueType>) {
+        if constexpr (detail::IsRegistered<ValueType>::value) {
             setArrayCopyImpl(first, last, opcua::getDataType<ValueType>());
         } else {
             setArrayCopyConvertImpl(first, last);
@@ -1684,7 +1684,7 @@ public:
 private:
     template <typename T>
     static constexpr bool isScalarType() noexcept {
-        return detail::isRegisteredType<T> || detail::isConvertibleType<T>;
+        return detail::IsRegistered<T>::value || detail::IsConvertible<T>::value;
     }
 
     template <typename T>
@@ -1695,7 +1695,7 @@ private:
     template <typename T>
     static constexpr void assertIsRegistered() {
         static_assert(
-            detail::isRegisteredType<T>,
+            detail::IsRegistered<T>::value,
             "Template type must be a native/wrapper type to assign or get scalar/array without copy"
         );
     }
@@ -1703,7 +1703,7 @@ private:
     template <typename T>
     static constexpr void assertIsRegisteredOrConvertible() {
         static_assert(
-            detail::isRegisteredType<T> || detail::isConvertibleType<T>,
+            detail::IsRegistered<T>::value || detail::IsConvertible<T>::value,
             "Template type must be either a native/wrapper type or a convertible type. "
             "If the type is a native type: Provide the type definition (UA_DataType) manually or "
             "register the type with a TypeRegistry template specialization. "
@@ -1762,7 +1762,7 @@ private:
 template <typename T>
 T Variant::toScalarImpl() const {
     assertIsRegisteredOrConvertible<T>();
-    if constexpr (detail::isRegisteredType<T>) {
+    if constexpr (detail::IsRegistered<T>::value) {
         return scalar<T>();
     } else {
         using Native = typename TypeConverter<T>::NativeType;
@@ -1774,7 +1774,7 @@ template <typename T>
 T Variant::toArrayImpl() const {
     using ValueType = typename T::value_type;
     assertIsRegisteredOrConvertible<ValueType>();
-    if constexpr (detail::isRegisteredType<ValueType>) {
+    if constexpr (detail::IsRegistered<ValueType>::value) {
         auto native = array<ValueType>();
         return T(native.begin(), native.end());
     } else {

--- a/include/open62541pp/typewrapper.hpp
+++ b/include/open62541pp/typewrapper.hpp
@@ -110,15 +110,12 @@ struct IsTypeWrapper {
     static constexpr bool value = type::value;
 };
 
-template <typename T>
-constexpr bool isTypeWrapper = IsTypeWrapper<T>::value;
-
 }  // namespace detail
 
 /* --------------------------------- TypeRegistry specialization -------------------------------- */
 
 template <typename T>
-struct TypeRegistry<T, std::enable_if_t<detail::isTypeWrapper<T>>> {
+struct TypeRegistry<T, std::enable_if_t<detail::IsTypeWrapper<T>::value>> {
     static const UA_DataType& getDataType() noexcept {
         return UA_TYPES[T::typeIndex()];
     }

--- a/include/open62541pp/wrapper.hpp
+++ b/include/open62541pp/wrapper.hpp
@@ -126,9 +126,6 @@ struct IsWrapper {
     static constexpr bool value = type::value;
 };
 
-template <typename T>
-constexpr bool isWrapper = IsWrapper<T>::value;
-
 }  // namespace detail
 
 /* ------------------------------ Cast native type to wrapper type ------------------------------ */
@@ -137,7 +134,7 @@ namespace detail {
 
 template <typename WrapperType>
 struct WrapperConversion {
-    static_assert(isWrapper<WrapperType>);
+    static_assert(detail::IsWrapper<WrapperType>::value);
     static_assert(std::is_standard_layout_v<WrapperType>);
 
     using NativeType = typename WrapperType::NativeType;

--- a/tests/typeregistry.cpp
+++ b/tests/typeregistry.cpp
@@ -23,10 +23,10 @@ struct TypeRegistry<Custom> {
 
 TEST_CASE("TypeRegistry") {
     SUBCASE("Builtin") {
-        CHECK(detail::isRegisteredType<float>);
-        CHECK_FALSE(detail::isRegisteredType<const volatile float>);
-        CHECK_FALSE(detail::isRegisteredType<float*>);
-        CHECK_FALSE(detail::isRegisteredType<float&>);
+        CHECK(detail::IsRegistered<float>::value);
+        CHECK_FALSE(detail::IsRegistered<const volatile float>::value);
+        CHECK_FALSE(detail::IsRegistered<float*>::value);
+        CHECK_FALSE(detail::IsRegistered<float&>::value);
 
         CHECK(&TypeRegistry<float>::getDataType() == &UA_TYPES[UA_TYPES_FLOAT]);
         CHECK(&getDataType<float>() == &UA_TYPES[UA_TYPES_FLOAT]);

--- a/tests/types_handling.cpp
+++ b/tests/types_handling.cpp
@@ -7,13 +7,13 @@
 using namespace opcua;
 
 TEST_CASE("Types handling") {
-    SUBCASE("isPointerFree") {
-        CHECK(detail::isPointerFree<bool>);
-        CHECK(detail::isPointerFree<int>);
-        CHECK(detail::isPointerFree<float>);
-        CHECK(detail::isPointerFree<UA_Guid>);
-        CHECK_FALSE(detail::isPointerFree<UA_String>);
-        CHECK_FALSE(detail::isPointerFree<UA_NodeId>);
+    SUBCASE("IsPointerFree") {
+        CHECK(detail::IsPointerFree<bool>::value);
+        CHECK(detail::IsPointerFree<int>::value);
+        CHECK(detail::IsPointerFree<float>::value);
+        CHECK(detail::IsPointerFree<UA_Guid>::value);
+        CHECK_FALSE(detail::IsPointerFree<UA_String>::value);
+        CHECK_FALSE(detail::IsPointerFree<UA_NodeId>::value);
     }
 
     SUBCASE("Allocate / deallocate") {


### PR DESCRIPTION
- Rename `detail::IsRegisteredType` -> `detail::IsRegistered`
- Rename `detail::IsConvertibleType` -> `detail::IsConvertible`
- Remove `constexpr bool is*` aliases, use `::value` instead