### PR TITLE
feat: comparison operators for registered types

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -92,6 +92,7 @@ PREDEFINED             = UA_ENABLE_DA \
                          UAPP_HAS_TYPEDESCRIPTION=1 \
                          UAPP_HAS_PARSING=1 \
                          UAPP_HAS_TOSTRING=1 \
+                         UAPP_HAS_ORDER=1 \
                          UAPP_HAS_DATAACCESS=1 \
                          UAPP_HAS_ASYNC_SUBSCRIPTIONS=1 \
                          UAPP_HAS_CREATE_CERTIFICATE=1 \

--- a/include/open62541pp/config.hpp.in
+++ b/include/open62541pp/config.hpp.in
@@ -51,6 +51,8 @@
 #define UAPP_HAS_TOSTRING 0
 #endif
 
+#define UAPP_HAS_ORDER UAPP_OPEN62541_VER_GE(1, 2)
+
 #ifdef UA_ENABLE_DA
 // types like UA_EUInformation added since v1.1
 #define UAPP_HAS_DATAACCESS UAPP_OPEN62541_VER_GE(1, 1)

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -2549,7 +2549,7 @@ String toString(const NumericRange& range);
  * Requires open62541 v1.2 or later.
  * The open62541 library must be compiled with the `UA_ENABLE_TYPEDESCRIPTION` option.
  * If these conditions are not met, the function returns an empty String.
- * 
+ *
  * @param object Native or wrapper object.
  * @param type Data type of `object`.
  *
@@ -2574,6 +2574,54 @@ template <typename T, typename = std::enable_if_t<detail::IsRegistered<T>::value
 String toString(const T& object) {
     return toString(object, getDataType<T>());
 }
+
+/* ------------------------------------ Comparison operators ------------------------------------ */
+
+#if UAPP_HAS_ORDER
+
+/// @relates TypeWrapper
+/// @ingroup Wrapper
+template <typename T, typename = std::enable_if_t<detail::IsRegistered<T>::value>>
+inline bool operator==(const T& lhs, const T& rhs) noexcept {
+    return UA_order(&lhs, &rhs, &getDataType<T>()) == UA_ORDER_EQ;
+}
+
+/// @relates TypeWrapper
+/// @ingroup Wrapper
+template <typename T, typename = std::enable_if_t<detail::IsRegistered<T>::value>>
+inline bool operator!=(const T& lhs, const T& rhs) noexcept {
+    return UA_order(&lhs, &rhs, &getDataType<T>()) != UA_ORDER_EQ;
+}
+
+/// @relates TypeWrapper
+/// @ingroup Wrapper
+template <typename T, typename = std::enable_if_t<detail::IsRegistered<T>::value>>
+inline bool operator<(const T& lhs, const T& rhs) noexcept {
+    return UA_order(&lhs, &rhs, &getDataType<T>()) == UA_ORDER_LESS;
+}
+
+/// @relates TypeWrapper
+/// @ingroup Wrapper
+template <typename T, typename = std::enable_if_t<detail::IsRegistered<T>::value>>
+inline bool operator<=(const T& lhs, const T& rhs) noexcept {
+    return UA_order(&lhs, &rhs, &getDataType<T>()) <= UA_ORDER_EQ;
+}
+
+/// @relates TypeWrapper
+/// @ingroup Wrapper
+template <typename T, typename = std::enable_if_t<detail::IsRegistered<T>::value>>
+inline bool operator>(const T& lhs, const T& rhs) noexcept {
+    return UA_order(&lhs, &rhs, &getDataType<T>()) == UA_ORDER_MORE;
+}
+
+/// @relates TypeWrapper
+/// @ingroup Wrapper
+template <typename T, typename = std::enable_if_t<detail::IsRegistered<T>::value>>
+inline bool operator>=(const T& lhs, const T& rhs) noexcept {
+    return UA_order(&lhs, &rhs, &getDataType<T>()) >= UA_ORDER_EQ;
+}
+
+#endif
 
 }  // namespace opcua
 

--- a/tests/types_builtin.cpp
+++ b/tests/types_builtin.cpp
@@ -8,6 +8,7 @@
 #include "open62541pp/detail/string_utils.hpp"  // toNativeString
 #include "open62541pp/types.hpp"
 #include "open62541pp/ua/nodeids.hpp"
+#include "open62541pp/ua/typeregistry.hpp"
 
 using Catch::Matchers::ContainsSubstring;
 using Catch::Matchers::Message;
@@ -1157,14 +1158,44 @@ TEST_CASE("NumericRange") {
 
 #if UAPP_HAS_TOSTRING
 TEST_CASE("toString") {
-    const auto toStringStl = [](auto... args) {
-        return std::string{toString(args...)};
-    };
+    const auto toStringStl = [](auto... args) { return std::string{toString(args...)}; };
 
     CHECK_THAT(toStringStl(11), ContainsSubstring("11"));
     CHECK_THAT(toStringStl(11, UA_TYPES[UA_TYPES_INT32]), ContainsSubstring("11"));
 
     CHECK_THAT(toStringStl(String("test")), ContainsSubstring("test"));
     CHECK_THAT(toStringStl(String("test"), UA_TYPES[UA_TYPES_STRING]), ContainsSubstring("test"));
+}
+#endif
+
+#if UAPP_HAS_ORDER
+TEST_CASE("Comparison operators") {
+    // use simple registered type without custom comparison overloads
+    STATIC_REQUIRE(detail::IsRegistered<UA_Range>::value);
+    const UA_Range r1{1, 2};
+    const UA_Range r2{3, 4};
+    const UA_Range r3{5, 6};
+
+    CHECK((r1 == r1));
+    CHECK_FALSE((r1 == r2));
+
+    CHECK((r1 != r2));
+    CHECK_FALSE((r1 != r1));
+
+    CHECK((r1 < r2));
+    CHECK_FALSE((r2 < r2));
+    CHECK_FALSE((r3 < r2));
+
+    CHECK((r1 <= r2));
+    CHECK((r2 <= r2));
+    CHECK_FALSE((r3 <= r2));
+
+    CHECK((r3 > r2));
+    CHECK_FALSE((r2 > r2));
+    CHECK_FALSE((r1 > r2));
+
+    CHECK((r3 >= r2));
+    CHECK((r2 >= r2));
+    CHECK_FALSE((r1 >= r2));
 }
 #endif


### PR DESCRIPTION
Since open62541 v1.2, the function `UA_order` can compare any types described by `UA_DataType`.
This PR adds comparison overloads (`==`, `!=`, `<`, `<=`, `>`, `>=`) for all registered types.