### PR TITLE
fix: store memberName in DataType wrapper

### DIFF
--- a/include/open62541pp/config.hpp.in
+++ b/include/open62541pp/config.hpp.in
@@ -24,6 +24,12 @@
 #error "open62541 must be compiled with UA_ENABLE_NODEMANAGEMENT"
 #endif
 
+#if defined(UA_ENABLE_TYPEDESCRIPTION) || defined(UA_ENABLE_TYPENAMES)
+#define UAPP_HAS_TYPEDESCRIPTION 1
+#else
+#define UAPP_HAS_TYPEDESCRIPTION 0
+#endif
+
 #ifdef UA_ENABLE_PARSING
 #define UAPP_HAS_PARSING UAPP_OPEN62541_VER_GE(1, 1)
 #else

--- a/include/open62541pp/datatype.hpp
+++ b/include/open62541pp/datatype.hpp
@@ -81,7 +81,7 @@ public:
 #ifdef UA_ENABLE_TYPEDESCRIPTION
         return handle()->typeName;
 #else
-        return nullptr;
+        return {};
 #endif
     }
 

--- a/include/open62541pp/datatype.hpp
+++ b/include/open62541pp/datatype.hpp
@@ -78,7 +78,7 @@ public:
     DataType& operator=(DataType&& other) noexcept;
 
     std::string_view typeName() const noexcept {
-#ifdef UA_ENABLE_TYPEDESCRIPTION
+#if UAPP_HAS_TYPEDESCRIPTION
         return handle()->typeName;
 #else
         return {};
@@ -92,7 +92,7 @@ public:
     }
 
     void setTypeName([[maybe_unused]] std::string_view typeName) noexcept {
-#ifdef UA_ENABLE_TYPEDESCRIPTION
+#if UAPP_HAS_TYPEDESCRIPTION
         detail::clear(handle()->typeName);
         handle()->typeName = detail::allocCString(typeName);
 #endif

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -367,9 +367,9 @@ std::vector<EndpointDescription> Client::getEndpoints(std::string_view serverUrl
 
 void Client::setCustomDataTypes(Span<const DataType> dataTypes) {
     context().dataTypes = {dataTypes.begin(), dataTypes.end()};
-    context().dataTypeArray = std::make_unique<UA_DataTypeArray>(
-        detail::createDataTypeArray(context().dataTypes)
-    );
+    context().dataTypeArray = std::make_unique<UA_DataTypeArray>(detail::createDataTypeArray(
+        asNative(context().dataTypes.data()), context().dataTypes.size(), nullptr
+    ));
     config()->customDataTypes = context().dataTypeArray.get();
 }
 

--- a/src/datatype.cpp
+++ b/src/datatype.cpp
@@ -112,9 +112,12 @@ UA_DataTypeMember copy(const UA_DataTypeMember& src) {
 static void copyMembers(const UA_DataTypeMember* members, size_t membersSize, UA_DataType& dst) {
     dst.members = detail::allocateArray<UA_DataTypeMember>(membersSize);
     dst.membersSize = membersSize;
-    std::transform(members, std::next(members, membersSize), dst.members, [](const auto& member) {
-        return copy(member);
-    });
+    std::transform(
+        members,
+        members + membersSize,  // NOLINT(*pointer-arithmetic)
+        dst.members,
+        [](const auto& member) { return copy(member); }
+    );
 }
 
 UA_DataType copy(const UA_DataType& src) {

--- a/src/datatype.cpp
+++ b/src/datatype.cpp
@@ -18,7 +18,7 @@ DataTypeMember createDataTypeMember(
     [[maybe_unused]] bool isOptional
 ) noexcept {
     DataTypeMember result{};
-#ifdef UA_ENABLE_TYPEDESCRIPTION
+#if UAPP_HAS_TYPEDESCRIPTION
     result.memberName = memberName;
 #endif
 #if UAPP_OPEN62541_VER_GE(1, 3)
@@ -47,7 +47,7 @@ UA_DataType createDataType(
     DataTypeMember* members
 ) noexcept {
     UA_DataType result{};
-#ifdef UA_ENABLE_TYPEDESCRIPTION
+#if UAPP_HAS_TYPEDESCRIPTION
     result.typeName = typeName;
 #endif
     result.typeId = typeId;
@@ -85,7 +85,7 @@ void clear(UA_DataTypeMember& native) noexcept {
 }
 
 static void clearMembers(UA_DataType& native) noexcept {
-#ifdef UA_ENABLE_TYPEDESCRIPTION
+#if UAPP_HAS_TYPEDESCRIPTION
     std::for_each_n(native.members, native.membersSize, [](auto& member) { clear(member); });
 #endif
     detail::deallocateArray(native.members);
@@ -94,7 +94,7 @@ static void clearMembers(UA_DataType& native) noexcept {
 }
 
 void clear(UA_DataType& native) noexcept {
-#ifdef UA_ENABLE_TYPEDESCRIPTION
+#if UAPP_HAS_TYPEDESCRIPTION
     detail::clear(native.typeName);
 #endif
     clearMembers(native);
@@ -103,7 +103,7 @@ void clear(UA_DataType& native) noexcept {
 
 UA_DataTypeMember copy(const UA_DataTypeMember& src) {
     UA_DataTypeMember dst{src};
-#ifdef UA_ENABLE_TYPEDESCRIPTION
+#if UAPP_HAS_TYPEDESCRIPTION
     dst.memberName = detail::allocCString(src.memberName);
 #endif
     return dst;
@@ -119,7 +119,7 @@ static void copyMembers(const UA_DataTypeMember* members, size_t membersSize, UA
 
 UA_DataType copy(const UA_DataType& src) {
     UA_DataType dst{src};
-#ifdef UA_ENABLE_TYPEDESCRIPTION
+#if UAPP_HAS_TYPEDESCRIPTION
     dst.typeName = detail::allocCString(src.typeName);
 #endif
     copyMembers(src.members, src.membersSize, dst);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -314,9 +314,9 @@ void Server::setCustomHostname([[maybe_unused]] std::string_view hostname) {
 
 void Server::setCustomDataTypes(Span<const DataType> dataTypes) {
     context().dataTypes = {dataTypes.begin(), dataTypes.end()};
-    context().dataTypeArray = std::make_unique<UA_DataTypeArray>(
-        detail::createDataTypeArray(context().dataTypes)
-    );
+    context().dataTypeArray = std::make_unique<UA_DataTypeArray>(detail::createDataTypeArray(
+        asNative(context().dataTypes.data()), context().dataTypes.size(), nullptr
+    ));
     config()->customDataTypes = context().dataTypeArray.get();
 }
 


### PR DESCRIPTION
Allow `memberName`s that are no string literals (known at compile time).