### PR TITLE
feat: deprecate specialized Variable*Attributes::setValue* functions

### DIFF
--- a/examples/custom_datatypes/server_custom_datatypes.cpp
+++ b/examples/custom_datatypes/server_custom_datatypes.cpp
@@ -37,11 +37,13 @@ int main() {
                 .setDataType<opcua::EnumValueType>()
                 .setValueRank(opcua::ValueRank::OneDimension)
                 .setArrayDimensions({0})
-                .setValueArray(opcua::Span<const opcua::EnumValueType>{
-                    {0, {"", "Red"}, {}},
-                    {1, {"", "Green"}, {}},
-                    {2, {"", "Yellow"}, {}},
-                })
+                .setValue(
+                    opcua::Variant{opcua::Span<const opcua::EnumValueType>{
+                        {0, {"", "Red"}, {}},
+                        {1, {"", "Green"}, {}},
+                        {2, {"", "Yellow"}, {}},
+                    }}
+                )
         )
         .addModellingRule(opcua::ModellingRule::Mandatory);
 
@@ -53,7 +55,7 @@ int main() {
         opcua::VariableTypeAttributes{}
             .setDataType(dataTypePoint.typeId())
             .setValueRank(opcua::ValueRank::ScalarOrOneDimension)
-            .setValueScalar(Point{1, 2, 3}, dataTypePoint)
+            .setValue(opcua::Variant{Point{1, 2, 3}, dataTypePoint})
     );
     auto variableTypeMeasurementNode = baseDataVariableTypeNode.addVariableType(
         {1, 4444},
@@ -61,7 +63,7 @@ int main() {
         opcua::VariableTypeAttributes{}
             .setDataType(dataTypeMeasurements.typeId())
             .setValueRank(opcua::ValueRank::Scalar)
-            .setValueScalar(Measurements{}, dataTypeMeasurements)
+            .setValue(opcua::Variant{Measurements{}, dataTypeMeasurements})
     );
     auto variableTypeOptNode = baseDataVariableTypeNode.addVariableType(
         {1, 4645},
@@ -69,7 +71,7 @@ int main() {
         opcua::VariableTypeAttributes{}
             .setDataType(dataTypeOpt.typeId())
             .setValueRank(opcua::ValueRank::Scalar)
-            .setValueScalar(Opt{}, dataTypeOpt)
+            .setValue(opcua::Variant{Opt{}, dataTypeOpt})
     );
     auto variableTypeUniNode = baseDataVariableTypeNode.addVariableType(
         {1, 4846},
@@ -77,7 +79,7 @@ int main() {
         opcua::VariableTypeAttributes{}
             .setDataType(dataTypeUni.typeId())
             .setValueRank(opcua::ValueRank::Scalar)
-            .setValueScalar(Uni{}, dataTypeUni)
+            .setValue(opcua::Variant{Uni{}, dataTypeUni})
     );
 
     // Add variable nodes with some values
@@ -90,7 +92,7 @@ int main() {
         opcua::VariableAttributes{}
             .setDataType(dataTypePoint.typeId())
             .setValueRank(opcua::ValueRank::Scalar)
-            .setValueScalar(point, dataTypePoint),
+            .setValue(opcua::Variant{point, dataTypePoint}),
         variableTypePointNode.id()
     );
 
@@ -102,7 +104,7 @@ int main() {
             .setDataType(dataTypePoint.typeId())
             .setArrayDimensions({0})  // single dimension but unknown in size
             .setValueRank(opcua::ValueRank::OneDimension)
-            .setValueArray(pointVec, dataTypePoint),
+            .setValue(opcua::Variant{pointVec, dataTypePoint}),
         variableTypePointNode.id()
     );
 
@@ -118,7 +120,7 @@ int main() {
         opcua::VariableAttributes{}
             .setDataType(dataTypeMeasurements.typeId())
             .setValueRank(opcua::ValueRank::Scalar)
-            .setValueScalar(measurements, dataTypeMeasurements),
+            .setValue(opcua::Variant{measurements, dataTypeMeasurements}),
         variableTypeMeasurementNode.id()
     );
 
@@ -130,7 +132,7 @@ int main() {
         opcua::VariableAttributes{}
             .setDataType(dataTypeOpt.typeId())
             .setValueRank(opcua::ValueRank::Scalar)
-            .setValueScalar(opt, dataTypeOpt),
+            .setValue(opcua::Variant{opt, dataTypeOpt}),
         variableTypeOptNode.id()
     );
 
@@ -143,7 +145,7 @@ int main() {
         opcua::VariableAttributes{}
             .setDataType(dataTypeUni.typeId())
             .setValueRank(opcua::ValueRank::Scalar)
-            .setValueScalar(uni, dataTypeUni),
+            .setValue(opcua::Variant{uni, dataTypeUni}),
         variableTypeUniNode.id()
     );
 
@@ -153,7 +155,7 @@ int main() {
         opcua::VariableAttributes{}
             .setDataType(dataTypeColor.typeId())
             .setValueRank(opcua::ValueRank::Scalar)
-            .setValueScalar(Color::Green, dataTypeColor)
+            .setValue(opcua::Variant{Color::Green, dataTypeColor})
     );
 
     server.run();

--- a/examples/server_accesscontrol.cpp
+++ b/examples/server_accesscontrol.cpp
@@ -68,7 +68,7 @@ int main() {
                 .setAccessLevel(AccessLevel::CurrentRead | AccessLevel::CurrentWrite)
                 .setDataType(DataTypeId::Int32)
                 .setValueRank(ValueRank::Scalar)
-                .setValueScalar(0)
+                .setValue(opcua::Variant{0})
         );
 
     server.run();

--- a/examples/server_instantiation.cpp
+++ b/examples/server_instantiation.cpp
@@ -26,7 +26,7 @@ int main() {
             opcua::VariableAttributes{}
                 .setDisplayName({"en-US", "Age"})
                 .setDescription({"en-US", "This mammals age in months"})
-                .setValueScalar(0U)  // default age
+                .setValue(opcua::Variant{0U})  // default age
         )
         .addModellingRule(opcua::ModellingRule::Mandatory);  // create on new instance
 
@@ -45,7 +45,7 @@ int main() {
             opcua::VariableAttributes{}
                 .setDisplayName({"en-US", "Name"})
                 .setDescription({"en-US", "This dogs name"})
-                .setValueScalar("unnamed dog")  // default name
+                .setValue(opcua::Variant{"unnamed dog"})  // default name
         )
         .addModellingRule(opcua::ModellingRule::Mandatory);  // create on new instance
 

--- a/include/open62541pp/ua/types.hpp
+++ b/include/open62541pp/ua/types.hpp
@@ -477,14 +477,16 @@ public:
     UAPP_NODEATTR_COMMON
     UAPP_NODEATTR_WRAPPER(Variant, Value, value, UA_NODEATTRIBUTESMASK_VALUE)
 
-    /// @see Variant::Variant
+    /// @deprecated Use setValue(Variant{...}) instead
     template <typename... Args>
+    [[deprecated("use setValue(Variant{...}) instead")]]
     auto& setValueScalar(Args&&... args) {
         return setValue(Variant(std::forward<Args>(args)...));
     }
 
-    /// @see Variant::Variant
+    /// @deprecated Use setValue(Variant{...}) instead
     template <typename... Args>
+    [[deprecated("use setValue(Variant{...}) instead")]]
     auto& setValueArray(Args&&... args) {
         return setValue(Variant(std::forward<Args>(args)...));
     }
@@ -574,14 +576,16 @@ public:
     UAPP_NODEATTR_COMMON
     UAPP_NODEATTR_WRAPPER(Variant, Value, value, UA_NODEATTRIBUTESMASK_VALUE)
 
-    /// @see Variant::Variant
+    /// @deprecated Use setValue(Variant{...}) instead
     template <typename... Args>
+    [[deprecated("use setValue(Variant{...}) instead")]]
     auto& setValueScalar(Args&&... args) {
         return setValue(Variant(std::forward<Args>(args)...));
     }
 
-    /// @see Variant::Variant
+    /// @deprecated Use setValue(Variant{...}) instead
     template <typename... Args>
+    [[deprecated("use setValue(Variant{...}) instead")]]
     auto& setValueArray(Args&&... args) {
         return setValue(Variant(std::forward<Args>(args)...));
     }

--- a/tests/node.cpp
+++ b/tests/node.cpp
@@ -490,7 +490,7 @@ TEMPLATE_TEST_CASE("Node", "", Server, Client, Async<Client>) {
                 .setWriteMask(WriteMask::None)
                 .setAccessLevel(AccessLevel::CurrentRead | AccessLevel::CurrentWrite)
                 .setDataType<double>()
-                .setValueScalar(11.11)
+                .setValue(opcua::Variant{11.11})
         );
         CHECK(objNode.readObjectProperty({1, "Property"}).template scalar<double>() == 11.11);
         CHECK_NOTHROW(objNode.writeObjectProperty({1, "Property"}, Variant(22.22)));


### PR DESCRIPTION
The unified `Variant` API introduced in v0.17.0 is only slightly more verbose but more explicit:
- `VariableAttributes::setValueScalar(...)` -> `VariableAttributes::setValue(Variant{...})`
- `VariableAttributes::setValueArray(...)` -> `VariableAttributes::setValue(Variant{...})`
- `VariableTypeAttributes::setValueScalar(...)` -> `VariableTypeAttributes::setValue(Variant{...})`
- `VariableTypeAttributes::setValueArray(...)` -> `VariableTypeAttributes::setValue(Variant{...})`