### PR TITLE
feat: DataTypeBuilder::addField overloads with manual offsets

### DIFF
--- a/include/open62541pp/datatype.hpp
+++ b/include/open62541pp/datatype.hpp
@@ -511,7 +511,7 @@ template <typename TArray, typename TSize>
 auto& DataTypeBuilder<T, Tag, U>::addArrayFieldWithOffset(
     const std::string_view fieldName,
     size_t offsetSize,
-    size_t offsetArray,
+    [[maybe_unused]] size_t offsetArray,
     const UA_DataType& fieldType
 ) {
     static_assert(

--- a/include/open62541pp/datatype.hpp
+++ b/include/open62541pp/datatype.hpp
@@ -310,7 +310,7 @@ public:
      *  Add a structure field from an offset (derive DataType from `field).
      */
     template <typename TMember>
-    auto& addFieldWithOffset(std::string_view fieldName, const size_t offset) {
+    auto& addFieldWithOffset(std::string_view fieldName, size_t offset) {
         return addFieldWithOffset<TMember>(
             fieldName, offset, getDataType<std::remove_pointer_t<TMember>>()
         );
@@ -511,7 +511,7 @@ template <typename TArray, typename TSize>
 auto& DataTypeBuilder<T, Tag, U>::addArrayFieldWithOffset(
     const std::string_view fieldName,
     size_t offsetSize,
-    const size_t offsetArray,
+    size_t offsetArray,
     const UA_DataType& fieldType
 ) {
     static_assert(

--- a/include/open62541pp/datatype.hpp
+++ b/include/open62541pp/datatype.hpp
@@ -287,6 +287,7 @@ public:
 
     /**
      * Add a structure field.
+     * The offset is derived from the member pointer.
      * @tparam field Member pointer, e.g. `&S::value`
      * @param fieldName Human-readable field name
      * @param fieldType Member data type
@@ -307,16 +308,6 @@ public:
     }
 
     /**
-     * Add a structure field with a manual offset (derive DataType from `TMember`).
-     */
-    template <typename TMember>
-    auto& addField(std::string_view fieldName, size_t offset) {
-        return addField<TMember>(
-            fieldName, offset, getDataType<std::remove_pointer_t<TMember>>()
-        );
-    }
-
-    /**
      * Add a structure field with a manual offset.
      * @tparam TMember Type of the member, e.g. `opcua::String`
      * @param fieldName Human-readable field name
@@ -329,9 +320,21 @@ public:
     );
 
     /**
+     * Add a structure field with a manual offset (derive DataType from `TMember`).
+     * @overload
+     */
+    template <typename TMember>
+    auto& addField(std::string_view fieldName, size_t offset) {
+        return addField<TMember>(
+            fieldName, offset, getDataType<std::remove_pointer_t<TMember>>()
+        );
+    }
+
+    /**
      * Add a structure array field.
      * Arrays must consists of two fields: its size (of type `size_t`) and the pointer to the data.
      * No padding allowed between the size field and the array field.
+     * The offset is derived from the member pointer.
      * @tparam fieldSize Member pointer to the size field, e.g. `&S::length`
      * @tparam fieldArray Member pointer to the array field, e.g. `&S::data`
      * @param fieldName Human-readable field name
@@ -358,22 +361,6 @@ public:
     }
 
     /**
-     * Add a structure array field with a manual offset (derive DataType from `TArray`).
-     * @tparam TArray Type of the array field, e.g. `opcua::String`
-     * @param fieldName Human-readable field name
-     * @param offsetSize Offset of the size field in the structure
-     * @param offsetArray Offset of the array field in the structure
-     */
-    template <typename TArray>
-    auto& addField(
-        std::string_view fieldName, size_t offsetSize, size_t offsetArray
-    ) {
-        return addField<TArray>(
-            fieldName, offsetSize, offsetArray, getDataType<std::remove_pointer_t<TArray>>()
-        );
-    }
-
-    /**
      * Add a structure array field with a manual offset.
      * @tparam TArray Type of the array field, e.g. `opcua::String`
      * @param fieldName Human-readable field name
@@ -388,6 +375,19 @@ public:
         size_t offsetArray,
         const UA_DataType& fieldType
     );
+
+    /**
+     * Add a structure array field with a manual offset (derive DataType from `TArray`).
+     * @overload
+     */
+    template <typename TArray>
+    auto& addField(
+        std::string_view fieldName, size_t offsetSize, size_t offsetArray
+    ) {
+        return addField<TArray>(
+            fieldName, offsetSize, offsetArray, getDataType<std::remove_pointer_t<TArray>>()
+        );
+    }
 
     /**
      * Add a union field.

--- a/include/open62541pp/datatype.hpp
+++ b/include/open62541pp/datatype.hpp
@@ -311,7 +311,9 @@ public:
      */
     template <typename TMember>
     auto& addFieldWithOffset(std::string_view fieldName, const size_t offset) {
-        return addFieldWithOffset<TMember>(fieldName, offset, getDataType<std::remove_pointer_t<TMember>>());
+        return addFieldWithOffset<TMember>(
+            fieldName, offset, getDataType<std::remove_pointer_t<TMember>>()
+        );
     }
 
     /**
@@ -322,8 +324,9 @@ public:
      * @param fieldType Member data type
      */
     template <typename TMember>
-    auto& addFieldWithOffset(std::string_view fieldName, size_t offset, const UA_DataType& fieldType);
-
+    auto& addFieldWithOffset(
+        std::string_view fieldName, size_t offset, const UA_DataType& fieldType
+    );
 
     /**
      * Add a structure array field.
@@ -335,12 +338,17 @@ public:
      * @param fieldType Member data type
      */
     template <auto U::* fieldSize, auto U::* fieldArray>
-    auto& addField(std::string_view fieldName, const UA_DataType& fieldType)
-    {
+    auto& addField(std::string_view fieldName, const UA_DataType& fieldType) {
         using TArray = detail::MemberTypeT<decltype(fieldArray)>;
         using TSize = detail::MemberTypeT<decltype(fieldSize)>;
-        return addArrayFieldWithOffset<TArray, TSize>(fieldName, detail::offsetOfMember(fieldSize), detail::offsetOfMember(fieldArray), fieldType);
+        return addArrayFieldWithOffset<TArray, TSize>(
+            fieldName,
+            detail::offsetOfMember(fieldSize),
+            detail::offsetOfMember(fieldArray),
+            fieldType
+        );
     }
+
     /**
      * Add a structure array field (derive DataType from `fieldArray`).
      * @overload
@@ -358,8 +366,12 @@ public:
      * @param fieldType Member data type
      */
     template <typename TArray, typename TSize>
-    auto& addArrayFieldWithOffset(std::string_view fieldName, size_t offsetSize, size_t offsetArray) {
-        return addArrayFieldWithOffset<TArray, TSize>(fieldName, offsetSize, offsetArray, getDataType<std::remove_pointer_t<TArray>>());
+    auto& addArrayFieldWithOffset(
+        std::string_view fieldName, size_t offsetSize, size_t offsetArray
+    ) {
+        return addArrayFieldWithOffset<TArray, TSize>(
+            fieldName, offsetSize, offsetArray, getDataType<std::remove_pointer_t<TArray>>()
+        );
     }
 
     /**
@@ -370,8 +382,12 @@ public:
      * @param fieldType Member data type
      */
     template <typename TArray, typename TSize>
-    auto& addArrayFieldWithOffset(std::string_view fieldName, size_t offsetSize, size_t offsetArray, const UA_DataType& fieldType);
-
+    auto& addArrayFieldWithOffset(
+        std::string_view fieldName,
+        size_t offsetSize,
+        size_t offsetArray,
+        const UA_DataType& fieldType
+    );
 
     /**
      * Add a union field.
@@ -466,7 +482,9 @@ auto DataTypeBuilder<T, Tag, U>::createUnion(
 
 template <typename T, typename Tag, typename U>
 template <typename TMember>
-auto& DataTypeBuilder<T, Tag, U>::addFieldWithOffset(std::string_view fieldName, size_t offset, const UA_DataType& fieldType) {
+auto& DataTypeBuilder<T, Tag, U>::addFieldWithOffset(
+    std::string_view fieldName, size_t offset, const UA_DataType& fieldType
+) {
     static_assert(
         std::is_same_v<Tag, detail::TagDataTypeStruct>,
         "Built type must be a struct or class to add members"
@@ -491,8 +509,10 @@ auto& DataTypeBuilder<T, Tag, U>::addFieldWithOffset(std::string_view fieldName,
 template <typename T, typename Tag, typename U>
 template <typename TArray, typename TSize>
 auto& DataTypeBuilder<T, Tag, U>::addArrayFieldWithOffset(
-    const std::string_view fieldName, size_t offsetSize,
-    const size_t offsetArray, const UA_DataType& fieldType
+    const std::string_view fieldName,
+    size_t offsetSize,
+    const size_t offsetArray,
+    const UA_DataType& fieldType
 ) {
     static_assert(
         std::is_same_v<Tag, detail::TagDataTypeStruct>,

--- a/include/open62541pp/datatype.hpp
+++ b/include/open62541pp/datatype.hpp
@@ -307,7 +307,7 @@ public:
     }
 
     /**
-     *  Add a structure field from an offset (derive DataType from `field).
+     * Add a structure field with a manual offset (derive DataType from `TMember`).
      */
     template <typename TMember>
     auto& addFieldWithOffset(std::string_view fieldName, size_t offset) {
@@ -317,7 +317,7 @@ public:
     }
 
     /**
-     * Add a structure field from an offset.
+     * Add a structure field with a manual offset.
      * @tparam TMember Type of the member, e.g. `opcua::String`
      * @param fieldName Human-readable field name
      * @param offset Offset of the member in the structure
@@ -359,11 +359,11 @@ public:
     }
 
     /**
-     * Add a structure field from an offset.
-     * @tparam TMember Type of the member, e.g. `opcua::String`
+     * Add a structure array field with a manual offset (derive DataType from `TArray`).
+     * @tparam TArray Type of the array field, e.g. `opcua::String`
      * @param fieldName Human-readable field name
-     * @param offset Offset of the member in the structure
-     * @param fieldType Member data type
+     * @param offsetSize Offset of the size field in the structure
+     * @param offsetArray Offset of the array field in the structure
      */
     template <typename TArray, typename TSize>
     auto& addArrayFieldWithOffset(
@@ -375,11 +375,12 @@ public:
     }
 
     /**
-     * Add a structure field from an offset.
-     * @tparam TMember Type of the member, e.g. `opcua::String`
+     * Add a structure array field with a manual offset.
+     * @tparam TArray Type of the array field, e.g. `opcua::String`
      * @param fieldName Human-readable field name
-     * @param offset Offset of the member in the structure
-     * @param fieldType Member data type
+     * @param offsetSize Offset of the size field in the structure
+     * @param offsetArray Offset of the array field in the structure
+     * @param fieldType Array field data type
      */
     template <typename TArray, typename TSize>
     auto& addArrayFieldWithOffset(


### PR DESCRIPTION
Sometimes it's not possible to get the member pointer at compile time, and offsets may need to be used. This is especially true when using reflection to generate offsets, in which case there is no way to get a member pointer at compile time.