### PR TITLE
feat!: return String instead of std::string from wrapper type member functions

### DIFF
--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -11,7 +11,6 @@
 #include <iterator>  // reverse_iterator
 #include <optional>
 #include <ratio>
-#include <string>
 #include <string_view>
 #include <type_traits>  // is_same_v
 #include <utility>  // move
@@ -464,7 +463,7 @@ public:
 
     /// Convert to string with given format (same format codes as strftime).
     /// @see https://en.cppreference.com/w/cpp/chrono/c/strftime
-    std::string format(std::string_view format, bool localtime = false) const;
+    String format(std::string_view format, bool localtime = false) const;
 };
 
 template <typename Clock, typename Duration>
@@ -529,7 +528,7 @@ public:
 
     /// @deprecated Use free function opcua::toString(const T&) instead
     [[deprecated("use free function toString instead")]]
-    std::string toString() const;
+    String toString() const;
 };
 
 /// @relates Guid
@@ -836,7 +835,7 @@ public:
 
     /// @deprecated Use free function opcua::toString(const T&) instead
     [[deprecated("use free function toString instead")]]
-    std::string toString() const;
+    String toString() const;
 
 private:
     std::variant<uint32_t, String, Guid, ByteString> getIdentifierImpl() const {
@@ -986,7 +985,7 @@ public:
 
     /// @deprecated Use free function opcua::toString(const T&) instead
     [[deprecated("use free function toString instead")]]
-    std::string toString() const;
+    String toString() const;
 };
 
 /// @relates ExpandedNodeId
@@ -2515,7 +2514,7 @@ public:
 
     /// @deprecated Use free function opcua::toString(const T&) instead
     [[deprecated("use free function toString instead")]]
-    std::string toString() const;
+    String toString() const;
 
 private:
     void clear() noexcept {

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -18,20 +18,20 @@ std::ostream& operator<<(std::ostream& os, const String& str) {
 
 /* -------------------------------------------- Guid -------------------------------------------- */
 
-std::string Guid::toString() const {
-    return std::string(opcua::toString(*this));
+String Guid::toString() const {
+    return opcua::toString(*this);
 }
 
 /* ------------------------------------------ DateTime ------------------------------------------ */
 
-std::string DateTime::format(std::string_view format, bool localtime) const {
+String DateTime::format(std::string_view format, bool localtime) const {
     const std::time_t unixTime = toUnixTime();
     std::ostringstream ss;
     const auto* timeinfo = localtime ? std::localtime(&unixTime) : std::gmtime(&unixTime);
     if (timeinfo != nullptr) {
         ss << std::put_time(timeinfo, std::string(format).c_str());
     }
-    return ss.str();
+    return String{ss.str()};
 }
 
 /* ----------------------------------------- ByteString ----------------------------------------- */
@@ -56,14 +56,14 @@ String ByteString::toBase64() const {
 
 /* ------------------------------------------- NodeId ------------------------------------------- */
 
-std::string NodeId::toString() const {
-    return std::string{opcua::toString(*this)};
+String NodeId::toString() const {
+    return opcua::toString(*this);
 }
 
 /* --------------------------------------- ExpandedNodeId --------------------------------------- */
 
-std::string ExpandedNodeId::toString() const {
-    return std::string{opcua::toString(*this)};
+String ExpandedNodeId::toString() const {
+    return opcua::toString(*this);
 }
 
 /* ---------------------------------------- NumericRange ---------------------------------------- */
@@ -77,7 +77,7 @@ NumericRange::NumericRange(std::string_view encodedRange) {
 #endif
 }
 
-static std::string toStringImpl(const NumericRange& range) {
+static String toStringImpl(const NumericRange& range) {
     std::ostringstream ss;
     for (const auto& dimension : range.dimensions()) {
         ss << dimension.min;
@@ -88,15 +88,15 @@ static std::string toStringImpl(const NumericRange& range) {
     }
     auto str = ss.str();
     str.pop_back();  // remove last comma
-    return str;
+    return String{str};
 }
 
-std::string NumericRange::toString() const {
+String NumericRange::toString() const {
     return toStringImpl(*this);
 }
 
 String toString(const NumericRange& range) {
-    return String(toStringImpl(range));
+    return toStringImpl(range);
 }
 
 }  // namespace opcua

--- a/tests/types_builtin.cpp
+++ b/tests/types_builtin.cpp
@@ -1,4 +1,5 @@
 #include <sstream>
+#include <string>
 
 #include <catch2/catch_template_test_macros.hpp>
 #include <catch2/catch_test_macros.hpp>


### PR DESCRIPTION
Avoid `#include <string>` in core headers.