### PR TITLE
feat!: remove deprecations ≤ v0.17.0

### DIFF
--- a/include/open62541pp/client.hpp
+++ b/include/open62541pp/client.hpp
@@ -208,12 +208,6 @@ public:
     /// Get all defined namespaces.
     std::vector<std::string> namespaceArray();
 
-    /// @deprecated Use namespaceArray() instead
-    [[deprecated("use namespaceArray() instead")]]
-    std::vector<std::string> getNamespaceArray() {
-        return namespaceArray();
-    }
-
 #ifdef UA_ENABLE_SUBSCRIPTIONS
     /// Create a subscription to monitor data changes and events.
     /// @deprecated Use Subscription constructor
@@ -222,12 +216,6 @@ public:
 
     /// Get all active subscriptions
     std::vector<Subscription<Client>> subscriptions();
-
-    /// @deprecated Use subscriptions() instead
-    [[deprecated("use subscriptions() instead")]]
-    std::vector<Subscription<Client>> getSubscriptions() {
-        return subscriptions();
-    }
 #endif
 
     /**

--- a/include/open62541pp/datatype.hpp
+++ b/include/open62541pp/datatype.hpp
@@ -129,12 +129,6 @@ public:
 #endif
     }
 
-    /// @deprecated Use typeName() instead
-    [[deprecated("use typeName() instead")]]
-    std::string_view getTypeName() const noexcept {
-        return typeName();
-    }
-
     void setTypeName([[maybe_unused]] std::string_view typeName) noexcept {
 #if UAPP_HAS_TYPEDESCRIPTION
         detail::clear(handle()->typeName);
@@ -144,12 +138,6 @@ public:
 
     NodeId typeId() const noexcept {
         return NodeId{handle()->typeId};  // NOLINT
-    }
-
-    /// @deprecated Use typeId() instead
-    [[deprecated("use typeId() instead")]]
-    NodeId getTypeId() const noexcept {
-        return typeId();
     }
 
     void setTypeId(NodeId typeId) {
@@ -164,12 +152,6 @@ public:
 #endif
     }
 
-    /// @deprecated Use binaryEncodingId() instead
-    [[deprecated("use binaryEncodingId() instead")]]
-    NodeId getBinaryEncodingId() const noexcept {
-        return binaryEncodingId();
-    }
-
     void setBinaryEncodingId(NodeId binaryEncodingId) {
 #if UAPP_OPEN62541_VER_GE(1, 2)
         asWrapper<NodeId>(handle()->binaryEncodingId) = std::move(binaryEncodingId);
@@ -182,24 +164,12 @@ public:
         return handle()->memSize;
     }
 
-    /// @deprecated Use memSize() instead
-    [[deprecated("use memSize() instead")]]
-    uint16_t getMemSize() const noexcept {
-        return memSize();
-    }
-
     void setMemSize(uint16_t memSize) noexcept {
         handle()->memSize = memSize;
     }
 
     uint8_t typeKind() const noexcept {
         return handle()->typeKind;
-    }
-
-    /// @deprecated Use typeKind() instead
-    [[deprecated("use typeKind() instead")]]
-    uint8_t getTypeKind() const noexcept {
-        return typeKind();
     }
 
     void setTypeKind(uint8_t typeKind) noexcept {
@@ -210,12 +180,6 @@ public:
         return handle()->pointerFree;
     }
 
-    /// @deprecated Use pointerFree() instead
-    [[deprecated("use pointerFree() instead")]]
-    bool getPointerFree() const noexcept {
-        return pointerFree();
-    }
-
     void setPointerFree(bool pointerFree) noexcept {
         handle()->pointerFree = pointerFree;
     }
@@ -224,24 +188,12 @@ public:
         return handle()->overlayable;
     }
 
-    /// @deprecated Use overlayable() instead
-    [[deprecated("use overlayable() instead")]]
-    bool getOverlayable() const noexcept {
-        return overlayable();
-    }
-
     void setOverlayable(bool overlayable) noexcept {
         handle()->overlayable = overlayable;
     }
 
     Span<const DataTypeMember> members() const noexcept {
         return {asWrapper<DataTypeMember>(handle()->members), handle()->membersSize};
-    }
-
-    /// @deprecated Use members() instead
-    [[deprecated("use members() instead")]]
-    Span<const DataTypeMember> getMembers() const noexcept {
-        return members();
     }
 
     void setMembers(Span<const DataTypeMember> members);

--- a/include/open62541pp/monitoreditem.hpp
+++ b/include/open62541pp/monitoreditem.hpp
@@ -60,20 +60,8 @@ public:
     /// Get the monitored NodeId.
     const NodeId& nodeId();
 
-    /// @deprecated Use nodeId() instead
-    [[deprecated("use nodeId() instead")]]
-    const NodeId& getNodeId() {
-        return nodeId();
-    }
-
     /// Get the monitored AttributeId.
     AttributeId attributeId();
-
-    /// @deprecated Use attributeId() instead
-    [[deprecated("use attributeId() instead")]]
-    AttributeId getAttributeId() {
-        return attributeId();
-    }
 
     /// Modify this monitored item.
     /// @note Not implemented for Server.

--- a/include/open62541pp/server.hpp
+++ b/include/open62541pp/server.hpp
@@ -159,20 +159,8 @@ public:
     /// Get active sessions.
     std::vector<Session> sessions();
 
-    /// @deprecated Use sessions() instead
-    [[deprecated("use sessions() instead")]]
-    std::vector<Session> getSessions() {
-        return sessions();
-    }
-
     /// Get all defined namespaces.
     std::vector<std::string> namespaceArray();
-
-    /// @deprecated Use namespaceArray() instead
-    [[deprecated("use namespaceArray() instead")]]
-    std::vector<std::string> getNamespaceArray() {
-        return namespaceArray();
-    }
 
     /// Register namespace. The new namespace index will be returned.
     [[nodiscard]] NamespaceIndex registerNamespace(std::string_view uri);

--- a/include/open62541pp/subscription.hpp
+++ b/include/open62541pp/subscription.hpp
@@ -70,12 +70,6 @@ public:
     /// Get all local monitored items.
     std::vector<MonitoredItem<Connection>> monitoredItems();
 
-    /// @deprecated Use monitoredItems() instead
-    [[deprecated("use monitoredItems() instead")]]
-    std::vector<MonitoredItem<Connection>> getMonitoredItems() {
-        return monitoredItems();
-    }
-
     /// Modify this subscription.
     /// @note Not implemented for Server.
     /// @see services::modifySubscription

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -706,20 +706,8 @@ public:
         return handle()->namespaceIndex;
     }
 
-    /// @deprecated Use namespaceIndex() instead
-    [[deprecated("use namespaceIndex() instead")]]
-    NamespaceIndex getNamespaceIndex() const noexcept {
-        return namespaceIndex();
-    }
-
     NodeIdType identifierType() const noexcept {
         return static_cast<NodeIdType>(handle()->identifierType);
-    }
-
-    /// @deprecated Use identifierType() instead
-    [[deprecated("use identifierType() instead")]]
-    NodeIdType getIdentifierType() const noexcept {
-        return identifierType();
     }
 
     /**
@@ -875,36 +863,12 @@ public:
         return asWrapper<NodeId>(handle()->nodeId);
     }
 
-    /// @deprecated Use nodeId() instead
-    [[deprecated("use nodeId() instead")]]
-    NodeId& getNodeId() noexcept {
-        return nodeId();
-    }
-
-    /// @deprecated Use nodeId() instead
-    [[deprecated("use nodeId() instead")]]
-    const NodeId& getNodeId() const noexcept {
-        return nodeId();
-    }
-
     std::string_view namespaceUri() const {
         return detail::toStringView(handle()->namespaceUri);
     }
 
-    /// @deprecated Use namespaceUri() instead
-    [[deprecated("use namespaceUri() instead")]]
-    std::string_view getNamespaceUri() const {
-        return namespaceUri();
-    }
-
     uint32_t serverIndex() const noexcept {
         return handle()->serverIndex;
-    }
-
-    /// @deprecated Use serverIndex() instead
-    [[deprecated("use serverIndex() instead")]]
-    uint32_t getServerIndex() const noexcept {
-        return serverIndex();
     }
 
     /// @deprecated Use free function opcua::toString(const T&) instead
@@ -961,20 +925,8 @@ public:
         return handle()->namespaceIndex;
     }
 
-    /// @deprecated Use namespaceIndex() instead
-    [[deprecated("use namespaceIndex() instead")]]
-    NamespaceIndex getNamespaceIndex() const noexcept {
-        return namespaceIndex();
-    }
-
     std::string_view name() const noexcept {
         return detail::toStringView(handle()->name);
-    }
-
-    /// @deprecated Use name() instead
-    [[deprecated("use name() instead")]]
-    std::string_view getName() const noexcept {
-        return name();
     }
 };
 
@@ -1012,20 +964,8 @@ public:
         return detail::toStringView(handle()->locale);
     }
 
-    /// @deprecated Use locale() instead
-    [[deprecated("use locale() instead")]]
-    std::string_view getLocale() const noexcept {
-        return locale();
-    }
-
     std::string_view text() const noexcept {
         return detail::toStringView(handle()->text);
-    }
-
-    /// @deprecated Use text() instead
-    [[deprecated("use text() instead")]]
-    std::string_view getText() const noexcept {
-        return text();
     }
 };
 
@@ -1334,32 +1274,14 @@ public:
         return handle()->type;
     }
 
-    /// @deprecated Use type() instead
-    [[deprecated("use type() instead")]]
-    const UA_DataType* getDataType() const noexcept {
-        return type();
-    }
-
     /// Get array length or 0 if variant is not an array.
     size_t arrayLength() const noexcept {
         return handle()->arrayLength;
     }
 
-    /// @deprecated Use arrayLength() instead
-    [[deprecated("use arrayLength() instead")]]
-    size_t getArrayLength() const noexcept {
-        return arrayLength();
-    }
-
     /// Get array dimensions.
     Span<const uint32_t> arrayDimensions() const noexcept {
         return {handle()->arrayDimensions, handle()->arrayDimensionsSize};
-    }
-
-    /// @deprecated Use arrayDimensions() instead
-    [[deprecated("use arrayDimensions() instead")]]
-    Span<const uint32_t> getArrayDimensions() const noexcept {
-        return arrayDimensions();
     }
 
     /**
@@ -1411,20 +1333,6 @@ public:
         return std::move(scalar<T>());
     }
 
-    /// @deprecated Use scalar() instead
-    template <typename T>
-    [[deprecated("use scalar() instead")]]
-    T& getScalar() {
-        return scalar<T>();
-    }
-
-    /// @deprecated Use scalar() instead
-    template <typename T>
-    [[deprecated("use scalar() instead")]]
-    const T& getScalar() const {
-        return scalar<T>();
-    }
-
     /// Get reference to array with given template type (only native or wrapper types).
     /// @exception BadVariantAccess If the variant is not an array or not of type `T`.
     template <typename T>
@@ -1443,20 +1351,6 @@ public:
         checkIsArray();
         checkIsType<T>();
         return Span<const T>(static_cast<const T*>(handle()->data), handle()->arrayLength);
-    }
-
-    /// @deprecated Use array() instead
-    template <typename T>
-    [[deprecated("use array() instead")]]
-    Span<T> getArray() {
-        return array<T>();
-    }
-
-    /// @deprecated Use array() instead
-    template <typename T>
-    [[deprecated("use array() instead")]]
-    Span<const T> getArray() const {
-        return array<T>();
     }
 
     /**
@@ -1792,39 +1686,9 @@ public:
         return std::move(value());  // NOLINT(*move-const-arg)
     }
 
-    /// @deprecated Use value() instead
-    [[deprecated("use value() instead")]]
-    Variant& getValue() & noexcept {
-        return value();
-    }
-
-    /// @deprecated Use value() instead
-    [[deprecated("use value() instead")]]
-    const Variant& getValue() const& noexcept {
-        return value();
-    }
-
-    /// @deprecated Use value() instead
-    [[deprecated("use value() instead")]]
-    Variant&& getValue() && noexcept {
-        return std::move(value());
-    }
-
-    /// @deprecated Use value() instead
-    [[deprecated("use value() instead")]]
-    const Variant&& getValue() const&& noexcept {
-        return std::move(value());  // NOLINT(*move-const-arg)
-    }
-
     /// Get source timestamp for the value.
     DateTime sourceTimestamp() const noexcept {
         return DateTime{handle()->sourceTimestamp};  // NOLINT
-    }
-
-    /// @deprecated Use sourceTimestamp() instead
-    [[deprecated("use sourceTimestamp() instead")]]
-    DateTime getSourceTimestamp() const noexcept {
-        return sourceTimestamp();
     }
 
     /// Get server timestamp for the value.
@@ -1832,21 +1696,9 @@ public:
         return DateTime{handle()->serverTimestamp};  // NOLINT
     }
 
-    /// @deprecated Use serverTimestamp() instead
-    [[deprecated("use serverTimestamp() instead")]]
-    DateTime getServerTimestamp() const noexcept {
-        return serverTimestamp();
-    }
-
     /// Get picoseconds interval added to the source timestamp.
     uint16_t sourcePicoseconds() const noexcept {
         return handle()->sourcePicoseconds;
-    }
-
-    /// @deprecated Use sourcePicoseconds() instead
-    [[deprecated("use sourcePicoseconds() instead")]]
-    uint16_t getSourcePicoseconds() const noexcept {
-        return sourcePicoseconds();
     }
 
     /// Get picoseconds interval added to the server timestamp.
@@ -1854,21 +1706,9 @@ public:
         return handle()->serverPicoseconds;
     }
 
-    /// @deprecated Use serverPicoseconds() instead
-    [[deprecated("use serverPicoseconds() instead")]]
-    uint16_t getServerPicoseconds() const noexcept {
-        return serverPicoseconds();
-    }
-
     /// Get status.
     StatusCode status() const noexcept {
         return handle()->status;
-    }
-
-    /// @deprecated Use status() instead
-    [[deprecated("use status() instead")]]
-    StatusCode getStatus() const noexcept {
-        return status();
     }
 };
 
@@ -1979,24 +1819,12 @@ public:
         return static_cast<ExtensionObjectEncoding>(handle()->encoding);
     }
 
-    /// @deprecated Use encoding() instead
-    [[deprecated("use encoding() instead")]]
-    ExtensionObjectEncoding getEncoding() const noexcept {
-        return encoding();
-    }
-
     /// Get the encoded type id.
     /// Returns `nullptr` if ExtensionObject is not encoded.
     const NodeId* encodedTypeId() const noexcept {
         return isEncoded()
             ? asWrapper<NodeId>(&handle()->content.encoded.typeId)  // NOLINT
             : nullptr;
-    }
-
-    /// @deprecated Use encodedTypeId() instead
-    [[deprecated("use encodedTypeId() instead")]]
-    const NodeId* getEncodedTypeId() const noexcept {
-        return encodedTypeId();
     }
 
     /// Get the encoded body in binary format.
@@ -2015,26 +1843,12 @@ public:
             : nullptr;
     }
 
-    /// @deprecated Use encodedBinary() or encodedXml() instead
-    [[deprecated("use encodedBinary() or encodedXml() instead")]]
-    const ByteString* getEncodedBody() const noexcept {
-        return isEncoded()
-            ? asWrapper<ByteString>(&handle()->content.encoded.body)  // NOLINT
-            : nullptr;
-    }
-
     /// Get the decoded data type.
     /// Returns `nullptr` if ExtensionObject is not decoded.
     const UA_DataType* decodedType() const noexcept {
         return isDecoded()
             ? handle()->content.decoded.type  // NOLINT
             : nullptr;
-    }
-
-    /// @deprecated Use decodedType() instead
-    [[deprecated("use decodedType() instead")]]
-    const UA_DataType* getDecodedDataType() const noexcept {
-        return decodedType();
     }
 
     /// Get pointer to the decoded data with given template type.
@@ -2053,20 +1867,6 @@ public:
         return isDecodedType<T>() ? static_cast<const T*>(decodedData()) : nullptr;
     }
 
-    /// @deprecated Use decodedData<T>() instead
-    template <typename T>
-    [[deprecated("use decodedData<T>() instead")]]
-    T* getDecodedData() noexcept {
-        return decodedData<T>();
-    }
-
-    /// @deprecated Use decodedData<T>() instead
-    template <typename T>
-    [[deprecated("use decodedData<T>() instead")]]
-    const T* getDecodedData() const noexcept {
-        return decodedData<T>();
-    }
-
     /// Get pointer to the decoded data.
     /// Returns `nullptr` if the ExtensionObject is not decoded.
     /// @warning Type erased version, use with caution.
@@ -2083,18 +1883,6 @@ public:
         return isDecoded()
             ? handle()->content.decoded.data  // NOLINT
             : nullptr;
-    }
-
-    /// @deprecated Use decodedData() instead
-    [[deprecated("use decodedData() instead")]]
-    void* getDecodedData() noexcept {
-        return decodedData();
-    }
-
-    /// @deprecated Use decodedData() instead
-    [[deprecated("use decodedData() instead")]]
-    const void* getDecodedData() const noexcept {
-        return decodedData();
     }
 
 private:
@@ -2148,70 +1936,28 @@ public:
         return handle()->symbolicId;
     }
 
-    /// @deprecated Use symbolicId() instead
-    [[deprecated("use symbolicId() instead")]]
-    int32_t getSymbolicId() const noexcept {
-        return symbolicId();
-    }
-
     int32_t namespaceUri() const noexcept {
         return handle()->namespaceUri;
-    }
-
-    /// @deprecated Use namespaceUri() instead
-    [[deprecated("use namespaceUri() instead")]]
-    int32_t getNamespaceUri() const noexcept {
-        return namespaceUri();
     }
 
     int32_t localizedText() const noexcept {
         return handle()->localizedText;
     }
 
-    /// @deprecated Use localizedText() instead
-    [[deprecated("use localizedText() instead")]]
-    int32_t getLocalizedText() const noexcept {
-        return localizedText();
-    }
-
     int32_t locale() const noexcept {
         return handle()->locale;
-    }
-
-    /// @deprecated Use locale() instead
-    [[deprecated("use locale() instead")]]
-    int32_t getLocale() const noexcept {
-        return locale();
     }
 
     const String& additionalInfo() const noexcept {
         return asWrapper<String>(handle()->additionalInfo);
     }
 
-    /// @deprecated Use additionalInfo() instead
-    [[deprecated("use additionalInfo() instead")]]
-    const String& getAdditionalInfo() const noexcept {
-        return additionalInfo();
-    }
-
     StatusCode innerStatusCode() const noexcept {
         return handle()->innerStatusCode;
     }
 
-    /// @deprecated Use innerStatusCode() instead
-    [[deprecated("use innerStatusCode() instead")]]
-    StatusCode getInnerStatusCode() const noexcept {
-        return innerStatusCode();
-    }
-
     const DiagnosticInfo* innerDiagnosticInfo() const noexcept {
         return asWrapper<DiagnosticInfo>(handle()->innerDiagnosticInfo);
-    }
-
-    /// @deprecated Use innerDiagnosticInfo() instead
-    [[deprecated("use innerDiagnosticInfo() instead")]]
-    const DiagnosticInfo* getInnerDiagnosticInfo() const noexcept {
-        return innerDiagnosticInfo();
     }
 };
 

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -14,7 +14,6 @@
 #include <string_view>
 #include <type_traits>  // is_same_v
 #include <utility>  // move
-#include <variant>
 #include <vector>
 
 #include "open62541pp/common.hpp"  // NamespaceIndex
@@ -792,66 +791,9 @@ public:
         throw TypeError("NodeId identifier type doesn't match the requested type");
     }
 
-    /// Get identifier variant.
-    /// @deprecated Use identifier<T>() or identifierIf<T>() instead
-    [[deprecated("use identifier<T>() or identifierIf<T>() instead")]]
-    std::variant<uint32_t, String, Guid, ByteString> getIdentifier() const {
-        return getIdentifierImpl();
-    }
-
-    /// Get identifier by template type.
-    /// @deprecated Use identifier<T>() or identifierIf<T>() instead
-    template <typename T>
-    [[deprecated("use identifier<T>() or identifierIf<T>() instead")]]
-    auto getIdentifierAs() const {
-        return getIdentifierAsImpl<T>();
-    }
-
-    /// Get identifier by NodeIdType enum.
-    /// @deprecated Use identifier<T>() or identifierIf<T>() instead
-    template <NodeIdType E>
-    [[deprecated("use identifier<T>() or identifierIf<T>() instead")]]
-    auto getIdentifierAs() const {
-        return getIdentifierAsImpl<E>();
-    }
-
     /// @deprecated Use free function opcua::toString(const T&) instead
     [[deprecated("use free function toString instead")]]
     String toString() const;
-
-private:
-    std::variant<uint32_t, String, Guid, ByteString> getIdentifierImpl() const {
-        switch (handle()->identifierType) {
-        case UA_NODEIDTYPE_NUMERIC:
-            return handle()->identifier.numeric;  // NOLINT
-        case UA_NODEIDTYPE_STRING:
-            return String(handle()->identifier.string);  // NOLINT
-        case UA_NODEIDTYPE_GUID:
-            return Guid(handle()->identifier.guid);  // NOLINT
-        case UA_NODEIDTYPE_BYTESTRING:
-            return ByteString(handle()->identifier.byteString);  // NOLINT
-        default:
-            return {};
-        }
-    }
-
-    template <typename T>
-    auto getIdentifierAsImpl() const {
-        return std::get<T>(getIdentifierImpl());
-    }
-
-    template <NodeIdType E>
-    auto getIdentifierAsImpl() const {
-        if constexpr (E == NodeIdType::Numeric) {
-            return getIdentifierAsImpl<uint32_t>();
-        } else if constexpr (E == NodeIdType::String) {
-            return getIdentifierAsImpl<String>();
-        } else if constexpr (E == NodeIdType::Guid) {
-            return getIdentifierAsImpl<Guid>();
-        } else if constexpr (E == NodeIdType::ByteString) {
-            return getIdentifierAsImpl<ByteString>();
-        }
-    }
 };
 
 /// @relates NodeId

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -1283,41 +1283,6 @@ public:
         return *this;
     }
 
-    /// @deprecated Use assign overload with pointer instead
-    template <typename T, typename... Args>
-    [[deprecated("use assign overload with pointer instead")]]
-    void setScalar(T& value, Args&&... args) noexcept {
-        assign(&value, std::forward<Args>(args)...);
-    }
-
-    /// @deprecated Use assign overload instead
-    template <typename T, typename... Args>
-    [[deprecated("use assign overload instead")]]
-    void setScalarCopy(const T& value, Args&&... args) {
-        assign(value, std::forward<Args>(args)...);
-    }
-
-    /// @deprecated Use assign overload with pointer instead
-    template <typename T, typename... Args>
-    [[deprecated("use assign overload with pointer instead")]]
-    void setArray(T& array, Args&&... args) noexcept {
-        assign(&array, std::forward<Args>(args)...);
-    }
-
-    /// @deprecated Use assign overload instead
-    template <typename T, typename... Args>
-    [[deprecated("use assign overload instead")]]
-    void setArrayCopy(const T& array, Args&&... args) {
-        assign(array, std::forward<Args>(args)...);
-    }
-
-    /// @deprecated Use assign overload instead
-    template <typename InputIt, typename... Args>
-    [[deprecated("use assign overload instead")]]
-    void setArrayCopy(InputIt first, InputIt last, Args&&... args) {
-        assign(first, last, std::forward<Args>(args)...);
-    }
-
     /**
      * @name Observers
      * Check the type category, type definition and array structure of the internal value.

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -1041,18 +1041,6 @@ inline bool operator!=(const UA_LocalizedText& lhs, const UA_LocalizedText& rhs)
 
 /* ------------------------------------------- Variant ------------------------------------------ */
 
