### PR TITLE
fix: store typeName in DataType wrapper

### DIFF
--- a/include/open62541pp/datatype.hpp
+++ b/include/open62541pp/datatype.hpp
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <cstdint>
 #include <iterator>  // prev
+#include <string_view>
 #include <type_traits>
 #include <utility>  // move
 #include <vector>
@@ -11,6 +12,7 @@
 #include "open62541pp/common.hpp"  // TypeIndex
 #include "open62541pp/config.hpp"
 #include "open62541pp/detail/open62541/common.h"
+#include "open62541pp/detail/string_utils.hpp"
 #include "open62541pp/detail/traits.hpp"
 #include "open62541pp/span.hpp"
 #include "open62541pp/typeregistry.hpp"  // getDataType
@@ -41,7 +43,7 @@ public:
     DataType& operator=(const DataType& other);
     DataType& operator=(DataType&& other) noexcept;
 
-    const char* typeName() const noexcept {
+    std::string_view typeName() const noexcept {
 #ifdef UA_ENABLE_TYPEDESCRIPTION
         return handle()->typeName;
 #else
@@ -51,13 +53,14 @@ public:
 
     /// @deprecated Use typeName() instead
     [[deprecated("use typeName() instead")]]
-    const char* getTypeName() const noexcept {
+    std::string_view getTypeName() const noexcept {
         return typeName();
     }
 
-    void setTypeName([[maybe_unused]] const char* typeName) noexcept {
+    void setTypeName([[maybe_unused]] std::string_view typeName) noexcept {
 #ifdef UA_ENABLE_TYPEDESCRIPTION
-        handle()->typeName = typeName;
+        detail::clear(handle()->typeName);
+        handle()->typeName = detail::allocCString(typeName);
 #endif
     }
 

--- a/include/open62541pp/detail/string_utils.hpp
+++ b/include/open62541pp/detail/string_utils.hpp
@@ -14,6 +14,11 @@ UA_String toNativeString(std::string_view src) noexcept;
 /// Allocate UA_String from std::string_view
 [[nodiscard]] UA_String allocNativeString(std::string_view src);
 
+/// Allocate const char* from std::string_view
+[[nodiscard]] char* allocCString(std::string_view src);
+
+void clear(const char* str) noexcept;
+
 /// Convert UA_String to std::string_view
 /// Can be marked noexcept: https://stackoverflow.com/a/62061549/9967707
 inline std::string_view toStringView(const UA_String& src) noexcept {

--- a/src/datatype.cpp
+++ b/src/datatype.cpp
@@ -15,6 +15,9 @@ static void clearMembers(UA_DataType& native) noexcept {
 }
 
 static void clear(UA_DataType& native) noexcept {
+#ifdef UA_ENABLE_TYPEDESCRIPTION
+    detail::clear(native.typeName);
+#endif
     clearMembers(native);
     native = {};
 }
@@ -27,6 +30,9 @@ static void copyMembers(const DataTypeMember* members, size_t membersSize, UA_Da
 
 [[nodiscard]] static UA_DataType copy(const UA_DataType& other) {
     UA_DataType result{other};
+#ifdef UA_ENABLE_TYPEDESCRIPTION
+    result.typeName = detail::allocCString(other.typeName);
+#endif
     copyMembers(other.members, other.membersSize, result);
     return result;
 }

--- a/tests/string_utils.cpp
+++ b/tests/string_utils.cpp
@@ -36,6 +36,14 @@ TEST_CASE("Alloc UA_String from string_view") {
     UA_clear(&str, &UA_TYPES[UA_TYPES_STRING]);
 }
 
+TEST_CASE("Alloc const char* from string_view") {
+    const char* cstr = detail::allocCString("test123");
+    CHECK(std::strlen(cstr) == 7);
+    CHECK(std::strcmp(cstr, "test123") == 0);
+    CHECK(cstr[7] == '\0');  // NOLINT
+    detail::clear(cstr);
+}
+
 TEST_CASE("Alloc UA_String from non-null-terminated string_view") {
     std::string str("test123");
     std::string_view sv(str.c_str(), 4);


### PR DESCRIPTION
Allow `typeName`s that are no string literals (known at compile time).