### PR TITLE
feat!: remove ByteString <-> std::string_view equality operator overloads

### DIFF
--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -590,26 +590,6 @@ public:
     }
 };
 
-/// @relates ByteString
-inline bool operator==(const ByteString& lhs, std::string_view rhs) noexcept {
-    return (static_cast<std::string_view>(lhs) == rhs);
-}
-
-/// @relates ByteString
-inline bool operator!=(const ByteString& lhs, std::string_view rhs) noexcept {
-    return (static_cast<std::string_view>(lhs) != rhs);
-}
-
-/// @relates ByteString
-inline bool operator==(std::string_view lhs, const ByteString& rhs) noexcept {
-    return (lhs == static_cast<std::string_view>(rhs));
-}
-
-/// @relates ByteString
-inline bool operator!=(std::string_view lhs, const ByteString& rhs) noexcept {
-    return (lhs != static_cast<std::string_view>(rhs));
-}
-
 /* ----------------------------------------- XmlElement ----------------------------------------- */
 
 /**

--- a/src/plugin/accesscontrol_default.cpp
+++ b/src/plugin/accesscontrol_default.cpp
@@ -85,7 +85,8 @@ StatusCode AccessControlDefault::activateSession(
         }
         // try to match username / password
         for (const auto& login : logins_) {
-            if ((login.username == token->userName()) && (login.password == token->password())) {
+            if ((login.username == static_cast<std::string_view>(token->userName())) &&
+                (login.password == static_cast<std::string_view>(token->password()))) {
                 return UA_STATUSCODE_GOOD;
             }
         }

--- a/tests/types_builtin.cpp
+++ b/tests/types_builtin.cpp
@@ -201,11 +201,11 @@ TEMPLATE_TEST_CASE("StringLike equality overloads", "", String, ByteString, XmlE
     CHECK(TestType("test") != TestType());
 }
 
-TEMPLATE_TEST_CASE("StringLike equality overloads with std::string_view", "", String, ByteString) {
-    CHECK(TestType("test") == std::string("test"));
-    CHECK(TestType("test") != std::string("abc"));
-    CHECK(std::string("test") == TestType("test"));
-    CHECK(std::string("test") != TestType("abc"));
+TEMPLATE_TEST_CASE("StringLike equality overloads with std::string_view", "", String) {
+    CHECK(TestType("test") == std::string_view("test"));
+    CHECK(TestType("test") != std::string_view("abc"));
+    CHECK(std::string_view("test") == TestType("test"));
+    CHECK(std::string_view("test") != TestType("abc"));
 }
 
 TEMPLATE_TEST_CASE("StringLike ostream overloads", "", String) {


### PR DESCRIPTION
Use explicit conversion to `std::string_view` if required.