### PR TITLE
feat: deprecate specialized Node::readValue* and Node::writeValue* functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ cog.out(Path("examples/server_minimal.cpp").read_text())
 cog.outl("```")
 ]]] -->
 ```cpp
-#include <open62541pp/open62541pp.hpp>
+#include <open62541pp/node.hpp>
+#include <open62541pp/server.hpp>
 
 int main() {
     opcua::Server server;
@@ -77,7 +78,7 @@ int main() {
     opcua::Node parentNode(server, opcua::ObjectId::ObjectsFolder);
     opcua::Node myIntegerNode = parentNode.addVariable({1, 1000}, "TheAnswer");
     // Write value attribute
-    myIntegerNode.writeValueScalar(42);
+    myIntegerNode.writeValue(opcua::Variant{42});
 
     server.run();
 }
@@ -96,14 +97,15 @@ cog.outl("```")
 ```cpp
 #include <iostream>
 
-#include <open62541pp/open62541pp.hpp>
+#include <open62541pp/client.hpp>
+#include <open62541pp/node.hpp>
 
 int main() {
     opcua::Client client;
     client.connect("opc.tcp://localhost:4840");
 
     opcua::Node node(client, opcua::VariableId::Server_ServerStatus_CurrentTime);
-    const auto dt = node.readValueScalar<opcua::DateTime>();
+    const auto dt = node.readValue().to<opcua::DateTime>();
 
     std::cout << "Server date (UTC): " << dt.format("%Y-%m-%d %H:%M:%S") << std::endl;
 }

--- a/examples/client_connect.cpp
+++ b/examples/client_connect.cpp
@@ -31,7 +31,7 @@ int main(int argc, char* argv[]) {
     client.connect(serverUrl);
 
     opcua::Node node(client, opcua::VariableId::Server_ServerStatus_CurrentTime);
-    const auto dt = node.readValueScalar<opcua::DateTime>();
+    const auto dt = node.readValue().to<opcua::DateTime>();
     client.disconnect();
 
     std::cout << "Server date (UTC): " << dt.format("%Y-%m-%d %H:%M:%S") << std::endl;

--- a/examples/client_minimal.cpp
+++ b/examples/client_minimal.cpp
@@ -8,7 +8,7 @@ int main() {
     client.connect("opc.tcp://localhost:4840");
 
     opcua::Node node(client, opcua::VariableId::Server_ServerStatus_CurrentTime);
-    const auto dt = node.readValueScalar<opcua::DateTime>();
+    const auto dt = node.readValue().to<opcua::DateTime>();
 
     std::cout << "Server date (UTC): " << dt.format("%Y-%m-%d %H:%M:%S") << std::endl;
 }

--- a/examples/server.cpp
+++ b/examples/server.cpp
@@ -23,10 +23,10 @@ int main() {
     );
 
     // Write a value (attribute) to the node
-    myIntegerNode.writeValueScalar(42);
+    myIntegerNode.writeValue(opcua::Variant{42});
 
     // Read the value (attribute) from the node
-    std::cout << "The answer is: " << myIntegerNode.readValueScalar<int>() << std::endl;
+    std::cout << "The answer is: " << myIntegerNode.readValue().to<int>() << std::endl;
 
     server.run();
 }

--- a/examples/server_instantiation.cpp
+++ b/examples/server_instantiation.cpp
@@ -65,8 +65,8 @@ int main() {
     );
 
     // Set variables Age and Name
-    nodeBello.browseChild({{1, "Age"}}).writeValueScalar(3U);
-    nodeBello.browseChild({{1, "Name"}}).writeValueScalar("Bello");
+    nodeBello.browseChild({{1, "Age"}}).writeValue(opcua::Variant{3U});
+    nodeBello.browseChild({{1, "Name"}}).writeValue(opcua::Variant{"Bello"});
 
     server.run();
 }

--- a/examples/server_minimal.cpp
+++ b/examples/server_minimal.cpp
@@ -8,7 +8,7 @@ int main() {
     opcua::Node parentNode(server, opcua::ObjectId::ObjectsFolder);
     opcua::Node myIntegerNode = parentNode.addVariable({1, 1000}, "TheAnswer");
     // Write value attribute
-    myIntegerNode.writeValueScalar(42);
+    myIntegerNode.writeValue(opcua::Variant{42});
 
     server.run();
 }

--- a/examples/server_valuecallback.cpp
+++ b/examples/server_valuecallback.cpp
@@ -16,7 +16,7 @@ class CurrentTimeCallback : public opcua::ValueCallbackBase {
         const auto timeNow = opcua::DateTime::now();
         std::cout << "Time before read: " << timeOld.format("%Y-%m-%d %H:%M:%S") << std::endl;
         std::cout << "Set current time: " << timeNow.format("%Y-%m-%d %H:%M:%S") << std::endl;
-        node.writeValueScalar(timeNow);
+        node.writeValue(opcua::Variant{timeNow});
     }
 
     void onWrite(
@@ -36,7 +36,7 @@ int main() {
         .writeDisplayName({"en-US", "Current time"})
         .writeDescription({"en-US", "Current time"})
         .writeDataType<opcua::DateTime>()
-        .writeValueScalar(opcua::DateTime::now());
+        .writeValue(opcua::Variant{opcua::DateTime::now()});
 
     CurrentTimeCallback currentTimeCallback;
     server.setVariableNodeValueCallback(currentTimeId, currentTimeCallback);

--- a/include/open62541pp/node.hpp
+++ b/include/open62541pp/node.hpp
@@ -845,14 +845,16 @@ public:
         return services::readValueAsync(connection(), id(), std::forward<CompletionToken>(token));
     }
 
-    /// Read scalar value from variable node.
+    /// @deprecated Use readValue().to<T>() instead
     template <typename T>
+    [[deprecated("use readValue().to<T>() instead")]]
     T readValueScalar() {
         return readValue().template to<T>();
     }
-
-    /// Read array value from variable node.
+    
+    /// @deprecated Use readValue().to<std::vector<T>>() instead
     template <typename T>
+    [[deprecated("use readValue().to<std::vector<T>>() instead")]]
     std::vector<T> readValueArray() {
         return readValue().template to<std::vector<T>>();
     }
@@ -1163,34 +1165,25 @@ public:
         );
     }
 
-    /// Write scalar to variable node.
+    /// @deprecated Use writeValue(Variant(value)) instead
     template <typename T>
+    [[deprecated("use writeValue(Variant(value)) instead")]]
     Node& writeValueScalar(const T& value) {
-        if constexpr (detail::IsRegistered<T>::value) {
-            // NOLINTNEXTLINE(*-const-cast), variant isn't modified, avoid copy
-            writeValue(Variant(const_cast<T*>(&value)));
-        } else {
-            writeValue(Variant(value));
-        }
-
+        writeValue(Variant(value));
         return *this;
     }
-
-    /// Write array value to variable node.
+    
+    /// @deprecated Use writeValue(Variant(array)) instead
     template <typename ArrayLike>
+    [[deprecated("use writeValue(Variant(array)) instead")]]
     Node& writeValueArray(const ArrayLike& array) {
-        if constexpr (detail::IsContiguousRange<ArrayLike>::value &&
-                      detail::IsRegistered<detail::RangeValueT<ArrayLike>>::value) {
-            // NOLINTNEXTLINE(*-const-cast), variant isn't modified, avoid copy
-            writeValue(Variant(const_cast<ArrayLike*>(&array)));
-        } else {
-            writeValue(Variant(array));
-        }
+        writeValue(Variant(array));
         return *this;
     }
-
-    /// Write range of elements as array value to variable node.
+    
+    /// @deprecated Use writeValue(Variant(first, last)) instead
     template <typename InputIt>
+    [[deprecated("use writeValue(Variant(first, last)) instead")]]
     Node& writeValueArray(InputIt first, InputIt last) {
         writeValue(Variant(first, last));
         return *this;

--- a/tests/node.cpp
+++ b/tests/node.cpp
@@ -380,61 +380,6 @@ TEMPLATE_TEST_CASE("Node", "", Server, Client, Async<Client>) {
         }
     }
 
-    SECTION("writeValue*/readValue*") {
-        SECTION("Scalar") {
-            CHECK_NOTHROW(varNode.writeDataType(DataTypeId::Float));
-
-            // write with wrong data type
-            CHECK_THROWS(varNode.writeValueScalar(bool{}));
-            CHECK_THROWS(varNode.writeValueScalar(int{}));
-
-            // write with correct data type
-            float value = 11.11f;
-            CHECK_NOTHROW(varNode.writeValueScalar(value));
-            CHECK(varNode.template readValueScalar<float>() == value);
-        }
-
-        SECTION("String") {
-            CHECK_NOTHROW(varNode.writeDataType(DataTypeId::String));
-
-            String str("test");
-            CHECK_NOTHROW(varNode.writeValueScalar(str));
-            CHECK(varNode.template readValueScalar<std::string>() == "test");
-        }
-
-        SECTION("Array") {
-            CHECK_NOTHROW(varNode.writeDataType(DataTypeId::Double));
-
-            // write with wrong data type
-            CHECK_THROWS(varNode.writeValueArray(std::vector<int>{}));
-            CHECK_THROWS(varNode.writeValueArray(std::vector<float>{}));
-
-            // write with correct data type
-            std::vector<double> array{11.11, 22.22, 33.33};
-
-            SECTION("Write as std::vector") {
-                CHECK_NOTHROW(varNode.writeValueArray(array));
-                CHECK(varNode.template readValueArray<double>() == array);
-            }
-
-            SECTION("Write as raw array") {
-                CHECK_NOTHROW(varNode.writeValueArray(Span{array.data(), array.size()}));
-                CHECK(varNode.template readValueArray<double>() == array);
-            }
-
-            SECTION("Write as iterator pair") {
-                CHECK_NOTHROW(varNode.writeValueArray(array.begin(), array.end()));
-                CHECK(varNode.template readValueArray<double>() == array);
-            }
-        }
-
-        SECTION("Array (std::vector<bool>)") {
-            std::vector<bool> array{true, false, true};
-            CHECK_NOTHROW(varNode.writeValueArray(array));
-            CHECK_NOTHROW(varNode.writeValueArray(array.begin(), array.end()));
-        }
-    }
-
     SECTION("writeDataType/readDataType") {
         const NodeId dataType(DataTypeId::Float);
         if constexpr (isAsync<TestType>) {

--- a/tests/server.cpp
+++ b/tests/server.cpp
@@ -250,7 +250,7 @@ TEST_CASE("ValueCallback") {
 
     const NodeId id{1, 1000};
     auto node = Node(server, ObjectId::ObjectsFolder).addVariable(id, "TestVariable");
-    node.writeValueScalar<int>(1);
+    node.writeValue(Variant{1});
 
     auto callbackPtr = std::make_unique<ValueCallbackTest>();
     auto& callback = *callbackPtr;
@@ -261,14 +261,14 @@ TEST_CASE("ValueCallback") {
     }
 
     SECTION("trigger onRead callback with read operation") {
-        CHECK(node.readValueScalar<int>() == 1);
+        CHECK(node.readValue().to<int>() == 1);
         CHECK(callback.onReadCalled == true);
         CHECK(callback.onWriteCalled == false);
         CHECK(callback.valueBeforeRead.value().scalar<int>() == 1);
     }
 
     SECTION("trigger onAfterWrite callback with write operation") {
-        node.writeValueScalar<int>(2);
+        node.writeValue(Variant{2});
         CHECK(callback.onReadCalled == false);
         CHECK(callback.onWriteCalled == true);
         CHECK(callback.valueAfterWrite.value().scalar<int>() == 2);
@@ -326,23 +326,23 @@ TEST_CASE("DataSource") {
 
     SECTION("read") {
         source.data = 1;
-        CHECK(node.readValueScalar<int>() == 1);
+        CHECK(node.readValue().to<int>() == 1);
     }
 
     SECTION("write") {
-        CHECK_NOTHROW(node.writeValueScalar<int>(2));
+        CHECK_NOTHROW(node.writeValue(Variant{2}));
         CHECK(source.data == 2);
     }
 
     SECTION("read/write with bad status code") {
         source.code = UA_STATUSCODE_BADINTERNALERROR;
-        CHECK_THROWS_MATCHES(node.readValueScalar<int>(), BadStatus, Message("BadInternalError"));
-        CHECK_THROWS_MATCHES(node.writeValueScalar<int>(2), BadStatus, Message("BadInternalError"));
+        CHECK_THROWS_MATCHES(node.readValue(), BadStatus, Message("BadInternalError"));
+        CHECK_THROWS_MATCHES(node.writeValue(Variant{2}), BadStatus, Message("BadInternalError"));
     }
 
     SECTION("read/write with exception in callback") {
         source.exception = BadStatus(UA_STATUSCODE_BADUNEXPECTEDERROR);
-        CHECK_THROWS_MATCHES(node.readValueScalar<int>(), BadStatus, Message("BadUnexpectedError"));
-        CHECK_THROWS_MATCHES(node.writeValueScalar<int>(2), BadStatus, Message("BadUnexpectedError"));
+        CHECK_THROWS_MATCHES(node.readValue(), BadStatus, Message("BadUnexpectedError"));
+        CHECK_THROWS_MATCHES(node.writeValue(Variant{2}), BadStatus, Message("BadUnexpectedError"));
     }
 }


### PR DESCRIPTION
Deprecate specialized `Node::readValue*` and `Node::writeValue*` functions.
The unified `Variant` API introduced in v0.17.0 is only slightly more verbose but more explicit:

- `Node::readValueScalar<T>()` -> `Node::readValue().to<T>()`
- `Node::readValueArray<T>()` -> `Node::readValue().to<std::vector<T>>()`
- `Node::writeValueScalar(const T& value)` -> `Node::writeValue(Variant(value))`
- `Node::writeValueArray(const T& array)` -> `Node::writeValue(Variant(array))`