### PR TITLE
feat: String type conversion for all string-like types

### DIFF
--- a/include/open62541pp/detail/traits.hpp
+++ b/include/open62541pp/detail/traits.hpp
@@ -82,6 +82,7 @@ struct IsStringLike<T, std::enable_if_t<IsRange<T>::value>>
     : std::conjunction<
           IsContiguousRange<T>,
           std::is_same<RangeValueT<T>, char>,
-          std::is_constructible<std::remove_reference_t<T>, const char*>> {};
+          std::is_constructible<std::remove_reference_t<T>, const char*>,
+          std::is_constructible<std::remove_reference_t<T>, const char*, size_t>> {};
 
 }  // namespace opcua::detail

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -331,23 +331,9 @@ inline bool operator!=(std::string_view lhs, const String& rhs) noexcept {
 /// @relates String
 std::ostream& operator<<(std::ostream& os, const String& str);
 
-template <typename Traits>
-struct TypeConverter<std::basic_string_view<char, Traits>> {
-    using Type = std::basic_string_view<char, Traits>;
-    using NativeType = String;
-
-    static void fromNative(const NativeType& src, Type& dst) {
-        dst = Type{src.data(), src.size()};
-    }
-
-    static void toNative(Type src, NativeType& dst) {
-        dst = NativeType{src};
-    }
-};
-
-template <typename Traits, typename Allocator>
-struct TypeConverter<std::basic_string<char, Traits, Allocator>> {
-    using Type = std::basic_string<char, Traits, Allocator>;
+template <typename T>
+struct TypeConverter<T, std::enable_if_t<detail::IsStringLike<T>::value>> {
+    using Type = T;
     using NativeType = String;
 
     static void fromNative(const NativeType& src, Type& dst) {
@@ -355,7 +341,7 @@ struct TypeConverter<std::basic_string<char, Traits, Allocator>> {
     }
 
     static void toNative(const Type& src, NativeType& dst) {
-        dst = NativeType{src};
+        dst = NativeType{src.begin(), src.end()};
     }
 };
 

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -257,7 +257,7 @@ public:
     using TypeWrapper::TypeWrapper;
 
     explicit String(std::string_view str)
-        : TypeWrapper{detail::allocNativeString(str)} {}
+        : String{detail::allocNativeString(str)} {}
 
     template <typename InputIt>
     String(InputIt first, InputIt last) {
@@ -533,7 +533,7 @@ public:
     using TypeWrapper::TypeWrapper;
 
     explicit ByteString(std::string_view str)
-        : TypeWrapper{detail::allocNativeString(str)} {}
+        : ByteString{detail::allocNativeString(str)} {}
 
     explicit ByteString(const char* str)  // required to avoid ambiguity
         : ByteString{std::string_view{str}} {}
@@ -575,7 +575,7 @@ public:
     using TypeWrapper::TypeWrapper;
 
     explicit XmlElement(std::string_view str)
-        : TypeWrapper{detail::allocNativeString(str)} {}
+        : XmlElement{detail::allocNativeString(str)} {}
 
     template <typename InputIt>
     XmlElement(InputIt first, InputIt last) {

--- a/include/open62541pp/ua/types.hpp
+++ b/include/open62541pp/ua/types.hpp
@@ -405,7 +405,7 @@ public:
 
     /// Construct with default attribute definitions.
     ObjectAttributes()
-        : TypeWrapper{UA_ObjectAttributes_default} {}
+        : ObjectAttributes{UA_ObjectAttributes_default} {}
 
     UAPP_NODEATTR_COMMON
     UAPP_NODEATTR_CAST(
@@ -423,7 +423,7 @@ public:
 
     /// Construct with default attribute definitions.
     VariableAttributes()
-        : TypeWrapper{UA_VariableAttributes_default} {}
+        : VariableAttributes{UA_VariableAttributes_default} {}
 
     UAPP_NODEATTR_COMMON
     UAPP_NODEATTR_WRAPPER(Variant, Value, value, UA_NODEATTRIBUTESMASK_VALUE)
@@ -487,7 +487,7 @@ public:
 
     /// Construct with default attribute definitions.
     MethodAttributes()
-        : TypeWrapper{UA_MethodAttributes_default} {}
+        : MethodAttributes{UA_MethodAttributes_default} {}
 
     UAPP_NODEATTR_COMMON
     UAPP_NODEATTR(bool, Executable, executable, UA_NODEATTRIBUTESMASK_EXECUTABLE)
@@ -505,7 +505,7 @@ public:
 
     /// Construct with default attribute definitions.
     ObjectTypeAttributes()
-        : TypeWrapper{UA_ObjectTypeAttributes_default} {}
+        : ObjectTypeAttributes{UA_ObjectTypeAttributes_default} {}
 
     UAPP_NODEATTR_COMMON
     UAPP_NODEATTR(bool, IsAbstract, isAbstract, UA_NODEATTRIBUTESMASK_ISABSTRACT)
@@ -522,7 +522,7 @@ public:
 
     /// Construct with default attribute definitions.
     VariableTypeAttributes()
-        : TypeWrapper{UA_VariableTypeAttributes_default} {}
+        : VariableTypeAttributes{UA_VariableTypeAttributes_default} {}
 
     UAPP_NODEATTR_COMMON
     UAPP_NODEATTR_WRAPPER(Variant, Value, value, UA_NODEATTRIBUTESMASK_VALUE)
@@ -572,7 +572,7 @@ public:
 
     /// Construct with default attribute definitions.
     ReferenceTypeAttributes()
-        : TypeWrapper{UA_ReferenceTypeAttributes_default} {}
+        : ReferenceTypeAttributes{UA_ReferenceTypeAttributes_default} {}
 
     UAPP_NODEATTR_COMMON
     UAPP_NODEATTR(bool, IsAbstract, isAbstract, UA_NODEATTRIBUTESMASK_ISABSTRACT)
@@ -592,7 +592,7 @@ public:
 
     /// Construct with default attribute definitions.
     DataTypeAttributes()
-        : TypeWrapper{UA_DataTypeAttributes_default} {}
+        : DataTypeAttributes{UA_DataTypeAttributes_default} {}
 
     UAPP_NODEATTR_COMMON
     UAPP_NODEATTR(bool, IsAbstract, isAbstract, UA_NODEATTRIBUTESMASK_ISABSTRACT)
@@ -608,7 +608,7 @@ public:
 
     /// Construct with default attribute definitions.
     ViewAttributes()
-        : TypeWrapper{UA_ViewAttributes_default} {}
+        : ViewAttributes{UA_ViewAttributes_default} {}
 
     UAPP_NODEATTR_COMMON
     UAPP_NODEATTR(bool, IsAbstract, containsNoLoops, UA_NODEATTRIBUTESMASK_CONTAINSNOLOOPS)

--- a/src/string_utils.cpp
+++ b/src/string_utils.cpp
@@ -19,7 +19,7 @@ UA_String toNativeString(std::string_view src) noexcept {
     return s;
 }
 
-UA_String allocNativeString(std::string_view src) {
+[[nodiscard]] UA_String allocNativeString(std::string_view src) {
     UA_String s{src.size(), nullptr};
     if (src.data() == nullptr) {
         return s;
@@ -36,7 +36,7 @@ UA_String allocNativeString(std::string_view src) {
     return s;
 }
 
-char* allocCString(std::string_view src) {
+[[nodiscard]] char* allocCString(std::string_view src) {
     char* cstr = static_cast<char*>(UA_malloc(src.size() + 1));  // NOLINT
     if (cstr == nullptr) {
         throw BadStatus(UA_STATUSCODE_BADOUTOFMEMORY);


### PR DESCRIPTION
`TypeConverter` specialization to convert any string-like types to `String` if they meet following criteria:
- `begin()` and `end()` member functions (range)
- `data()` and `size()` member functions (continuous range)
- iterator value type must be `char*`
- `data()` must return a pointer of type `char*`
- constructible from `const char*`
- constructible from `const char*` and a length of type `size_t`

This is true, e.g. for `std::string`, `std::string_view`, `absl::string_view`, `boost::basic_string<char>`, ...