### PR TITLE
feat: construct Client/Server from native

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,7 @@ jobs:
       - name: Configure CMake
         run: >
           cmake -S . -B ./build
+          -DCMAKE_POLICY_VERSION_MINIMUM=3.5
           -DCMAKE_CXX_COMPILER=${{ matrix.config.compiler }}
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
           -DBUILD_SHARED_LIBS=${{ matrix.library_type == 'shared' }}

--- a/.github/workflows/open62541-compatibility.yml
+++ b/.github/workflows/open62541-compatibility.yml
@@ -62,6 +62,7 @@ jobs:
           mkdir build
           cd build
           cmake -G Ninja \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DUAPP_BUILD_TESTS=ON \
             -DUAPP_BUILD_EXAMPLES=ON \

--- a/include/open62541pp/client.hpp
+++ b/include/open62541pp/client.hpp
@@ -140,6 +140,9 @@ public:
     );
 #endif
 
+    /// Create client from native instance (move ownership to client).
+    explicit Client(UA_Client* native);
+
     ~Client();
 
     Client(const Client&) = delete;

--- a/include/open62541pp/server.hpp
+++ b/include/open62541pp/server.hpp
@@ -164,6 +164,9 @@ public:
           ) {}
 #endif
 
+    /// Create server from native instance (move ownership to server).
+    explicit Server(UA_Server* native);
+
     ~Server();
 
     Server(const Server&) = delete;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -291,6 +291,14 @@ Client::Client(
     : Client(ClientConfig(certificate, privateKey, trustList, revocationList)) {}
 #endif
 
+Client::Client(UA_Client* native)
+    : context_(std::make_unique<detail::ClientContext>()),
+      client_(native) {
+    if (handle() == nullptr) {
+        throw BadStatus(UA_STATUSCODE_BADOUTOFMEMORY);
+    }
+}
+
 Client::~Client() = default;
 
 Client::Client(Client&& other) noexcept

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -297,6 +297,7 @@ Client::Client(UA_Client* native)
     if (handle() == nullptr) {
         throw BadStatus(UA_STATUSCODE_BADOUTOFMEMORY);
     }
+    setWrapperAsContextPointer(*this);
 }
 
 Client::~Client() = default;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -278,6 +278,7 @@ Server::Server(UA_Server* native)
     if (handle() == nullptr) {
         throw BadStatus(UA_STATUSCODE_BADOUTOFMEMORY);
     }
+    setWrapperAsContextPointer(*this);
 }
 
 Server::~Server() = default;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -272,6 +272,14 @@ Server::Server(ServerConfig&& config)
     setWrapperAsContextPointer(*this);
 }
 
+Server::Server(UA_Server* native)
+    : context_(std::make_unique<detail::ServerContext>()),
+      server_(native) {
+    if (handle() == nullptr) {
+        throw BadStatus(UA_STATUSCODE_BADOUTOFMEMORY);
+    }
+}
+
 Server::~Server() = default;
 
 Server::Server(Server&& other) noexcept

--- a/tests/client.cpp
+++ b/tests/client.cpp
@@ -52,6 +52,7 @@ TEST_CASE("ClientConfig") {
 TEST_CASE("Client constructors") {
     SUBCASE("From native") {
         UA_Client* native = UA_Client_new();
+        UA_ClientConfig_setDefault(UA_Client_getConfig(native));
         Client client{native};
     }
 

--- a/tests/client.cpp
+++ b/tests/client.cpp
@@ -49,6 +49,18 @@ TEST_CASE("ClientConfig") {
     }
 }
 
+TEST_CASE("Client constructors") {
+    SUBCASE("From native") {
+        UA_Client* native = UA_Client_new();
+        Client client{native};
+    }
+
+    SUBCASE("From native (nullptr)") {
+        UA_Client* native{nullptr};
+        CHECK_THROWS(Client{native});
+    }
+}
+
 TEST_CASE("Client discovery") {
     Server server;
     ServerRunner serverRunner(server);

--- a/tests/server.cpp
+++ b/tests/server.cpp
@@ -116,6 +116,20 @@ TEST_CASE("ServerConfig") {
     }
 }
 
+TEST_CASE("Server constructors") {
+    SUBCASE("From native") {
+        UA_ServerConfig config{};
+        UA_ServerConfig_setDefault(&config);
+        UA_Server* native = UA_Server_newWithConfig(&config);
+        Server server{native};
+    }
+
+    SUBCASE("From native (nullptr)") {
+        UA_Server* native{nullptr};
+        CHECK_THROWS(Server{native});
+    }
+}
+
 TEST_CASE("Server run/stop/runIterate") {
     Server server;
     CHECK_FALSE(server.isRunning());


### PR DESCRIPTION
Add constructors to create `Client` and `Server` from native instances:

```cpp
explicit Client::Client(UA_Client* native);
explicit Server::Server(UA_Server* native);
```