-/**
- * Policies for variant factory methods Variant::fromScalar, Variant::fromArray.
- */
-enum class VariantPolicy {
-    // clang-format off
-    Copy,                 ///< Store copy of scalar/array inside the variant.
-    Reference,            ///< Store reference to scalar/array inside the variant.
-                          ///< Both scalars and arrays must be mutable native/wrapper types.
-                          ///< Arrays must store the elements contiguously in memory.
-    // clang-format on
-};
-
 class BadVariantAccess : public TypeError {
 public:
     using TypeError::TypeError;
@@ -1163,35 +1151,6 @@ public:
     template <typename InputIt>
     Variant(InputIt first, InputIt last, const UA_DataType& type) {
         assign(first, last, type);
-    }
-
-    /// @deprecated Use new universal Variant constructor instead
-    template <VariantPolicy Policy = VariantPolicy::Copy, typename T, typename... Args>
-    [[deprecated("use new universal Variant constructor instead")]] [[nodiscard]]
-    static Variant fromScalar(T&& value, Args&&... args) {
-        if constexpr (Policy == VariantPolicy::Copy) {
-            return Variant{std::forward<T>(value), std::forward<Args>(args)...};
-        } else {
-            return Variant{&value, std::forward<Args>(args)...};
-        }
-    }
-
-    /// @deprecated Use new universal Variant constructor instead
-    template <VariantPolicy Policy = VariantPolicy::Copy, typename T, typename... Args>
-    [[deprecated("use new universal Variant constructor instead")]] [[nodiscard]]
-    static Variant fromArray(T&& array, Args&&... args) {
-        if constexpr (Policy == VariantPolicy::Copy) {
-            return Variant{std::forward<T>(array), std::forward<Args>(args)...};
-        } else {
-            return Variant{&array, std::forward<Args>(args)...};
-        }
-    }
-
-    /// @deprecated Use new universal Variant constructor instead
-    template <VariantPolicy Policy = VariantPolicy::Copy, typename InputIt, typename... Args>
-    [[deprecated("use new universal Variant constructor instead")]] [[nodiscard]]
-    static Variant fromArray(InputIt first, InputIt last, Args&&... args) {
-        return Variant{first, last, std::forward<Args>(args)...};
     }
 
     /**
@@ -1802,25 +1761,6 @@ public:
         setValue(std::move(value));
     }
 
-    /// Create DataValue from scalar value.
-    /// @deprecated Use constructor with new universal Variant constructor instead:
-    ///             `opcua::DataValue dv(opcua::Variant{value})`
-    template <VariantPolicy Policy = VariantPolicy::Copy, typename... Args>
-    [[deprecated("use constructor with new universal Variant constructor instead")]] [[nodiscard]]
-    static DataValue fromScalar(Args&&... args) {
-        return DataValue{Variant::fromScalar<Policy>(std::forward<Args>(args)...)};
-    }
-
-    /// Create DataValue from array.
-    /// @see Variant::fromArray
-    /// @deprecated Use constructor with new universal Variant constructor instead:
-    ///             `opcua::DataValue dv(opcua::Variant{array})`
-    template <VariantPolicy Policy = VariantPolicy::Copy, typename... Args>
-    [[deprecated("use constructor with new universal Variant constructor instead")]] [[nodiscard]]
-    static DataValue fromArray(Args&&... args) {
-        return DataValue{Variant::fromArray<Policy>(std::forward<Args>(args)...)};
-    }
-
     /// Set value (copy).
     void setValue(const Variant& value) {
         asWrapper<Variant>(handle()->value) = value;
@@ -2070,20 +2010,6 @@ public:
         handle()->encoding = UA_EXTENSIONOBJECT_DECODED;
         handle()->content.decoded.type = &type;  // NOLINT
         handle()->content.decoded.data = ptr.release();  // NOLINT
-    }
-
-    /// @deprecated Use new universal ExtensionObject constructor instead
-    template <typename T, typename... Args>
-    [[deprecated("use new universal ExtensionObject constructor instead")]] [[nodiscard]]
-    static ExtensionObject fromDecoded(T& data, Args&&... args) noexcept {
-        return ExtensionObject{&data, std::forward<Args>(args)...};
-    }
-
-    /// @deprecated Use new universal ExtensionObject constructor instead
-    template <typename T, typename... Args>
-    [[deprecated("use new universal ExtensionObject constructor instead")]] [[nodiscard]]
-    static ExtensionObject fromDecodedCopy(const T& data, Args&&... args) {
-        return ExtensionObject{data, std::forward<Args>(args)...};
     }
 
     /// Check if the ExtensionObject is empty

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -1328,12 +1328,6 @@ public:
         return handle()->type == nullptr;
     }
 
-    /// @deprecated Use empty() instead
-    [[deprecated("use empty() instead")]]
-    bool isEmpty() const noexcept {
-        return empty();
-    }
-
     /// Check if the variant is a scalar.
     bool isScalar() const noexcept {
         return (
@@ -2015,12 +2009,6 @@ public:
     /// Check if the ExtensionObject is empty
     bool empty() const noexcept {
         return (handle()->encoding == UA_EXTENSIONOBJECT_ENCODED_NOBODY);
-    }
-
-    /// @deprecated Use empty() instead
-    [[deprecated("use empty() instead")]]
-    bool isEmpty() const noexcept {
-        return empty();
     }
 
     /// Check if the ExtensionObject is encoded (usually if the data type is unknown).

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -1425,13 +1425,6 @@ public:
         return scalar<T>();
     }
 
-    /// @deprecated Use to<T>() instead
-    template <typename T>
-    [[deprecated("use to<T>() instead")]]
-    T getScalarCopy() const {
-        return to<T>();
-    }
-
     /// Get reference to array with given template type (only native or wrapper types).
     /// @exception BadVariantAccess If the variant is not an array or not of type `T`.
     template <typename T>
@@ -1464,13 +1457,6 @@ public:
     [[deprecated("use array() instead")]]
     Span<const T> getArray() const {
         return array<T>();
-    }
-
-    /// @deprecated Use to<std::vector<T>>() instead
-    template <typename T>
-    [[deprecated("use to<std::vector<T>>() instead")]]
-    std::vector<T> getArrayCopy() const {
-        return to<std::vector<T>>();
     }
 
     /**

--- a/include/open62541pp/ua/types.hpp
+++ b/include/open62541pp/ua/types.hpp
@@ -343,13 +343,6 @@ constexpr std::true_type isBitmaskEnum(NodeAttributesMask);
         handle()->member = member;                                                                 \
         return *this;                                                                              \
     }
-#define UAPP_NODEATTR_BITMASK(Type, suffix, member, flag)                                          \
-    UAPP_GETTER(Type, member)                                                                      \
-    auto& set##suffix(Type member) noexcept {                                                      \
-        handle()->specifiedAttributes |= flag;                                                     \
-        handle()->member = member.get();                                                           \
-        return *this;                                                                              \
-    }
 #define UAPP_NODEATTR_CAST(Type, suffix, member, flag)                                             \
     UAPP_GETTER_CAST(Type, member)                                                                 \
     auto& set##suffix(Type member) noexcept {                                                      \
@@ -382,10 +375,10 @@ constexpr std::true_type isBitmaskEnum(NodeAttributesMask);
     UAPP_NODEATTR_WRAPPER(                                                                         \
         LocalizedText, Description, description, UA_NODEATTRIBUTESMASK_DESCRIPTION                 \
     )                                                                                              \
-    UAPP_NODEATTR_BITMASK(                                                                         \
+    UAPP_NODEATTR_CAST(                                                                         \
         Bitmask<WriteMask>, WriteMask, writeMask, UA_NODEATTRIBUTESMASK_WRITEMASK                  \
     )                                                                                              \
-    UAPP_NODEATTR_BITMASK(                                                                         \
+    UAPP_NODEATTR_CAST(                                                                         \
         Bitmask<WriteMask>, UserWriteMask, userWriteMask, UA_NODEATTRIBUTESMASK_USERWRITEMASK      \
     )
 
@@ -415,7 +408,7 @@ public:
         : TypeWrapper{UA_ObjectAttributes_default} {}
 
     UAPP_NODEATTR_COMMON
-    UAPP_NODEATTR_BITMASK(
+    UAPP_NODEATTR_CAST(
         Bitmask<EventNotifier>, EventNotifier, eventNotifier, UA_NODEATTRIBUTESMASK_EVENTNOTIFIER
     )
 };
@@ -466,10 +459,10 @@ public:
         arrayDimensionsSize,
         UA_NODEATTRIBUTESMASK_ARRAYDIMENSIONS
     )
-    UAPP_NODEATTR_BITMASK(
+    UAPP_NODEATTR_CAST(
         Bitmask<AccessLevel>, AccessLevel, accessLevel, UA_NODEATTRIBUTESMASK_ACCESSLEVEL
     )
-    UAPP_NODEATTR_BITMASK(
+    UAPP_NODEATTR_CAST(
         Bitmask<AccessLevel>,
         UserAccessLevel,
         userAccessLevel,
@@ -619,12 +612,13 @@ public:
 
     UAPP_NODEATTR_COMMON
     UAPP_NODEATTR(bool, IsAbstract, containsNoLoops, UA_NODEATTRIBUTESMASK_CONTAINSNOLOOPS)
-    UAPP_NODEATTR_BITMASK(
+    UAPP_NODEATTR_CAST(
         Bitmask<EventNotifier>, EventNotifier, eventNotifier, UA_NODEATTRIBUTESMASK_EVENTNOTIFIER
     )
 };
 
 #undef UAPP_NODEATTR
+#undef UAPP_NODEATTR_CAST
 #undef UAPP_NODEATTR_WRAPPER
 #undef UAPP_NODEATTR_ARRAY
 #undef UAPP_NODEATTR_COMMON

--- a/include/open62541pp/ua/types.hpp
+++ b/include/open62541pp/ua/types.hpp
@@ -36,81 +36,41 @@ UA_EXPORT extern const UA_ViewAttributes UA_ViewAttributes_default;
 #endif
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
-#define UAPP_GETTER(Type, getterName, member)                                                      \
+#define UAPP_GETTER(Type, member)                                                                  \
     Type member() const noexcept {                                                                 \
-        return handle()->member;                                                                   \
-    }                                                                                              \
-    /** @deprecated Use @ref member instead */                                                     \
-    [[deprecated("use " #member " instead")]]                                                      \
-    Type getterName() const noexcept {                                                             \
         return handle()->member;                                                                   \
     }
 
-#define UAPP_GETTER_CAST(Type, getterName, member)                                                 \
+#define UAPP_GETTER_CAST(Type, member)                                                             \
     Type member() const noexcept {                                                                 \
-        return static_cast<Type>(handle()->member);                                                \
-    }                                                                                              \
-    /** @deprecated Use @ref member instead */                                                     \
-    [[deprecated("use " #member " instead")]]                                                      \
-    Type getterName() const noexcept {                                                             \
         return static_cast<Type>(handle()->member);                                                \
     }
 
-#define UAPP_GETTER_WRAPPER_CONST(Type, getterName, member)                                        \
+#define UAPP_GETTER_WRAPPER_CONST(Type, member)                                                    \
     const Type& member() const noexcept {                                                          \
         return asWrapper<Type>(handle()->member);                                                  \
-    }                                                                                              \
-    /** @deprecated Use @ref member instead */                                                     \
-    [[deprecated("use " #member " instead")]]                                                      \
-    const Type& getterName() const noexcept {                                                      \
-        return asWrapper<Type>(handle()->member);                                                  \
     }
-#define UAPP_GETTER_WRAPPER_NONCONST(Type, getterName, member)                                     \
+#define UAPP_GETTER_WRAPPER_NONCONST(Type, member)                                                 \
     Type& member() noexcept {                                                                      \
         return asWrapper<Type>(handle()->member);                                                  \
-    }                                                                                              \
-    /** @deprecated Use @ref member instead */                                                     \
-    [[deprecated("use " #member " instead")]]                                                      \
-    Type& getterName() noexcept {                                                                  \
-        return asWrapper<Type>(handle()->member);                                                  \
     }
-#define UAPP_GETTER_WRAPPER(Type, getterName, member)                                              \
-    UAPP_GETTER_WRAPPER_CONST(Type, getterName, member)                                            \
-    UAPP_GETTER_WRAPPER_NONCONST(Type, getterName, member)
+#define UAPP_GETTER_WRAPPER(Type, member)                                                          \
+    UAPP_GETTER_WRAPPER_CONST(Type, member)                                                        \
+    UAPP_GETTER_WRAPPER_NONCONST(Type, member)
 
-#define UAPP_GETTER_SPAN(Type, getterName, memberArray, memberSize)                                \
+#define UAPP_GETTER_SPAN(Type, memberArray, memberSize)                                            \
     Span<const Type> memberArray() const noexcept {                                                \
         return {handle()->memberArray, handle()->memberSize};                                      \
     }                                                                                              \
     Span<Type> memberArray() noexcept {                                                            \
         return {handle()->memberArray, handle()->memberSize};                                      \
-    }                                                                                              \
-    /** @deprecated Use @ref memberArray instead */                                                \
-    [[deprecated("use " #memberArray " instead")]]                                                 \
-    Span<const Type> getterName() const noexcept {                                                 \
-        return {handle()->memberArray, handle()->memberSize};                                      \
-    }                                                                                              \
-    /** @deprecated Use @ref memberArray instead */                                                \
-    [[deprecated("use " #memberArray " instead")]]                                                 \
-    Span<Type> getterName() noexcept {                                                             \
-        return {handle()->memberArray, handle()->memberSize};                                      \
     }
 
-#define UAPP_GETTER_SPAN_WRAPPER(Type, getterName, memberArray, memberSize)                        \
+#define UAPP_GETTER_SPAN_WRAPPER(Type, memberArray, memberSize)                                    \
     Span<const Type> memberArray() const noexcept {                                                \
         return {asWrapper<Type>(handle()->memberArray), handle()->memberSize};                     \
     }                                                                                              \
     Span<Type> memberArray() noexcept {                                                            \
-        return {asWrapper<Type>(handle()->memberArray), handle()->memberSize};                     \
-    }                                                                                              \
-    /** @deprecated Use @ref memberArray instead */                                                \
-    [[deprecated("use " #memberArray " instead")]]                                                 \
-    Span<const Type> getterName() const noexcept {                                                 \
-        return {asWrapper<Type>(handle()->memberArray), handle()->memberSize};                     \
-    }                                                                                              \
-    /** @deprecated Use @ref memberArray instead */                                                \
-    [[deprecated("use " #memberArray " instead")]]                                                 \
-    Span<Type> getterName() noexcept {                                                             \
         return {asWrapper<Type>(handle()->memberArray), handle()->memberSize};                     \
     }
 
@@ -142,9 +102,9 @@ public:
         handle()->description = detail::toNative(std::move(description));
     }
 
-    UAPP_GETTER(int64_t, getValue, value)
-    UAPP_GETTER_WRAPPER(LocalizedText, getDisplayName, displayName)
-    UAPP_GETTER_WRAPPER(LocalizedText, getDescription, description)
+    UAPP_GETTER(int64_t, value)
+    UAPP_GETTER_WRAPPER(LocalizedText, displayName)
+    UAPP_GETTER_WRAPPER(LocalizedText, description)
 };
 
 /**
@@ -187,13 +147,13 @@ public:
         handle()->discoveryUrls = detail::toNativeArray(discoveryUrls);
     }
 
-    UAPP_GETTER_WRAPPER(String, getApplicationUri, applicationUri)
-    UAPP_GETTER_WRAPPER(String, getProductUri, productUri)
-    UAPP_GETTER_WRAPPER(LocalizedText, getApplicationName, applicationName)
-    UAPP_GETTER_CAST(ApplicationType, getApplicationType, applicationType)
-    UAPP_GETTER_WRAPPER(String, getGatewayServerUri, gatewayServerUri)
-    UAPP_GETTER_WRAPPER(String, getDiscoveryProfileUri, discoveryProfileUri)
-    UAPP_GETTER_SPAN_WRAPPER(String, getDiscoveryUrls, discoveryUrls, discoveryUrlsSize)
+    UAPP_GETTER_WRAPPER(String, applicationUri)
+    UAPP_GETTER_WRAPPER(String, productUri)
+    UAPP_GETTER_WRAPPER(LocalizedText, applicationName)
+    UAPP_GETTER_CAST(ApplicationType, applicationType)
+    UAPP_GETTER_WRAPPER(String, gatewayServerUri)
+    UAPP_GETTER_WRAPPER(String, discoveryProfileUri)
+    UAPP_GETTER_SPAN_WRAPPER(String, discoveryUrls, discoveryUrlsSize)
 };
 
 /**
@@ -222,13 +182,13 @@ public:
         handle()->additionalHeader = detail::toNative(std::move(additionalHeader));
     }
 
-    UAPP_GETTER_WRAPPER(NodeId, getAuthenticationToken, authenticationToken)
-    UAPP_GETTER_WRAPPER(DateTime, getTimestamp, timestamp)
-    UAPP_GETTER(IntegerId, getRequestHandle, requestHandle)
-    UAPP_GETTER(uint32_t, getReturnDiagnostics, returnDiagnostics)
-    UAPP_GETTER_WRAPPER(String, getAuditEntryId, auditEntryId)
-    UAPP_GETTER(uint32_t, getTimeoutHint, timeoutHint)
-    UAPP_GETTER_WRAPPER(ExtensionObject, getAdditionalHeader, additionalHeader)
+    UAPP_GETTER_WRAPPER(NodeId, authenticationToken)
+    UAPP_GETTER_WRAPPER(DateTime, timestamp)
+    UAPP_GETTER(IntegerId, requestHandle)
+    UAPP_GETTER(uint32_t, returnDiagnostics)
+    UAPP_GETTER_WRAPPER(String, auditEntryId)
+    UAPP_GETTER(uint32_t, timeoutHint)
+    UAPP_GETTER_WRAPPER(ExtensionObject, additionalHeader)
 };
 
 /**
@@ -239,12 +199,12 @@ class ResponseHeader : public TypeWrapper<UA_ResponseHeader, UA_TYPES_RESPONSEHE
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(DateTime, getTimestamp, timestamp)
-    UAPP_GETTER(IntegerId, getRequestHandle, requestHandle)
-    UAPP_GETTER(StatusCode, getServiceResult, serviceResult)
-    UAPP_GETTER_WRAPPER(DiagnosticInfo, getServiceDiagnostics, serviceDiagnostics)
-    UAPP_GETTER_SPAN_WRAPPER(String, getStringTable, stringTable, stringTableSize)
-    UAPP_GETTER_WRAPPER(ExtensionObject, getAdditionalHeader, additionalHeader)
+    UAPP_GETTER_WRAPPER(DateTime, timestamp)
+    UAPP_GETTER(IntegerId, requestHandle)
+    UAPP_GETTER(StatusCode, serviceResult)
+    UAPP_GETTER_WRAPPER(DiagnosticInfo, serviceDiagnostics)
+    UAPP_GETTER_SPAN_WRAPPER(String, stringTable, stringTableSize)
+    UAPP_GETTER_WRAPPER(ExtensionObject, additionalHeader)
 };
 
 /**
@@ -296,11 +256,11 @@ public:
         handle()->securityPolicyUri = detail::toNative(securityPolicyUri);
     }
 
-    UAPP_GETTER_WRAPPER(String, getPolicyId, policyId)
-    UAPP_GETTER_CAST(UserTokenType, getTokenType, tokenType)
-    UAPP_GETTER_WRAPPER(String, getIssuedTokenType, issuedTokenType)
-    UAPP_GETTER_WRAPPER(String, getIssuerEndpointUrl, issuerEndpointUrl)
-    UAPP_GETTER_WRAPPER(String, getSecurityPolicyUri, securityPolicyUri)
+    UAPP_GETTER_WRAPPER(String, policyId)
+    UAPP_GETTER_CAST(UserTokenType, tokenType)
+    UAPP_GETTER_WRAPPER(String, issuedTokenType)
+    UAPP_GETTER_WRAPPER(String, issuerEndpointUrl)
+    UAPP_GETTER_WRAPPER(String, securityPolicyUri)
 };
 
 /**
@@ -312,16 +272,14 @@ class EndpointDescription
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(String, getEndpointUrl, endpointUrl)
-    UAPP_GETTER_WRAPPER(ApplicationDescription, getServer, server)
-    UAPP_GETTER_WRAPPER(ByteString, getServerCertificate, serverCertificate)
-    UAPP_GETTER_CAST(MessageSecurityMode, getSecurityMode, securityMode)
-    UAPP_GETTER_WRAPPER(String, getSecurityPolicyUri, securityPolicyUri)
-    UAPP_GETTER_SPAN_WRAPPER(
-        UserTokenPolicy, getUserIdentityTokens, userIdentityTokens, userIdentityTokensSize
-    )
-    UAPP_GETTER_WRAPPER(String, getTransportProfileUri, transportProfileUri)
-    UAPP_GETTER(UA_Byte, getSecurityLevel, securityLevel)
+    UAPP_GETTER_WRAPPER(String, endpointUrl)
+    UAPP_GETTER_WRAPPER(ApplicationDescription, server)
+    UAPP_GETTER_WRAPPER(ByteString, serverCertificate)
+    UAPP_GETTER_CAST(MessageSecurityMode, securityMode)
+    UAPP_GETTER_WRAPPER(String, securityPolicyUri)
+    UAPP_GETTER_SPAN_WRAPPER(UserTokenPolicy, userIdentityTokens, userIdentityTokensSize)
+    UAPP_GETTER_WRAPPER(String, transportProfileUri)
+    UAPP_GETTER(UA_Byte, securityLevel)
 };
 
 /* --------------------------------------- Node attributes -------------------------------------- */
@@ -379,35 +337,35 @@ constexpr std::true_type isBitmaskEnum(NodeAttributesMask);
 
 // NOLINTBEGIN(cppcoreguidelines-macro-usage)
 #define UAPP_NODEATTR(Type, suffix, member, flag)                                                  \
-    UAPP_GETTER(Type, get##suffix, member)                                                         \
+    UAPP_GETTER(Type, member)                                                                      \
     auto& set##suffix(Type member) noexcept {                                                      \
         handle()->specifiedAttributes |= flag;                                                     \
         handle()->member = member;                                                                 \
         return *this;                                                                              \
     }
 #define UAPP_NODEATTR_BITMASK(Type, suffix, member, flag)                                          \
-    UAPP_GETTER(Type, get##suffix, member)                                                         \
+    UAPP_GETTER(Type, member)                                                                      \
     auto& set##suffix(Type member) noexcept {                                                      \
         handle()->specifiedAttributes |= flag;                                                     \
         handle()->member = member.get();                                                           \
         return *this;                                                                              \
     }
 #define UAPP_NODEATTR_CAST(Type, suffix, member, flag)                                             \
-    UAPP_GETTER_CAST(Type, get##suffix, member)                                                    \
+    UAPP_GETTER_CAST(Type, member)                                                                 \
     auto& set##suffix(Type member) noexcept {                                                      \
         handle()->specifiedAttributes |= flag;                                                     \
         handle()->member = static_cast<decltype(handle()->member)>(member);                        \
         return *this;                                                                              \
     }
 #define UAPP_NODEATTR_WRAPPER(Type, suffix, member, flag)                                          \
-    UAPP_GETTER_WRAPPER_CONST(Type, get##suffix, member)                                           \
-    auto& set##suffix(Type member) {                                                        \
+    UAPP_GETTER_WRAPPER_CONST(Type, member)                                                        \
+    auto& set##suffix(Type member) {                                                               \
         handle()->specifiedAttributes |= flag;                                                     \
-        asWrapper<Type>(handle()->member) = std::move(member);                                                \
+        asWrapper<Type>(handle()->member) = std::move(member);                                     \
         return *this;                                                                              \
     }
 #define UAPP_NODEATTR_ARRAY(Type, suffix, member, memberSize, flag)                                \
-    UAPP_GETTER_SPAN(Type, get##suffix, member, memberSize)                                        \
+    UAPP_GETTER_SPAN(Type, member, memberSize)                                                     \
     auto& set##suffix(Span<const Type> member) {                                                   \
         const auto& dataType = opcua::getDataType<Type>();                                         \
         handle()->specifiedAttributes |= flag;                                                     \
@@ -417,7 +375,7 @@ constexpr std::true_type isBitmaskEnum(NodeAttributesMask);
         return *this;                                                                              \
     }
 #define UAPP_NODEATTR_COMMON                                                                       \
-    UAPP_GETTER(Bitmask<NodeAttributesMask>, getSpecifiedAttributes, specifiedAttributes)          \
+    UAPP_GETTER(Bitmask<NodeAttributesMask>, specifiedAttributes)                                  \
     UAPP_NODEATTR_WRAPPER(                                                                         \
         LocalizedText, DisplayName, displayName, UA_NODEATTRIBUTESMASK_DISPLAYNAME                 \
     )                                                                                              \
@@ -681,7 +639,7 @@ class UserIdentityToken : public TypeWrapper<UA_UserIdentityToken, UA_TYPES_USER
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(String, getPolicyId, policyId)
+    UAPP_GETTER_WRAPPER(String, policyId)
 };
 
 /**
@@ -693,7 +651,7 @@ class AnonymousIdentityToken
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(String, getPolicyId, policyId)
+    UAPP_GETTER_WRAPPER(String, policyId)
 };
 
 /**
@@ -715,10 +673,10 @@ public:
         handle()->encryptionAlgorithm = detail::toNative(encryptionAlgorithm);
     }
 
-    UAPP_GETTER_WRAPPER(String, getPolicyId, policyId)
-    UAPP_GETTER_WRAPPER(String, getUserName, userName)
-    UAPP_GETTER_WRAPPER(ByteString, getPassword, password)
-    UAPP_GETTER_WRAPPER(String, getEncryptionAlgorithm, encryptionAlgorithm)
+    UAPP_GETTER_WRAPPER(String, policyId)
+    UAPP_GETTER_WRAPPER(String, userName)
+    UAPP_GETTER_WRAPPER(ByteString, password)
+    UAPP_GETTER_WRAPPER(String, encryptionAlgorithm)
 };
 
 /**
@@ -733,8 +691,8 @@ public:
         handle()->certificateData = detail::toNative(std::move(certificateData));
     }
 
-    UAPP_GETTER_WRAPPER(String, getPolicyId, policyId)
-    UAPP_GETTER_WRAPPER(ByteString, getCertificateData, certificateData)
+    UAPP_GETTER_WRAPPER(String, policyId)
+    UAPP_GETTER_WRAPPER(ByteString, certificateData)
 };
 
 /**
@@ -751,9 +709,9 @@ public:
         handle()->encryptionAlgorithm = detail::toNative(encryptionAlgorithm);
     }
 
-    UAPP_GETTER_WRAPPER(String, getPolicyId, policyId)
-    UAPP_GETTER_WRAPPER(ByteString, getTokenData, tokenData)
-    UAPP_GETTER_WRAPPER(String, getEncryptionAlgorithm, encryptionAlgorithm)
+    UAPP_GETTER_WRAPPER(String, policyId)
+    UAPP_GETTER_WRAPPER(ByteString, tokenData)
+    UAPP_GETTER_WRAPPER(String, encryptionAlgorithm)
 };
 
 /**
@@ -782,13 +740,13 @@ public:
         handle()->typeDefinition = detail::toNative(std::move(typeDefinition));
     }
 
-    UAPP_GETTER_WRAPPER(ExpandedNodeId, getParentNodeId, parentNodeId)
-    UAPP_GETTER_WRAPPER(NodeId, getReferenceTypeId, referenceTypeId)
-    UAPP_GETTER_WRAPPER(ExpandedNodeId, getRequestedNewNodeId, requestedNewNodeId)
-    UAPP_GETTER_WRAPPER(QualifiedName, getBrowseName, browseName)
-    UAPP_GETTER_CAST(NodeClass, getNodeClass, nodeClass)
-    UAPP_GETTER_WRAPPER(ExtensionObject, getNodeAttributes, nodeAttributes)
-    UAPP_GETTER_WRAPPER(ExpandedNodeId, getTypeDefinition, typeDefinition)
+    UAPP_GETTER_WRAPPER(ExpandedNodeId, parentNodeId)
+    UAPP_GETTER_WRAPPER(NodeId, referenceTypeId)
+    UAPP_GETTER_WRAPPER(ExpandedNodeId, requestedNewNodeId)
+    UAPP_GETTER_WRAPPER(QualifiedName, browseName)
+    UAPP_GETTER_CAST(NodeClass, nodeClass)
+    UAPP_GETTER_WRAPPER(ExtensionObject, nodeAttributes)
+    UAPP_GETTER_WRAPPER(ExpandedNodeId, typeDefinition)
 };
 
 /**
@@ -799,8 +757,8 @@ class AddNodesResult : public TypeWrapper<UA_AddNodesResult, UA_TYPES_ADDNODESRE
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER(StatusCode, getStatusCode, statusCode)
-    UAPP_GETTER_WRAPPER(NodeId, getAddedNodeId, addedNodeId)
+    UAPP_GETTER(StatusCode, statusCode)
+    UAPP_GETTER_WRAPPER(NodeId, addedNodeId)
 };
 
 /**
@@ -817,8 +775,8 @@ public:
         handle()->nodesToAdd = detail::toNativeArray(nodesToAdd);
     }
 
-    UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER_SPAN_WRAPPER(AddNodesItem, getNodesToAdd, nodesToAdd, nodesToAddSize)
+    UAPP_GETTER_WRAPPER(RequestHeader, requestHeader)
+    UAPP_GETTER_SPAN_WRAPPER(AddNodesItem, nodesToAdd, nodesToAddSize)
 };
 
 /**
@@ -829,11 +787,9 @@ class AddNodesResponse : public TypeWrapper<UA_AddNodesResponse, UA_TYPES_ADDNOD
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
-    UAPP_GETTER_SPAN_WRAPPER(AddNodesResult, getResults, results, resultsSize)
-    UAPP_GETTER_SPAN_WRAPPER(
-        DiagnosticInfo, getDiagnosticInfos, diagnosticInfos, diagnosticInfosSize
-    )
+    UAPP_GETTER_WRAPPER(ResponseHeader, responseHeader)
+    UAPP_GETTER_SPAN_WRAPPER(AddNodesResult, results, resultsSize)
+    UAPP_GETTER_SPAN_WRAPPER(DiagnosticInfo, diagnosticInfos, diagnosticInfosSize)
 };
 
 /**
@@ -860,12 +816,12 @@ public:
         handle()->targetNodeClass = static_cast<UA_NodeClass>(targetNodeClass);
     }
 
-    UAPP_GETTER_WRAPPER(NodeId, getSourceNodeId, sourceNodeId)
-    UAPP_GETTER_WRAPPER(NodeId, getReferenceTypeId, referenceTypeId)
-    UAPP_GETTER(bool, getIsForward, isForward)
-    UAPP_GETTER_WRAPPER(String, getTargetServerUri, targetServerUri)
-    UAPP_GETTER_WRAPPER(ExpandedNodeId, getTargetNodeId, targetNodeId)
-    UAPP_GETTER_CAST(NodeClass, getTargetNodeClass, targetNodeClass)
+    UAPP_GETTER_WRAPPER(NodeId, sourceNodeId)
+    UAPP_GETTER_WRAPPER(NodeId, referenceTypeId)
+    UAPP_GETTER(bool, isForward)
+    UAPP_GETTER_WRAPPER(String, targetServerUri)
+    UAPP_GETTER_WRAPPER(ExpandedNodeId, targetNodeId)
+    UAPP_GETTER_CAST(NodeClass, targetNodeClass)
 };
 
 /**
@@ -885,10 +841,8 @@ public:
         handle()->referencesToAdd = detail::toNativeArray(referencesToAdd);
     }
 
-    UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER_SPAN_WRAPPER(
-        AddReferencesItem, getReferencesToAdd, referencesToAdd, referencesToAddSize
-    )
+    UAPP_GETTER_WRAPPER(RequestHeader, requestHeader)
+    UAPP_GETTER_SPAN_WRAPPER(AddReferencesItem, referencesToAdd, referencesToAddSize)
 };
 
 /**
@@ -900,11 +854,9 @@ class AddReferencesResponse
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
-    UAPP_GETTER_SPAN_WRAPPER(StatusCode, getResults, results, resultsSize)
-    UAPP_GETTER_SPAN_WRAPPER(
-        DiagnosticInfo, getDiagnosticInfos, diagnosticInfos, diagnosticInfosSize
-    )
+    UAPP_GETTER_WRAPPER(ResponseHeader, responseHeader)
+    UAPP_GETTER_SPAN_WRAPPER(StatusCode, results, resultsSize)
+    UAPP_GETTER_SPAN_WRAPPER(DiagnosticInfo, diagnosticInfos, diagnosticInfosSize)
 };
 
 /**
@@ -920,8 +872,8 @@ public:
         handle()->deleteTargetReferences = deleteTargetReferences;
     }
 
-    UAPP_GETTER_WRAPPER(NodeId, getNodeId, nodeId)
-    UAPP_GETTER(bool, getDeleteTargetReferences, deleteTargetReferences)
+    UAPP_GETTER_WRAPPER(NodeId, nodeId)
+    UAPP_GETTER(bool, deleteTargetReferences)
 };
 
 /**
@@ -938,8 +890,8 @@ public:
         handle()->nodesToDelete = detail::toNativeArray(nodesToDelete);
     }
 
-    UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER_SPAN_WRAPPER(DeleteNodesItem, getNodesToDelete, nodesToDelete, nodesToDeleteSize)
+    UAPP_GETTER_WRAPPER(RequestHeader, requestHeader)
+    UAPP_GETTER_SPAN_WRAPPER(DeleteNodesItem, nodesToDelete, nodesToDeleteSize)
 };
 
 /**
@@ -951,11 +903,9 @@ class DeleteNodesResponse
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
-    UAPP_GETTER_SPAN_WRAPPER(StatusCode, getResults, results, resultsSize)
-    UAPP_GETTER_SPAN_WRAPPER(
-        DiagnosticInfo, getDiagnosticInfos, diagnosticInfos, diagnosticInfosSize
-    )
+    UAPP_GETTER_WRAPPER(ResponseHeader, responseHeader)
+    UAPP_GETTER_SPAN_WRAPPER(StatusCode, results, resultsSize)
+    UAPP_GETTER_SPAN_WRAPPER(DiagnosticInfo, diagnosticInfos, diagnosticInfosSize)
 };
 
 /**
@@ -981,11 +931,11 @@ public:
         handle()->deleteBidirectional = deleteBidirectional;
     }
 
-    UAPP_GETTER_WRAPPER(NodeId, getSourceNodeId, sourceNodeId)
-    UAPP_GETTER_WRAPPER(NodeId, getReferenceTypeId, referenceTypeId)
-    UAPP_GETTER(bool, getIsForward, isForward)
-    UAPP_GETTER_WRAPPER(ExpandedNodeId, getTargetNodeId, targetNodeId)
-    UAPP_GETTER(bool, getDeleteBidirectional, deleteBidirectional)
+    UAPP_GETTER_WRAPPER(NodeId, sourceNodeId)
+    UAPP_GETTER_WRAPPER(NodeId, referenceTypeId)
+    UAPP_GETTER(bool, isForward)
+    UAPP_GETTER_WRAPPER(ExpandedNodeId, targetNodeId)
+    UAPP_GETTER(bool, deleteBidirectional)
 };
 
 /**
@@ -1005,10 +955,8 @@ public:
         handle()->referencesToDelete = detail::toNativeArray(referencesToDelete);
     }
 
-    UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER_SPAN_WRAPPER(
-        DeleteReferencesItem, getReferencesToDelete, referencesToDelete, referencesToDeleteSize
-    )
+    UAPP_GETTER_WRAPPER(RequestHeader, requestHeader)
+    UAPP_GETTER_SPAN_WRAPPER(DeleteReferencesItem, referencesToDelete, referencesToDeleteSize)
 };
 
 /**
@@ -1020,11 +968,9 @@ class DeleteReferencesResponse
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
-    UAPP_GETTER_SPAN_WRAPPER(StatusCode, getResults, results, resultsSize)
-    UAPP_GETTER_SPAN_WRAPPER(
-        DiagnosticInfo, getDiagnosticInfos, diagnosticInfos, diagnosticInfosSize
-    )
+    UAPP_GETTER_WRAPPER(ResponseHeader, responseHeader)
+    UAPP_GETTER_SPAN_WRAPPER(StatusCode, results, resultsSize)
+    UAPP_GETTER_SPAN_WRAPPER(DiagnosticInfo, diagnosticInfos, diagnosticInfosSize)
 };
 
 /**
@@ -1040,9 +986,9 @@ public:
         handle()->viewVersion = viewVersion;
     }
 
-    UAPP_GETTER_WRAPPER(NodeId, getViewId, viewId)
-    UAPP_GETTER_WRAPPER(DateTime, getTimestamp, timestamp)
-    UAPP_GETTER(uint32_t, getViewVersion, viewVersion)
+    UAPP_GETTER_WRAPPER(NodeId, viewId)
+    UAPP_GETTER_WRAPPER(DateTime, timestamp)
+    UAPP_GETTER(uint32_t, viewVersion)
 };
 
 /**
@@ -1112,12 +1058,12 @@ public:
         handle()->resultMask = resultMask.get();
     }
 
-    UAPP_GETTER_WRAPPER(NodeId, getNodeId, nodeId)
-    UAPP_GETTER_CAST(BrowseDirection, getBrowseDirection, browseDirection)
-    UAPP_GETTER_WRAPPER(NodeId, getReferenceTypeId, referenceTypeId)
-    UAPP_GETTER(bool, getIncludeSubtypes, includeSubtypes)
-    UAPP_GETTER(Bitmask<NodeClass>, getNodeClassMask, nodeClassMask)
-    UAPP_GETTER(Bitmask<BrowseResultMask>, getResultMask, resultMask)
+    UAPP_GETTER_WRAPPER(NodeId, nodeId)
+    UAPP_GETTER_CAST(BrowseDirection, browseDirection)
+    UAPP_GETTER_WRAPPER(NodeId, referenceTypeId)
+    UAPP_GETTER(bool, includeSubtypes)
+    UAPP_GETTER(Bitmask<NodeClass>, nodeClassMask)
+    UAPP_GETTER(Bitmask<BrowseResultMask>, resultMask)
 };
 
 /**
@@ -1140,10 +1086,10 @@ public:
         handle()->nodesToBrowse = detail::toNativeArray(nodesToBrowse);
     }
 
-    UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER_WRAPPER(ViewDescription, getView, view)
-    UAPP_GETTER(uint32_t, getRequestedMaxReferencesPerNode, requestedMaxReferencesPerNode)
-    UAPP_GETTER_SPAN_WRAPPER(BrowseDescription, getNodesToBrowse, nodesToBrowse, nodesToBrowseSize)
+    UAPP_GETTER_WRAPPER(RequestHeader, requestHeader)
+    UAPP_GETTER_WRAPPER(ViewDescription, view)
+    UAPP_GETTER(uint32_t, requestedMaxReferencesPerNode)
+    UAPP_GETTER_SPAN_WRAPPER(BrowseDescription, nodesToBrowse, nodesToBrowseSize)
 };
 
 /**
@@ -1155,13 +1101,13 @@ class ReferenceDescription
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(NodeId, getReferenceTypeId, referenceTypeId)
-    UAPP_GETTER(bool, getIsForward, isForward)
-    UAPP_GETTER_WRAPPER(ExpandedNodeId, getNodeId, nodeId)
-    UAPP_GETTER_WRAPPER(QualifiedName, getBrowseName, browseName)
-    UAPP_GETTER_WRAPPER(LocalizedText, getDisplayName, displayName)
-    UAPP_GETTER_CAST(NodeClass, getNodeClass, nodeClass)
-    UAPP_GETTER_WRAPPER(ExpandedNodeId, getTypeDefinition, typeDefinition)
+    UAPP_GETTER_WRAPPER(NodeId, referenceTypeId)
+    UAPP_GETTER(bool, isForward)
+    UAPP_GETTER_WRAPPER(ExpandedNodeId, nodeId)
+    UAPP_GETTER_WRAPPER(QualifiedName, browseName)
+    UAPP_GETTER_WRAPPER(LocalizedText, displayName)
+    UAPP_GETTER_CAST(NodeClass, nodeClass)
+    UAPP_GETTER_WRAPPER(ExpandedNodeId, typeDefinition)
 };
 
 /**
@@ -1172,9 +1118,9 @@ class BrowseResult : public TypeWrapper<UA_BrowseResult, UA_TYPES_BROWSERESULT> 
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER(StatusCode, getStatusCode, statusCode)
-    UAPP_GETTER_WRAPPER(ByteString, getContinuationPoint, continuationPoint)
-    UAPP_GETTER_SPAN_WRAPPER(ReferenceDescription, getReferences, references, referencesSize)
+    UAPP_GETTER(StatusCode, statusCode)
+    UAPP_GETTER_WRAPPER(ByteString, continuationPoint)
+    UAPP_GETTER_SPAN_WRAPPER(ReferenceDescription, references, referencesSize)
 };
 
 /**
@@ -1184,11 +1130,9 @@ class BrowseResponse : public TypeWrapper<UA_BrowseResponse, UA_TYPES_BROWSERESP
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
-    UAPP_GETTER_SPAN_WRAPPER(BrowseResult, getResults, results, resultsSize)
-    UAPP_GETTER_SPAN_WRAPPER(
-        DiagnosticInfo, getDiagnosticInfos, diagnosticInfos, diagnosticInfosSize
-    )
+    UAPP_GETTER_WRAPPER(ResponseHeader, responseHeader)
+    UAPP_GETTER_SPAN_WRAPPER(BrowseResult, results, resultsSize)
+    UAPP_GETTER_SPAN_WRAPPER(DiagnosticInfo, diagnosticInfos, diagnosticInfosSize)
 };
 
 /**
@@ -1209,11 +1153,9 @@ public:
         handle()->continuationPoints = detail::toNativeArray(continuationPoints);
     }
 
-    UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER(bool, getReleaseContinuationPoints, releaseContinuationPoints)
-    UAPP_GETTER_SPAN_WRAPPER(
-        ByteString, getContinuationPoints, continuationPoints, continuationPointsSize
-    )
+    UAPP_GETTER_WRAPPER(RequestHeader, requestHeader)
+    UAPP_GETTER(bool, releaseContinuationPoints)
+    UAPP_GETTER_SPAN_WRAPPER(ByteString, continuationPoints, continuationPointsSize)
 };
 
 /**
@@ -1223,11 +1165,9 @@ class BrowseNextResponse : public TypeWrapper<UA_BrowseNextResponse, UA_TYPES_BR
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
-    UAPP_GETTER_SPAN_WRAPPER(BrowseResult, getResults, results, resultsSize)
-    UAPP_GETTER_SPAN_WRAPPER(
-        DiagnosticInfo, getDiagnosticInfos, diagnosticInfos, diagnosticInfosSize
-    )
+    UAPP_GETTER_WRAPPER(ResponseHeader, responseHeader)
+    UAPP_GETTER_SPAN_WRAPPER(BrowseResult, results, resultsSize)
+    UAPP_GETTER_SPAN_WRAPPER(DiagnosticInfo, diagnosticInfos, diagnosticInfosSize)
 };
 
 /**
@@ -1247,10 +1187,10 @@ public:
         handle()->targetName = detail::toNative(std::move(targetName));
     }
 
-    UAPP_GETTER_WRAPPER(NodeId, getReferenceTypeId, referenceTypeId)
-    UAPP_GETTER(bool, getIsInverse, isInverse)
-    UAPP_GETTER(bool, getIncludeSubtypes, includeSubtypes)
-    UAPP_GETTER_WRAPPER(QualifiedName, getTargetName, targetName)
+    UAPP_GETTER_WRAPPER(NodeId, referenceTypeId)
+    UAPP_GETTER(bool, isInverse)
+    UAPP_GETTER(bool, includeSubtypes)
+    UAPP_GETTER_WRAPPER(QualifiedName, targetName)
 };
 
 /**
@@ -1268,7 +1208,7 @@ public:
         handle()->elements = detail::toNativeArray(elements);
     }
 
-    UAPP_GETTER_SPAN_WRAPPER(RelativePathElement, getElements, elements, elementsSize)
+    UAPP_GETTER_SPAN_WRAPPER(RelativePathElement, elements, elementsSize)
 };
 
 /**
@@ -1283,8 +1223,8 @@ public:
         handle()->relativePath = detail::toNative(std::move(relativePath));
     }
 
-    UAPP_GETTER_WRAPPER(NodeId, getStartingNode, startingNode)
-    UAPP_GETTER_WRAPPER(RelativePath, getRelativePath, relativePath)
+    UAPP_GETTER_WRAPPER(NodeId, startingNode)
+    UAPP_GETTER_WRAPPER(RelativePath, relativePath)
 };
 
 /**
@@ -1294,8 +1234,8 @@ class BrowsePathTarget : public TypeWrapper<UA_BrowsePathTarget, UA_TYPES_BROWSE
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(ExpandedNodeId, getTargetId, targetId)
-    UAPP_GETTER(uint32_t, getRemainingPathIndex, remainingPathIndex)
+    UAPP_GETTER_WRAPPER(ExpandedNodeId, targetId)
+    UAPP_GETTER(uint32_t, remainingPathIndex)
 };
 
 /**
@@ -1305,8 +1245,8 @@ class BrowsePathResult : public TypeWrapper<UA_BrowsePathResult, UA_TYPES_BROWSE
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER(StatusCode, getStatusCode, statusCode)
-    UAPP_GETTER_SPAN_WRAPPER(BrowsePathTarget, getTargets, targets, targetsSize)
+    UAPP_GETTER(StatusCode, statusCode)
+    UAPP_GETTER_SPAN_WRAPPER(BrowsePathTarget, targets, targetsSize)
 };
 
 /**
@@ -1327,8 +1267,8 @@ public:
         handle()->browsePaths = detail::toNativeArray(browsePaths);
     }
 
-    UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER_SPAN_WRAPPER(BrowsePath, getBrowsePaths, browsePaths, browsePathsSize)
+    UAPP_GETTER_WRAPPER(RequestHeader, requestHeader)
+    UAPP_GETTER_SPAN_WRAPPER(BrowsePath, browsePaths, browsePathsSize)
 };
 
 /**
@@ -1341,11 +1281,9 @@ class TranslateBrowsePathsToNodeIdsResponse
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
-    UAPP_GETTER_SPAN_WRAPPER(BrowsePathResult, getResults, results, resultsSize)
-    UAPP_GETTER_SPAN_WRAPPER(
-        DiagnosticInfo, getDiagnosticInfos, diagnosticInfos, diagnosticInfosSize
-    )
+    UAPP_GETTER_WRAPPER(ResponseHeader, responseHeader)
+    UAPP_GETTER_SPAN_WRAPPER(BrowsePathResult, results, resultsSize)
+    UAPP_GETTER_SPAN_WRAPPER(DiagnosticInfo, diagnosticInfos, diagnosticInfosSize)
 };
 
 /**
@@ -1362,8 +1300,8 @@ public:
         handle()->nodesToRegister = detail::toNativeArray(nodesToRegister);
     }
 
-    UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER_SPAN_WRAPPER(NodeId, getNodesToRegister, nodesToRegister, nodesToRegisterSize)
+    UAPP_GETTER_WRAPPER(RequestHeader, requestHeader)
+    UAPP_GETTER_SPAN_WRAPPER(NodeId, nodesToRegister, nodesToRegisterSize)
 };
 
 /**
@@ -1374,8 +1312,8 @@ class RegisterNodesResponse
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
-    UAPP_GETTER_SPAN_WRAPPER(NodeId, getRegisteredNodeIds, registeredNodeIds, registeredNodeIdsSize)
+    UAPP_GETTER_WRAPPER(ResponseHeader, responseHeader)
+    UAPP_GETTER_SPAN_WRAPPER(NodeId, registeredNodeIds, registeredNodeIdsSize)
 };
 
 /**
@@ -1392,8 +1330,8 @@ public:
         handle()->nodesToUnregister = detail::toNativeArray(nodesToUnregister);
     }
 
-    UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER_SPAN_WRAPPER(NodeId, getNodesToUnregister, nodesToUnregister, nodesToUnregisterSize)
+    UAPP_GETTER_WRAPPER(RequestHeader, requestHeader)
+    UAPP_GETTER_SPAN_WRAPPER(NodeId, nodesToUnregister, nodesToUnregisterSize)
 };
 
 /**
@@ -1404,7 +1342,7 @@ class UnregisterNodesResponse
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
+    UAPP_GETTER_WRAPPER(ResponseHeader, responseHeader)
 };
 
 /**
@@ -1442,10 +1380,10 @@ public:
         handle()->dataEncoding = detail::toNative(std::move(dataEncoding));
     }
 
-    UAPP_GETTER_WRAPPER(NodeId, getNodeId, nodeId)
-    UAPP_GETTER_CAST(AttributeId, getAttributeId, attributeId)
-    UAPP_GETTER_WRAPPER(String, getIndexRange, indexRange)
-    UAPP_GETTER_WRAPPER(QualifiedName, getDataEncoding, dataEncoding)
+    UAPP_GETTER_WRAPPER(NodeId, nodeId)
+    UAPP_GETTER_CAST(AttributeId, attributeId)
+    UAPP_GETTER_WRAPPER(String, indexRange)
+    UAPP_GETTER_WRAPPER(QualifiedName, dataEncoding)
 };
 
 /**
@@ -1469,10 +1407,10 @@ public:
         handle()->nodesToRead = detail::toNativeArray(nodesToRead);
     }
 
-    UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER(double, getMaxAge, maxAge)
-    UAPP_GETTER_CAST(TimestampsToReturn, getTimestampsToReturn, timestampsToReturn)
-    UAPP_GETTER_SPAN_WRAPPER(ReadValueId, getNodesToRead, nodesToRead, nodesToReadSize)
+    UAPP_GETTER_WRAPPER(RequestHeader, requestHeader)
+    UAPP_GETTER(double, maxAge)
+    UAPP_GETTER_CAST(TimestampsToReturn, timestampsToReturn)
+    UAPP_GETTER_SPAN_WRAPPER(ReadValueId, nodesToRead, nodesToReadSize)
 };
 
 /**
@@ -1483,11 +1421,9 @@ class ReadResponse : public TypeWrapper<UA_ReadResponse, UA_TYPES_READRESPONSE> 
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
-    UAPP_GETTER_SPAN_WRAPPER(DataValue, getResults, results, resultsSize)
-    UAPP_GETTER_SPAN_WRAPPER(
-        DiagnosticInfo, getDiagnosticInfos, diagnosticInfos, diagnosticInfosSize
-    )
+    UAPP_GETTER_WRAPPER(ResponseHeader, responseHeader)
+    UAPP_GETTER_SPAN_WRAPPER(DataValue, results, resultsSize)
+    UAPP_GETTER_SPAN_WRAPPER(DiagnosticInfo, diagnosticInfos, diagnosticInfosSize)
 };
 
 /**
@@ -1507,10 +1443,10 @@ public:
         handle()->value = detail::toNative(std::move(value));
     }
 
-    UAPP_GETTER_WRAPPER(NodeId, getNodeId, nodeId)
-    UAPP_GETTER_CAST(AttributeId, getAttributeId, attributeId)
-    UAPP_GETTER_WRAPPER(String, getIndexRange, indexRange)
-    UAPP_GETTER_WRAPPER(DataValue, getValue, value)
+    UAPP_GETTER_WRAPPER(NodeId, nodeId)
+    UAPP_GETTER_CAST(AttributeId, attributeId)
+    UAPP_GETTER_WRAPPER(String, indexRange)
+    UAPP_GETTER_WRAPPER(DataValue, value)
 };
 
 /**
@@ -1527,8 +1463,8 @@ public:
         handle()->nodesToWrite = detail::toNativeArray(nodesToWrite);
     }
 
-    UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER_SPAN_WRAPPER(WriteValue, getNodesToWrite, nodesToWrite, nodesToWriteSize)
+    UAPP_GETTER_WRAPPER(RequestHeader, requestHeader)
+    UAPP_GETTER_SPAN_WRAPPER(WriteValue, nodesToWrite, nodesToWriteSize)
 };
 
 /**
@@ -1539,11 +1475,9 @@ class WriteResponse : public TypeWrapper<UA_WriteResponse, UA_TYPES_WRITERESPONS
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
-    UAPP_GETTER_SPAN_WRAPPER(StatusCode, getResults, results, resultsSize)
-    UAPP_GETTER_SPAN_WRAPPER(
-        DiagnosticInfo, getDiagnosticInfos, diagnosticInfos, diagnosticInfosSize
-    )
+    UAPP_GETTER_WRAPPER(ResponseHeader, responseHeader)
+    UAPP_GETTER_SPAN_WRAPPER(StatusCode, results, resultsSize)
+    UAPP_GETTER_SPAN_WRAPPER(DiagnosticInfo, diagnosticInfos, diagnosticInfosSize)
 };
 
 /**
@@ -1570,12 +1504,12 @@ public:
         handle()->buildDate = detail::toNative(std::move(buildDate));
     }
 
-    UAPP_GETTER_WRAPPER(String, getProductUri, productUri);
-    UAPP_GETTER_WRAPPER(String, getManufacturerName, manufacturerName);
-    UAPP_GETTER_WRAPPER(String, getProductName, productName);
-    UAPP_GETTER_WRAPPER(String, getSoftwareVersion, softwareVersion);
-    UAPP_GETTER_WRAPPER(String, getBuildNumber, buildNumber);
-    UAPP_GETTER_WRAPPER(DateTime, getBuildDate, buildDate)
+    UAPP_GETTER_WRAPPER(String, productUri);
+    UAPP_GETTER_WRAPPER(String, manufacturerName);
+    UAPP_GETTER_WRAPPER(String, productName);
+    UAPP_GETTER_WRAPPER(String, softwareVersion);
+    UAPP_GETTER_WRAPPER(String, buildNumber);
+    UAPP_GETTER_WRAPPER(DateTime, buildDate)
 };
 
 /* ------------------------------------------- Method ------------------------------------------- */
@@ -1605,11 +1539,11 @@ public:
         handle()->arrayDimensions = detail::toNativeArray(arrayDimensions);
     }
 
-    UAPP_GETTER_WRAPPER(String, getName, name)
-    UAPP_GETTER_WRAPPER(LocalizedText, getDescription, description)
-    UAPP_GETTER_WRAPPER(NodeId, getDataType, dataType)
-    UAPP_GETTER_CAST(ValueRank, getValueRank, valueRank)
-    UAPP_GETTER_SPAN(uint32_t, getArrayDimensions, arrayDimensions, arrayDimensionsSize)
+    UAPP_GETTER_WRAPPER(String, name)
+    UAPP_GETTER_WRAPPER(LocalizedText, description)
+    UAPP_GETTER_WRAPPER(NodeId, dataType)
+    UAPP_GETTER_CAST(ValueRank, valueRank)
+    UAPP_GETTER_SPAN(uint32_t, arrayDimensions, arrayDimensionsSize)
 };
 
 /**
@@ -1627,9 +1561,9 @@ public:
         handle()->inputArguments = detail::toNativeArray(inputArguments);
     }
 
-    UAPP_GETTER_WRAPPER(NodeId, getObjectId, objectId)
-    UAPP_GETTER_WRAPPER(NodeId, getMethodId, methodId)
-    UAPP_GETTER_SPAN_WRAPPER(Variant, getInputArguments, inputArguments, inputArgumentsSize)
+    UAPP_GETTER_WRAPPER(NodeId, objectId)
+    UAPP_GETTER_WRAPPER(NodeId, methodId)
+    UAPP_GETTER_SPAN_WRAPPER(Variant, inputArguments, inputArgumentsSize)
 };
 
 /**
@@ -1640,17 +1574,12 @@ class CallMethodResult : public TypeWrapper<UA_CallMethodResult, UA_TYPES_CALLME
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(StatusCode, getStatusCode, statusCode)
+    UAPP_GETTER_WRAPPER(StatusCode, statusCode)
+    UAPP_GETTER_SPAN_WRAPPER(StatusCode, inputArgumentResults, inputArgumentResultsSize)
     UAPP_GETTER_SPAN_WRAPPER(
-        StatusCode, getInputArgumentResults, inputArgumentResults, inputArgumentResultsSize
+        DiagnosticInfo, inputArgumentDiagnosticInfos, inputArgumentDiagnosticInfosSize
     )
-    UAPP_GETTER_SPAN_WRAPPER(
-        DiagnosticInfo,
-        getInputArgumentDiagnosticInfos,
-        inputArgumentDiagnosticInfos,
-        inputArgumentDiagnosticInfosSize
-    )
-    UAPP_GETTER_SPAN_WRAPPER(Variant, getOutputArguments, outputArguments, outputArgumentsSize)
+    UAPP_GETTER_SPAN_WRAPPER(Variant, outputArguments, outputArgumentsSize)
 };
 
 /**
@@ -1667,8 +1596,8 @@ public:
         handle()->methodsToCall = detail::toNativeArray(methodsToCall);
     }
 
-    UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER_SPAN_WRAPPER(CallMethodRequest, getMethodsToCall, methodsToCall, methodsToCallSize)
+    UAPP_GETTER_WRAPPER(RequestHeader, requestHeader)
+    UAPP_GETTER_SPAN_WRAPPER(CallMethodRequest, methodsToCall, methodsToCallSize)
 };
 
 /**
@@ -1679,11 +1608,9 @@ class CallResponse : public TypeWrapper<UA_CallResponse, UA_TYPES_CALLRESPONSE> 
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
-    UAPP_GETTER_SPAN_WRAPPER(CallMethodResult, getResults, results, resultsSize)
-    UAPP_GETTER_SPAN_WRAPPER(
-        DiagnosticInfo, getDiagnosticInfos, diagnosticInfos, diagnosticInfosSize
-    )
+    UAPP_GETTER_WRAPPER(ResponseHeader, responseHeader)
+    UAPP_GETTER_SPAN_WRAPPER(CallMethodResult, results, resultsSize)
+    UAPP_GETTER_SPAN_WRAPPER(DiagnosticInfo, diagnosticInfos, diagnosticInfosSize)
 };
 
 #endif  // UA_ENABLE_METHODCALLS
@@ -1746,7 +1673,7 @@ public:
         handle()->index = index;
     }
 
-    UAPP_GETTER(uint32_t, getIndex, index)
+    UAPP_GETTER(uint32_t, index)
 };
 
 /**
@@ -1770,7 +1697,7 @@ public:
     explicit LiteralOperand(T&& literal)
         : LiteralOperand{Variant{std::forward<T>(literal)}} {}
 
-    UAPP_GETTER_WRAPPER(Variant, getValue, value)
+    UAPP_GETTER_WRAPPER(Variant, value)
 };
 
 /**
@@ -1795,11 +1722,11 @@ public:
         handle()->indexRange = detail::toNative(indexRange);
     }
 
-    UAPP_GETTER_WRAPPER(NodeId, getNodeId, nodeId)
-    UAPP_GETTER_WRAPPER(String, getAlias, alias)
-    UAPP_GETTER_WRAPPER(RelativePath, getBrowsePath, browsePath)
-    UAPP_GETTER_CAST(AttributeId, getAttributeId, attributeId)
-    UAPP_GETTER_WRAPPER(String, getIndexRange, indexRange)
+    UAPP_GETTER_WRAPPER(NodeId, nodeId)
+    UAPP_GETTER_WRAPPER(String, alias)
+    UAPP_GETTER_WRAPPER(RelativePath, browsePath)
+    UAPP_GETTER_CAST(AttributeId, attributeId)
+    UAPP_GETTER_WRAPPER(String, indexRange)
 };
 
 /**
@@ -1824,10 +1751,10 @@ public:
         handle()->indexRange = detail::toNative(indexRange);
     }
 
-    UAPP_GETTER_WRAPPER(NodeId, getTypeDefinitionId, typeDefinitionId)
-    UAPP_GETTER_SPAN_WRAPPER(QualifiedName, getBrowsePath, browsePath, browsePathSize)
-    UAPP_GETTER_CAST(AttributeId, getAttributeId, attributeId)
-    UAPP_GETTER_WRAPPER(String, getIndexRange, indexRange)
+    UAPP_GETTER_WRAPPER(NodeId, typeDefinitionId)
+    UAPP_GETTER_SPAN_WRAPPER(QualifiedName, browsePath, browsePathSize)
+    UAPP_GETTER_CAST(AttributeId, attributeId)
+    UAPP_GETTER_WRAPPER(String, indexRange)
 };
 
 /**
@@ -1866,8 +1793,8 @@ public:
 
     ContentFilterElement(FilterOperator filterOperator, Span<const FilterOperand> operands);
 
-    UAPP_GETTER_CAST(FilterOperator, getFilterOperator, filterOperator)
-    UAPP_GETTER_SPAN_WRAPPER(ExtensionObject, getFilterOperands, filterOperands, filterOperandsSize)
+    UAPP_GETTER_CAST(FilterOperator, filterOperator)
+    UAPP_GETTER_SPAN_WRAPPER(ExtensionObject, filterOperands, filterOperandsSize)
 };
 
 /**
@@ -1888,7 +1815,7 @@ public:
     ContentFilter(std::initializer_list<ContentFilterElement> elements);
     explicit ContentFilter(Span<const ContentFilterElement> elements);
 
-    UAPP_GETTER_SPAN_WRAPPER(ContentFilterElement, getElements, elements, elementsSize)
+    UAPP_GETTER_SPAN_WRAPPER(ContentFilterElement, elements, elementsSize)
 };
 
 /// @relates ContentFilterElement
@@ -1956,9 +1883,9 @@ public:
         handle()->deadbandValue = deadbandValue;
     }
 
-    UAPP_GETTER_CAST(DataChangeTrigger, getTrigger, trigger)
-    UAPP_GETTER_CAST(DeadbandType, getDeadbandType, deadbandType)
-    UAPP_GETTER(double, getDeadbandValue, deadbandValue)
+    UAPP_GETTER_CAST(DataChangeTrigger, trigger)
+    UAPP_GETTER_CAST(DeadbandType, deadbandType)
+    UAPP_GETTER(double, deadbandValue)
 };
 
 /**
@@ -1975,10 +1902,8 @@ public:
         handle()->whereClause = detail::toNative(std::move(whereClause));
     }
 
-    UAPP_GETTER_SPAN_WRAPPER(
-        SimpleAttributeOperand, getSelectClauses, selectClauses, selectClausesSize
-    )
-    UAPP_GETTER_WRAPPER(ContentFilter, getWhereClause, whereClause)
+    UAPP_GETTER_SPAN_WRAPPER(SimpleAttributeOperand, selectClauses, selectClausesSize)
+    UAPP_GETTER_WRAPPER(ContentFilter, whereClause)
 };
 
 using AggregateConfiguration = UA_AggregateConfiguration;
@@ -2003,10 +1928,10 @@ public:
         handle()->aggregateConfiguration = aggregateConfiguration;  // TODO: make wrapper?
     }
 
-    UAPP_GETTER_WRAPPER(DateTime, getStartTime, startTime)
-    UAPP_GETTER_WRAPPER(NodeId, getAggregateType, aggregateType)
-    UAPP_GETTER(double, getProcessingInterval, processingInterval)
-    UAPP_GETTER(AggregateConfiguration, getAggregateConfiguration, aggregateConfiguration)
+    UAPP_GETTER_WRAPPER(DateTime, startTime)
+    UAPP_GETTER_WRAPPER(NodeId, aggregateType)
+    UAPP_GETTER(double, processingInterval)
+    UAPP_GETTER(AggregateConfiguration, aggregateConfiguration)
 };
 
 /**
@@ -2034,10 +1959,10 @@ public:
         handle()->discardOldest = discardOldest;
     }
 
-    UAPP_GETTER(double, getSamplingInterval, samplingInterval)
-    UAPP_GETTER_WRAPPER(ExtensionObject, getFilter, filter)
-    UAPP_GETTER(uint32_t, getQueueSize, queueSize)
-    UAPP_GETTER(bool, getDiscardOldest, discardOldest)
+    UAPP_GETTER(double, samplingInterval)
+    UAPP_GETTER_WRAPPER(ExtensionObject, filter)
+    UAPP_GETTER(uint32_t, queueSize)
+    UAPP_GETTER(bool, discardOldest)
 };
 
 /**
@@ -2059,9 +1984,9 @@ public:
         handle()->requestedParameters = detail::toNative(std::move(requestedParameters));
     }
 
-    UAPP_GETTER_WRAPPER(ReadValueId, getItemToMonitor, itemToMonitor)
-    UAPP_GETTER_CAST(MonitoringMode, getMonitoringMode, monitoringMode)
-    UAPP_GETTER_WRAPPER(MonitoringParameters, getRequestedParameters, requestedParameters)
+    UAPP_GETTER_WRAPPER(ReadValueId, itemToMonitor)
+    UAPP_GETTER_CAST(MonitoringMode, monitoringMode)
+    UAPP_GETTER_WRAPPER(MonitoringParameters, requestedParameters)
 };
 
 /**
@@ -2073,11 +1998,11 @@ class MonitoredItemCreateResult
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(StatusCode, getStatusCode, statusCode);
-    UAPP_GETTER(IntegerId, getMonitoredItemId, monitoredItemId);
-    UAPP_GETTER(double, getRevisedSamplingInterval, revisedSamplingInterval);
-    UAPP_GETTER(IntegerId, getRevisedQueueSize, revisedQueueSize);
-    UAPP_GETTER_WRAPPER(ExtensionObject, getFilterResult, filterResult);
+    UAPP_GETTER_WRAPPER(StatusCode, statusCode);
+    UAPP_GETTER(IntegerId, monitoredItemId);
+    UAPP_GETTER(double, revisedSamplingInterval);
+    UAPP_GETTER(IntegerId, revisedQueueSize);
+    UAPP_GETTER_WRAPPER(ExtensionObject, filterResult);
 };
 
 /**
@@ -2102,12 +2027,10 @@ public:
         handle()->itemsToCreate = detail::toNativeArray(itemsToCreate);
     }
 
-    UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER(IntegerId, getSubscriptionId, subscriptionId)
-    UAPP_GETTER_CAST(TimestampsToReturn, getTimestampsToReturn, timestampsToReturn)
-    UAPP_GETTER_SPAN_WRAPPER(
-        MonitoredItemCreateRequest, getItemsToCreate, itemsToCreate, itemsToCreateSize
-    )
+    UAPP_GETTER_WRAPPER(RequestHeader, requestHeader)
+    UAPP_GETTER(IntegerId, subscriptionId)
+    UAPP_GETTER_CAST(TimestampsToReturn, timestampsToReturn)
+    UAPP_GETTER_SPAN_WRAPPER(MonitoredItemCreateRequest, itemsToCreate, itemsToCreateSize)
 };
 
 /**
@@ -2119,11 +2042,9 @@ class CreateMonitoredItemsResponse
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
-    UAPP_GETTER_SPAN_WRAPPER(MonitoredItemCreateResult, getResults, results, resultsSize);
-    UAPP_GETTER_SPAN_WRAPPER(
-        DiagnosticInfo, getDiagnosticInfos, diagnosticInfos, diagnosticInfosSize
-    )
+    UAPP_GETTER_WRAPPER(ResponseHeader, responseHeader)
+    UAPP_GETTER_SPAN_WRAPPER(MonitoredItemCreateResult, results, resultsSize);
+    UAPP_GETTER_SPAN_WRAPPER(DiagnosticInfo, diagnosticInfos, diagnosticInfosSize)
 };
 
 /**
@@ -2142,8 +2063,8 @@ public:
         handle()->requestedParameters = detail::toNative(std::move(requestedParameters));
     }
 
-    UAPP_GETTER(IntegerId, getMonitoredItemId, monitoredItemId);
-    UAPP_GETTER_WRAPPER(MonitoringParameters, getRequestedParameters, requestedParameters)
+    UAPP_GETTER(IntegerId, monitoredItemId);
+    UAPP_GETTER_WRAPPER(MonitoringParameters, requestedParameters)
 };
 
 /**
@@ -2155,10 +2076,10 @@ class MonitoredItemModifyResult
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(StatusCode, getStatusCode, statusCode);
-    UAPP_GETTER(double, getRevisedSamplingInterval, revisedSamplingInterval);
-    UAPP_GETTER(uint32_t, getRevisedQueueSize, revisedQueueSize);
-    UAPP_GETTER_WRAPPER(ExtensionObject, getFilterResult, filterResult);
+    UAPP_GETTER_WRAPPER(StatusCode, statusCode);
+    UAPP_GETTER(double, revisedSamplingInterval);
+    UAPP_GETTER(uint32_t, revisedQueueSize);
+    UAPP_GETTER_WRAPPER(ExtensionObject, filterResult);
 };
 
 /**
@@ -2183,12 +2104,10 @@ public:
         handle()->itemsToModify = detail::toNativeArray(itemsToModify);
     }
 
-    UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER(IntegerId, getSubscriptionId, subscriptionId)
-    UAPP_GETTER_CAST(TimestampsToReturn, getTimestampsToReturn, timestampsToReturn)
-    UAPP_GETTER_SPAN_WRAPPER(
-        MonitoredItemModifyRequest, getItemsToModify, itemsToModify, itemsToModifySize
-    )
+    UAPP_GETTER_WRAPPER(RequestHeader, requestHeader)
+    UAPP_GETTER(IntegerId, subscriptionId)
+    UAPP_GETTER_CAST(TimestampsToReturn, timestampsToReturn)
+    UAPP_GETTER_SPAN_WRAPPER(MonitoredItemModifyRequest, itemsToModify, itemsToModifySize)
 };
 
 /**
@@ -2200,11 +2119,9 @@ class ModifyMonitoredItemsResponse
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
-    UAPP_GETTER_SPAN_WRAPPER(MonitoredItemModifyResult, getResults, results, resultsSize);
-    UAPP_GETTER_SPAN_WRAPPER(
-        DiagnosticInfo, getDiagnosticInfos, diagnosticInfos, diagnosticInfosSize
-    )
+    UAPP_GETTER_WRAPPER(ResponseHeader, responseHeader)
+    UAPP_GETTER_SPAN_WRAPPER(MonitoredItemModifyResult, results, resultsSize);
+    UAPP_GETTER_SPAN_WRAPPER(DiagnosticInfo, diagnosticInfos, diagnosticInfosSize)
 };
 
 /**
@@ -2229,10 +2146,10 @@ public:
         handle()->monitoredItemIds = detail::toNativeArray(monitoredItemIds);
     }
 
-    UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER(IntegerId, getSubscriptionId, subscriptionId)
-    UAPP_GETTER_CAST(MonitoringMode, getMonitoringMode, monitoringMode)
-    UAPP_GETTER_SPAN(IntegerId, getMonitoredItemIds, monitoredItemIds, monitoredItemIdsSize)
+    UAPP_GETTER_WRAPPER(RequestHeader, requestHeader)
+    UAPP_GETTER(IntegerId, subscriptionId)
+    UAPP_GETTER_CAST(MonitoringMode, monitoringMode)
+    UAPP_GETTER_SPAN(IntegerId, monitoredItemIds, monitoredItemIdsSize)
 };
 
 /**
@@ -2244,11 +2161,9 @@ class SetMonitoringModeResponse
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
-    UAPP_GETTER_SPAN_WRAPPER(StatusCode, getResults, results, resultsSize);
-    UAPP_GETTER_SPAN_WRAPPER(
-        DiagnosticInfo, getDiagnosticInfos, diagnosticInfos, diagnosticInfosSize
-    )
+    UAPP_GETTER_WRAPPER(ResponseHeader, responseHeader)
+    UAPP_GETTER_SPAN_WRAPPER(StatusCode, results, resultsSize);
+    UAPP_GETTER_SPAN_WRAPPER(DiagnosticInfo, diagnosticInfos, diagnosticInfosSize)
 };
 
 /**
@@ -2276,11 +2191,11 @@ public:
         handle()->linksToRemove = detail::toNativeArray(linksToRemove);
     }
 
-    UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER(IntegerId, getSubscriptionId, subscriptionId)
-    UAPP_GETTER(IntegerId, getTriggeringItemId, triggeringItemId)
-    UAPP_GETTER_SPAN(IntegerId, getLinksToAdd, linksToAdd, linksToAddSize)
-    UAPP_GETTER_SPAN(IntegerId, getLinksToRemove, linksToRemove, linksToRemoveSize)
+    UAPP_GETTER_WRAPPER(RequestHeader, requestHeader)
+    UAPP_GETTER(IntegerId, subscriptionId)
+    UAPP_GETTER(IntegerId, triggeringItemId)
+    UAPP_GETTER_SPAN(IntegerId, linksToAdd, linksToAddSize)
+    UAPP_GETTER_SPAN(IntegerId, linksToRemove, linksToRemoveSize)
 };
 
 /**
@@ -2292,15 +2207,11 @@ class SetTriggeringResponse
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
-    UAPP_GETTER_SPAN_WRAPPER(StatusCode, getAddResults, addResults, addResultsSize);
-    UAPP_GETTER_SPAN_WRAPPER(
-        DiagnosticInfo, getAddDiagnosticInfos, addDiagnosticInfos, addDiagnosticInfosSize
-    )
-    UAPP_GETTER_SPAN_WRAPPER(StatusCode, getRemoveResults, removeResults, removeResultsSize);
-    UAPP_GETTER_SPAN_WRAPPER(
-        DiagnosticInfo, getRemoveDiagnosticInfos, removeDiagnosticInfos, removeDiagnosticInfosSize
-    )
+    UAPP_GETTER_WRAPPER(ResponseHeader, responseHeader)
+    UAPP_GETTER_SPAN_WRAPPER(StatusCode, addResults, addResultsSize);
+    UAPP_GETTER_SPAN_WRAPPER(DiagnosticInfo, addDiagnosticInfos, addDiagnosticInfosSize)
+    UAPP_GETTER_SPAN_WRAPPER(StatusCode, removeResults, removeResultsSize);
+    UAPP_GETTER_SPAN_WRAPPER(DiagnosticInfo, removeDiagnosticInfos, removeDiagnosticInfosSize)
 };
 
 /**
@@ -2323,9 +2234,9 @@ public:
         handle()->monitoredItemIds = detail::toNativeArray(monitoredItemIds);
     }
 
-    UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER(IntegerId, getSubscriptionId, subscriptionId)
-    UAPP_GETTER_SPAN(IntegerId, getMonitoredItemIds, monitoredItemIds, monitoredItemIdsSize)
+    UAPP_GETTER_WRAPPER(RequestHeader, requestHeader)
+    UAPP_GETTER(IntegerId, subscriptionId)
+    UAPP_GETTER_SPAN(IntegerId, monitoredItemIds, monitoredItemIdsSize)
 };
 
 /**
@@ -2337,11 +2248,9 @@ class DeleteMonitoredItemsResponse
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
-    UAPP_GETTER_SPAN_WRAPPER(StatusCode, getResults, results, resultsSize);
-    UAPP_GETTER_SPAN_WRAPPER(
-        DiagnosticInfo, getDiagnosticInfos, diagnosticInfos, diagnosticInfosSize
-    )
+    UAPP_GETTER_WRAPPER(ResponseHeader, responseHeader)
+    UAPP_GETTER_SPAN_WRAPPER(StatusCode, results, resultsSize);
+    UAPP_GETTER_SPAN_WRAPPER(DiagnosticInfo, diagnosticInfos, diagnosticInfosSize)
 };
 
 /**
@@ -2371,13 +2280,13 @@ public:
         handle()->priority = priority;
     }
 
-    UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER(double, getRequestedPublishingInterval, requestedPublishingInterval)
-    UAPP_GETTER(uint32_t, getRequestedLifetimeCount, requestedLifetimeCount)
-    UAPP_GETTER(uint32_t, getRequestedMaxKeepAliveCount, requestedMaxKeepAliveCount)
-    UAPP_GETTER(uint32_t, getMaxNotificationsPerPublish, maxNotificationsPerPublish)
-    UAPP_GETTER(bool, getPublishingEnabled, publishingEnabled)
-    UAPP_GETTER(uint8_t, getPriority, priority)
+    UAPP_GETTER_WRAPPER(RequestHeader, requestHeader)
+    UAPP_GETTER(double, requestedPublishingInterval)
+    UAPP_GETTER(uint32_t, requestedLifetimeCount)
+    UAPP_GETTER(uint32_t, requestedMaxKeepAliveCount)
+    UAPP_GETTER(uint32_t, maxNotificationsPerPublish)
+    UAPP_GETTER(bool, publishingEnabled)
+    UAPP_GETTER(uint8_t, priority)
 };
 
 /**
@@ -2389,11 +2298,11 @@ class CreateSubscriptionResponse
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
-    UAPP_GETTER(IntegerId, getSubscriptionId, subscriptionId)
-    UAPP_GETTER(bool, getRevisedPublishingInterval, revisedPublishingInterval)
-    UAPP_GETTER(uint32_t, getRevisedLifetimeCount, revisedLifetimeCount)
-    UAPP_GETTER(uint32_t, getRevisedMaxKeepAliveCount, revisedMaxKeepAliveCount)
+    UAPP_GETTER_WRAPPER(ResponseHeader, responseHeader)
+    UAPP_GETTER(IntegerId, subscriptionId)
+    UAPP_GETTER(bool, revisedPublishingInterval)
+    UAPP_GETTER(uint32_t, revisedLifetimeCount)
+    UAPP_GETTER(uint32_t, revisedMaxKeepAliveCount)
 };
 
 /**
@@ -2423,13 +2332,13 @@ public:
         handle()->priority = priority;
     }
 
-    UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER(IntegerId, getSubscriptionId, subscriptionId)
-    UAPP_GETTER(double, getRequestedPublishingInterval, requestedPublishingInterval)
-    UAPP_GETTER(uint32_t, getRequestedLifetimeCount, requestedLifetimeCount)
-    UAPP_GETTER(uint32_t, getRequestedMaxKeepAliveCount, requestedMaxKeepAliveCount)
-    UAPP_GETTER(uint32_t, getMaxNotificationsPerPublish, maxNotificationsPerPublish)
-    UAPP_GETTER(uint8_t, getPriority, priority)
+    UAPP_GETTER_WRAPPER(RequestHeader, requestHeader)
+    UAPP_GETTER(IntegerId, subscriptionId)
+    UAPP_GETTER(double, requestedPublishingInterval)
+    UAPP_GETTER(uint32_t, requestedLifetimeCount)
+    UAPP_GETTER(uint32_t, requestedMaxKeepAliveCount)
+    UAPP_GETTER(uint32_t, maxNotificationsPerPublish)
+    UAPP_GETTER(uint8_t, priority)
 };
 
 /**
@@ -2441,10 +2350,10 @@ class ModifySubscriptionResponse
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
-    UAPP_GETTER(bool, getRevisedPublishingInterval, revisedPublishingInterval)
-    UAPP_GETTER(uint32_t, getRevisedLifetimeCount, revisedLifetimeCount)
-    UAPP_GETTER(uint32_t, getRevisedMaxKeepAliveCount, revisedMaxKeepAliveCount)
+    UAPP_GETTER_WRAPPER(ResponseHeader, responseHeader)
+    UAPP_GETTER(bool, revisedPublishingInterval)
+    UAPP_GETTER(uint32_t, revisedLifetimeCount)
+    UAPP_GETTER(uint32_t, revisedMaxKeepAliveCount)
 };
 
 /**
@@ -2465,9 +2374,9 @@ public:
         handle()->subscriptionIds = detail::toNativeArray(subscriptionIds);
     }
 
-    UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER(bool, getPublishingEnabled, publishingEnabled)
-    UAPP_GETTER_SPAN(IntegerId, getSubscriptionIds, subscriptionIds, subscriptionIdsSize)
+    UAPP_GETTER_WRAPPER(RequestHeader, requestHeader)
+    UAPP_GETTER(bool, publishingEnabled)
+    UAPP_GETTER_SPAN(IntegerId, subscriptionIds, subscriptionIdsSize)
 };
 
 /**
@@ -2479,11 +2388,9 @@ class SetPublishingModeResponse
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
-    UAPP_GETTER_SPAN_WRAPPER(StatusCode, getResults, results, resultsSize)
-    UAPP_GETTER_SPAN_WRAPPER(
-        DiagnosticInfo, getDiagnosticInfos, diagnosticInfos, diagnosticInfosSize
-    )
+    UAPP_GETTER_WRAPPER(ResponseHeader, responseHeader)
+    UAPP_GETTER_SPAN_WRAPPER(StatusCode, results, resultsSize)
+    UAPP_GETTER_SPAN_WRAPPER(DiagnosticInfo, diagnosticInfos, diagnosticInfosSize)
 };
 
 /**
@@ -2495,8 +2402,8 @@ class StatusChangeNotification
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(StatusCode, getStatus, status)
-    UAPP_GETTER_WRAPPER(DiagnosticInfo, getDiagnosticInfo, diagnosticInfo)
+    UAPP_GETTER_WRAPPER(StatusCode, status)
+    UAPP_GETTER_WRAPPER(DiagnosticInfo, diagnosticInfo)
 };
 
 /**
@@ -2514,8 +2421,8 @@ public:
         handle()->subscriptionIds = detail::toNativeArray(subscriptionIds);
     }
 
-    UAPP_GETTER_WRAPPER(RequestHeader, getRequestHeader, requestHeader)
-    UAPP_GETTER_SPAN(IntegerId, getSubscriptionIds, subscriptionIds, subscriptionIdsSize)
+    UAPP_GETTER_WRAPPER(RequestHeader, requestHeader)
+    UAPP_GETTER_SPAN(IntegerId, subscriptionIds, subscriptionIdsSize)
 };
 
 /**
@@ -2527,11 +2434,9 @@ class DeleteSubscriptionsResponse
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(ResponseHeader, getResponseHeader, responseHeader)
-    UAPP_GETTER_SPAN_WRAPPER(StatusCode, getResults, results, resultsSize)
-    UAPP_GETTER_SPAN_WRAPPER(
-        DiagnosticInfo, getDiagnosticInfos, diagnosticInfos, diagnosticInfosSize
-    )
+    UAPP_GETTER_WRAPPER(ResponseHeader, responseHeader)
+    UAPP_GETTER_SPAN_WRAPPER(StatusCode, results, resultsSize)
+    UAPP_GETTER_SPAN_WRAPPER(DiagnosticInfo, diagnosticInfos, diagnosticInfosSize)
 };
 
 #endif  // UA_ENABLE_SUBSCRIPTIONS
@@ -2569,8 +2474,8 @@ public:
         handle()->high = high;
     }
 
-    UAPP_GETTER(double, getLow, low)
-    UAPP_GETTER(double, getHigh, high)
+    UAPP_GETTER(double, low)
+    UAPP_GETTER(double, high)
 };
 
 /**
@@ -2593,10 +2498,10 @@ public:
         handle()->description = detail::toNative(std::move(description));
     }
 
-    UAPP_GETTER_WRAPPER(String, getNamespaceUri, namespaceUri)
-    UAPP_GETTER(int32_t, getUnitId, unitId)
-    UAPP_GETTER_WRAPPER(LocalizedText, getDisplayName, displayName)
-    UAPP_GETTER_WRAPPER(LocalizedText, getDescription, description)
+    UAPP_GETTER_WRAPPER(String, namespaceUri)
+    UAPP_GETTER(int32_t, unitId)
+    UAPP_GETTER_WRAPPER(LocalizedText, displayName)
+    UAPP_GETTER_WRAPPER(LocalizedText, description)
 };
 
 /**
@@ -2612,8 +2517,8 @@ public:
         handle()->imaginary = imaginary;
     }
 
-    UAPP_GETTER(float, getReal, real)
-    UAPP_GETTER(float, getImaginary, imaginary)
+    UAPP_GETTER(float, real)
+    UAPP_GETTER(float, imaginary)
 };
 
 /**
@@ -2630,8 +2535,8 @@ public:
         handle()->imaginary = imaginary;
     }
 
-    UAPP_GETTER(double, getReal, real)
-    UAPP_GETTER(double, getImaginary, imaginary)
+    UAPP_GETTER(double, real)
+    UAPP_GETTER(double, imaginary)
 };
 
 /**
@@ -2667,11 +2572,11 @@ public:
         handle()->axisSteps = detail::toNativeArray(axisSteps);
     }
 
-    UAPP_GETTER_WRAPPER(EUInformation, getEngineeringUnits, engineeringUnits)
-    UAPP_GETTER_WRAPPER(Range, getEURange, eURange)
-    UAPP_GETTER_WRAPPER(LocalizedText, getTitle, title)
-    UAPP_GETTER_CAST(AxisScaleEnumeration, getAxisScaleType, axisScaleType)
-    UAPP_GETTER_SPAN(double, getAxisSteps, axisSteps, axisStepsSize)
+    UAPP_GETTER_WRAPPER(EUInformation, engineeringUnits)
+    UAPP_GETTER_WRAPPER(Range, eURange)
+    UAPP_GETTER_WRAPPER(LocalizedText, title)
+    UAPP_GETTER_CAST(AxisScaleEnumeration, axisScaleType)
+    UAPP_GETTER_SPAN(double, axisSteps, axisStepsSize)
 };
 
 /**
@@ -2687,8 +2592,8 @@ public:
         handle()->value = value;
     }
 
-    UAPP_GETTER(double, getX, x)
-    UAPP_GETTER(float, getValue, value)
+    UAPP_GETTER(double, x)
+    UAPP_GETTER(float, value)
 };
 
 #endif  // UAPP_HAS_DATAACCESS
@@ -2717,13 +2622,13 @@ class StructureField : public TypeWrapper<UA_StructureField, UA_TYPES_STRUCTUREF
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(String, getName, name)
-    UAPP_GETTER_WRAPPER(LocalizedText, getDescription, description)
-    UAPP_GETTER_WRAPPER(NodeId, getDataType, dataType)
-    UAPP_GETTER_CAST(ValueRank, getValueRank, valueRank)
-    UAPP_GETTER_SPAN(uint32_t, getArrayDimensions, arrayDimensions, arrayDimensionsSize)
-    UAPP_GETTER(uint32_t, getMaxStringLength, maxStringLength)
-    UAPP_GETTER(bool, getIsOptional, isOptional)
+    UAPP_GETTER_WRAPPER(String, name)
+    UAPP_GETTER_WRAPPER(LocalizedText, description)
+    UAPP_GETTER_WRAPPER(NodeId, dataType)
+    UAPP_GETTER_CAST(ValueRank, valueRank)
+    UAPP_GETTER_SPAN(uint32_t, arrayDimensions, arrayDimensionsSize)
+    UAPP_GETTER(uint32_t, maxStringLength)
+    UAPP_GETTER(bool, isOptional)
 };
 
 /**
@@ -2735,10 +2640,10 @@ class StructureDefinition
 public:
     using TypeWrapper::TypeWrapper;
 
-    UAPP_GETTER_WRAPPER(NodeId, getDefaultEncodingId, defaultEncodingId)
-    UAPP_GETTER_WRAPPER(NodeId, getBaseDataType, baseDataType)
-    UAPP_GETTER_CAST(StructureType, getStructureType, structureType)
-    UAPP_GETTER_SPAN_WRAPPER(StructureField, getFields, fields, fieldsSize)
+    UAPP_GETTER_WRAPPER(NodeId, defaultEncodingId)
+    UAPP_GETTER_WRAPPER(NodeId, baseDataType)
+    UAPP_GETTER_CAST(StructureType, structureType)
+    UAPP_GETTER_SPAN_WRAPPER(StructureField, fields, fieldsSize)
 };
 
 /**
@@ -2761,10 +2666,10 @@ public:
         handle()->name = detail::toNative(name);
     }
 
-    UAPP_GETTER(int64_t, getValue, value)
-    UAPP_GETTER_WRAPPER(LocalizedText, getDisplayName, displayName)
-    UAPP_GETTER_WRAPPER(LocalizedText, getDescription, description)
-    UAPP_GETTER_WRAPPER(String, getName, name)
+    UAPP_GETTER(int64_t, value)
+    UAPP_GETTER_WRAPPER(LocalizedText, displayName)
+    UAPP_GETTER_WRAPPER(LocalizedText, description)
+    UAPP_GETTER_WRAPPER(String, name)
 };
 
 /**
@@ -2783,7 +2688,7 @@ public:
         handle()->fields = detail::toNativeArray(fields);
     }
 
-    UAPP_GETTER_SPAN_WRAPPER(EnumField, getFields, fields, fieldsSize)
+    UAPP_GETTER_SPAN_WRAPPER(EnumField, fields, fieldsSize)
 };
 
 #endif  // UA_ENABLE_TYPEDESCRIPTION


### PR DESCRIPTION
Remove functions that have been deprecated at least since v0.17.0:

- Old `NodeId` identifier getter
- `*::fromScalar`, `*::fromArray`, `*::fromDecoded`, `*::fromDecodedCopy` factory functions
- `*::isEmpty` member functions
- `Variant::set*` functions
- `Variant::get*Copy` functions
- Member functions with `get` prefix