### PR TITLE
feat!: use String instead of std::string for Login::username and password

### DIFF
--- a/examples/server_accesscontrol.cpp
+++ b/examples/server_accesscontrol.cpp
@@ -49,8 +49,8 @@ int main() {
     AccessControlCustom accessControl(
         true,  // allow anonymous
         {
-            {"admin", "admin"},
-            {"user", "user"},
+            Login{String{"admin"}, String{"admin"}},
+            Login{String{"user"}, String{"user"}},
         }
     );
 

--- a/include/open62541pp/plugin/accesscontrol_default.hpp
+++ b/include/open62541pp/plugin/accesscontrol_default.hpp
@@ -2,6 +2,7 @@
 
 #include <vector>
 
+#include "open62541pp/span.hpp"
 #include "open62541pp/types.hpp"
 #include "open62541pp/plugin/accesscontrol.hpp"
 
@@ -23,7 +24,7 @@ struct Login {
  */
 class AccessControlDefault : public AccessControlBase {
 public:
-    explicit AccessControlDefault(bool allowAnonymous = true, std::vector<Login> logins = {});
+    explicit AccessControlDefault(bool allowAnonymous = true, Span<const Login> logins = {});
 
     Span<UserTokenPolicy> getUserTokenPolicies() override;
 

--- a/include/open62541pp/plugin/accesscontrol_default.hpp
+++ b/include/open62541pp/plugin/accesscontrol_default.hpp
@@ -1,16 +1,16 @@
 #pragma once
 
-#include <string>
 #include <vector>
 
+#include "open62541pp/types.hpp"
 #include "open62541pp/plugin/accesscontrol.hpp"
 
 namespace opcua {
 
 /// Login credentials.
 struct Login {
-    std::string username;
-    std::string password;
+    String username;
+    String password;
 };
 
 /**

--- a/src/plugin/accesscontrol_default.cpp
+++ b/src/plugin/accesscontrol_default.cpp
@@ -85,8 +85,7 @@ StatusCode AccessControlDefault::activateSession(
         }
         // try to match username / password
         for (const auto& login : logins_) {
-            if ((login.username == static_cast<std::string_view>(token->userName())) &&
-                (login.password == static_cast<std::string_view>(token->password()))) {
+            if ((login.username == token->userName()) && (login.password == token->password())) {
                 return UA_STATUSCODE_GOOD;
             }
         }

--- a/src/plugin/accesscontrol_default.cpp
+++ b/src/plugin/accesscontrol_default.cpp
@@ -10,9 +10,9 @@ namespace opcua {
 constexpr std::string_view policyIdAnonymous = "open62541-anonymous-policy";
 constexpr std::string_view policyIdUsername = "open62541-username-policy";
 
-AccessControlDefault::AccessControlDefault(bool allowAnonymous, std::vector<Login> logins)
+AccessControlDefault::AccessControlDefault(bool allowAnonymous, Span<const Login> logins)
     : allowAnonymous_(allowAnonymous),
-      logins_(std::move(logins)) {
+      logins_(logins.begin(), logins.end()) {
     const std::string_view issuedTokenType{};
     const std::string_view issuerEndpointUrl{};
     const std::string_view securityPolicyUri{};

--- a/tests/client.cpp
+++ b/tests/client.cpp
@@ -113,7 +113,7 @@ TEST_CASE("Client connect with AnonymousIdentityToken") {
 
 #if UAPP_OPEN62541_VER_GE(1, 3)
 TEST_CASE("Client connect with UserNameIdentityToken") {
-    AccessControlDefault accessControl(false, {{"username", "password"}});
+    AccessControlDefault accessControl(false, {Login{String{"username"}, String{"password"}}});
     Server server;
     server.config().setAccessControl(accessControl);
     ServerRunner serverRunner(server);

--- a/tests/plugin_accesscontrol.cpp
+++ b/tests/plugin_accesscontrol.cpp
@@ -14,7 +14,7 @@ TEST_CASE("AccessControlDefault") {
     Server server;
 
     SECTION("getUserTokenPolicies") {
-        AccessControlDefault ac(true, {{"username", "password"}});
+        AccessControlDefault ac(true, {Login{String{"username"}, String{"password"}}});
 
         CHECK(ac.getUserTokenPolicies().size() == 2);
         CHECK(ac.getUserTokenPolicies()[0].policyId() == "open62541-anonymous-policy");
@@ -28,7 +28,7 @@ TEST_CASE("AccessControlDefault") {
         for (bool allowAnonymous : {false, true}) {
             CAPTURE(allowAnonymous);
 
-            AccessControlDefault ac(allowAnonymous, {{"username", "password"}});
+            AccessControlDefault ac(allowAnonymous, {Login{String{"username"}, String{"password"}}});
             Session session(server, NodeId{}, nullptr);
             const EndpointDescription endpointDescription{};
             const ByteString secureChannelRemoteCertificate{};

--- a/tests/server.cpp
+++ b/tests/server.cpp
@@ -105,7 +105,7 @@ TEST_CASE("ServerConfig") {
         }
 
         SECTION("Use highest security policy to transfer user tokens") {
-            AccessControlDefault accessControl(true, {{"user", "password"}});
+            AccessControlDefault accessControl(true, {Login{String{"user"}, String{"password"}}});
             config.setAccessControl(accessControl);
             auto& ac = config->accessControl;
 


### PR DESCRIPTION
Avoid `#include <string>`.