### PR TITLE
feat: *Config::addCustomDataTypes

### DIFF
--- a/examples/custom_datatypes/client_custom_datatypes.cpp
+++ b/examples/custom_datatypes/client_custom_datatypes.cpp
@@ -17,7 +17,7 @@ int main() {
     const auto& dataTypeColor = getColorDataType();
 
     // Provide custom data type definitions to client
-    client.setCustomDataTypes({
+    client.config().addCustomDataTypes({
         dataTypePoint,
         dataTypeMeasurements,
         dataTypeOpt,

--- a/examples/custom_datatypes/server_custom_datatypes.cpp
+++ b/examples/custom_datatypes/server_custom_datatypes.cpp
@@ -14,7 +14,7 @@ int main() {
     const auto& dataTypeColor = getColorDataType();
 
     // Provide custom data type definitions to server
-    server.setCustomDataTypes({
+    server.config().addCustomDataTypes({
         dataTypePoint,
         dataTypeMeasurements,
         dataTypeOpt,

--- a/include/open62541pp/client.hpp
+++ b/include/open62541pp/client.hpp
@@ -94,6 +94,10 @@ public:
 
     /// Set message security mode.
     void setSecurityMode(MessageSecurityMode mode) noexcept;
+
+    /// Add custom data types.
+    /// All data types provided are automatically considered for decoding of received messages.
+    void addCustomDataTypes(Span<const DataType> types);
 };
 
 /* ------------------------------------------- Client ------------------------------------------- */
@@ -187,9 +191,10 @@ public:
         config().setSecurityMode(mode);
     }
 
-    /// Set custom data types.
-    /// All data types provided are automatically considered for decoding of received messages.
-    void setCustomDataTypes(Span<const DataType> dataTypes);
+    [[deprecated("use ClientConfig::addCustomDataTypes via config() or pass config to Client")]]
+    void setCustomDataTypes(Span<const DataType> dataTypes) {
+        config().addCustomDataTypes(dataTypes);
+    }
 
     /// Set a state callback that will be called after the client is connected.
     void onConnected(StateCallback callback);

--- a/include/open62541pp/server.hpp
+++ b/include/open62541pp/server.hpp
@@ -105,6 +105,10 @@ public:
     /// Set application name, default: `open62541-based OPC UA Application`.
     void setApplicationName(std::string_view name);
 
+    /// Add custom data types.
+    /// All data types provided are automatically considered for decoding of received messages.
+    void addCustomDataTypes(Span<const DataType> types);
+
     /// Set custom access control.
     void setAccessControl(AccessControlBase& accessControl);
     /// Set custom access control (transfer ownership to Server).
@@ -211,9 +215,10 @@ public:
         config().setAccessControl(std::move(accessControl));
     }
 
-    /// Set custom data types.
-    /// All data types provided are automatically considered for decoding of received messages.
-    void setCustomDataTypes(Span<const DataType> dataTypes);
+    [[deprecated("use ServerConfig::addCustomDataTypes via config() or pass config to Server")]]
+    void setCustomDataTypes(Span<const DataType> dataTypes) {
+        config().addCustomDataTypes(dataTypes);
+    }
 
     /// Get active sessions.
     std::vector<Session> sessions();

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -146,6 +146,10 @@ void ClientConfig::setSecurityMode(MessageSecurityMode mode) noexcept {
     native().securityMode = static_cast<UA_MessageSecurityMode>(mode);
 }
 
+void ClientConfig::addCustomDataTypes(Span<const DataType> types) {
+    detail::addDataTypes(native().customDataTypes, types);
+}
+
 /* --------------------------------------- State callbacks -------------------------------------- */
 
 // State changes in open62541.
@@ -368,10 +372,6 @@ std::vector<EndpointDescription> Client::getEndpoints(std::string_view serverUrl
     UA_Array_delete(array, arraySize, &UA_TYPES[UA_TYPES_ENDPOINTDESCRIPTION]);
     throwIfBad(status);
     return result;
-}
-
-void Client::setCustomDataTypes(Span<const DataType> dataTypes) {
-    detail::addDataTypes(config()->customDataTypes, dataTypes);
 }
 
 static void setStateCallback(Client& client, detail::ClientState state, StateCallback&& callback) {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -118,6 +118,10 @@ void ServerConfig::setApplicationName(std::string_view name) {
     copyApplicationDescriptionToEndpoints(native());
 }
 
+void ServerConfig::addCustomDataTypes(Span<const DataType> types) {
+    detail::addDataTypes(native().customDataTypes, types);
+}
+
 static void copyUserTokenPoliciesToEndpoints(UA_ServerConfig& config) {
     // copy config.accessControl.userTokenPolicies -> config.endpoints[i].userIdentityTokens
     auto& ac = config.accessControl;
@@ -312,10 +316,6 @@ void Server::setCustomHostname([[maybe_unused]] std::string_view hostname) {
 #if UAPP_OPEN62541_VER_LE(1, 3)
     asWrapper<String>(config()->customHostname) = String(hostname);
 #endif
-}
-
-void Server::setCustomDataTypes(Span<const DataType> dataTypes) {
-    detail::addDataTypes(config()->customDataTypes, dataTypes);
 }
 
 std::vector<Session> Server::sessions() {

--- a/tests/client_server_common.cpp
+++ b/tests/client_server_common.cpp
@@ -55,6 +55,21 @@ TEMPLATE_TEST_CASE("Config", "", ClientConfig, ServerConfig) {
         CHECK(lastMessage == "Message");
     }
 
+    SECTION("addCustomDataTypes") {
+        CHECK(config->customDataTypes == nullptr);
+
+        config.addCustomDataTypes({
+            DataType(UA_TYPES[UA_TYPES_STRING]),
+            DataType(UA_TYPES[UA_TYPES_INT32]),
+        });
+        CHECK(config->customDataTypes != nullptr);
+        CHECK(config->customDataTypes->next == nullptr);
+        CHECK(config->customDataTypes->typesSize == 2);
+        CHECK(config->customDataTypes->types != nullptr);
+        CHECK((config->customDataTypes->types[0] == UA_TYPES[UA_TYPES_STRING]));
+        CHECK((config->customDataTypes->types[1] == UA_TYPES[UA_TYPES_INT32]));
+    }
+
     SECTION("handle") {
         CHECK(config.handle() != nullptr);
         CHECK(std::as_const(config).handle() != nullptr);
@@ -88,21 +103,6 @@ TEMPLATE_TEST_CASE("Connection", "", Client, Server) {
     SECTION("handle") {
         CHECK(connection.handle() != nullptr);
         CHECK(std::as_const(connection).handle() != nullptr);
-    }
-
-    SECTION("setCustomDataTypes") {
-        CHECK(connection.config()->customDataTypes == nullptr);
-
-        connection.setCustomDataTypes({
-            DataType(UA_TYPES[UA_TYPES_STRING]),
-            DataType(UA_TYPES[UA_TYPES_INT32]),
-        });
-        CHECK(connection.config()->customDataTypes != nullptr);
-        CHECK(connection.config()->customDataTypes->next == nullptr);
-        CHECK(connection.config()->customDataTypes->typesSize == 2);
-        CHECK(connection.config()->customDataTypes->types != nullptr);
-        CHECK((connection.config()->customDataTypes->types[0] == UA_TYPES[UA_TYPES_STRING]));
-        CHECK((connection.config()->customDataTypes->types[1] == UA_TYPES[UA_TYPES_INT32]));
     }
 
     SECTION("Equality operators") {


### PR DESCRIPTION
`customDataTypes` are part of the client/server config and not the client/server instance. Move method to config class:

```cpp
ClientConfig::addCustomDataTypes(Span<const DataType> types);
ServerConfig::addCustomDataTypes(Span<const DataType> types);
```

The old methods `Client::setCustomDataTypes` and `Server::setCustomDataTypes` are deprecated.