### PR TITLE
fix: trim null terminator of string literals in char[N] TypeConverter

### DIFF
--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -361,7 +361,9 @@ struct TypeConverter<char[N]> {  // NOLINT
     using NativeType = String;
 
     static void toNative(const Type& src, NativeType& dst) {
-        dst = NativeType{std::string_view{static_cast<const char*>(src), N}};
+        // string literals are null-terminated, trim null terminator if present
+        const auto length = N > 0 && src[N - 1] == '\0' ? N - 1 : N;
+        dst = NativeType{std::string_view{static_cast<const char*>(src), length}};
     }
 };
 

--- a/tests/typeconverter.cpp
+++ b/tests/typeconverter.cpp
@@ -77,9 +77,15 @@ TEST_CASE("TypeConverter const char*") {
 
 TEST_CASE("TypeConverter char[N]") {
     SECTION("toNative") {
-        char src[7] = {'T', 'e', 's', 't', '1', '2', '3'};
-        String dst = detail::toNative(src);
-        CHECK(dst == "Test123");
+        SECTION("Runtime buffer") {
+            char src[7] = {'T', 'e', 's', 't', '1', '2', '3'};
+            String dst = detail::toNative(src);
+            CHECK(dst == "Test123");
+        }
+        SECTION("String literal") {
+            String dst = detail::toNative("Test123");
+            CHECK(dst == "Test123");
+        }
     }
 }
 


### PR DESCRIPTION
String literals are null-terminated but runtime buffers may not. Check last char and trim null terminator.