### PR TITLE
feat!: remove ostream overloads for Guid and XmlElement

### DIFF
--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -542,9 +542,6 @@ inline bool operator!=(const UA_Guid& lhs, const UA_Guid& rhs) noexcept {
     return !(lhs == rhs);
 }
 
-/// @relates Guid
-std::ostream& operator<<(std::ostream& os, const Guid& guid);
-
 /* ----------------------------------------- ByteString ----------------------------------------- */
 
 /**
@@ -658,9 +655,6 @@ public:
         return {data(), size()};
     }
 };
-
-/// @relates XmlElement
-std::ostream& operator<<(std::ostream& os, const XmlElement& xmlElement);
 
 /* ------------------------------------------- NodeId ------------------------------------------- */
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -22,11 +22,6 @@ std::string Guid::toString() const {
     return std::string(opcua::toString(*this));
 }
 
-std::ostream& operator<<(std::ostream& os, const Guid& guid) {
-    os << toString(guid);
-    return os;
-}
-
 /* ------------------------------------------ DateTime ------------------------------------------ */
 
 std::string DateTime::format(std::string_view format, bool localtime) const {
@@ -58,13 +53,6 @@ String ByteString::toBase64() const {
     return output;
 }
 #endif
-
-/* ----------------------------------------- XmlElement ----------------------------------------- */
-
-std::ostream& operator<<(std::ostream& os, const XmlElement& xmlElement) {
-    os << static_cast<std::string_view>(xmlElement);
-    return os;
-}
 
 /* ------------------------------------------- NodeId ------------------------------------------- */
 

--- a/tests/types_builtin.cpp
+++ b/tests/types_builtin.cpp
@@ -208,7 +208,7 @@ TEMPLATE_TEST_CASE("StringLike equality overloads with std::string_view", "", St
     CHECK(std::string("test") != TestType("abc"));
 }
 
-TEMPLATE_TEST_CASE("StringLike ostream overloads", "", String, XmlElement) {
+TEMPLATE_TEST_CASE("StringLike ostream overloads", "", String) {
     std::ostringstream ss;
     ss << TestType("test123");
     CHECK(ss.str() == "test123");


### PR DESCRIPTION
Explicitly convert to string with `opcua::toString` first.