### PR TITLE
feat: MethodCallback with session, methodId and objectId

### DIFF
--- a/doc/guide/error_handling.md
+++ b/doc/guide/error_handling.md
@@ -19,8 +19,8 @@ opcua::BadStatus::what() provides a human-readable name for the status code.
 **Example:**
 
 ```cpp
-const opcua::NodeId id(opcua::VariableId::Server_ServerStatus_CurrentTime);
-opcua::Node node(client, id);
+const opcua::NodeId id{opcua::VariableId::Server_ServerStatus_CurrentTime};
+opcua::Node node{client, id};
 try {
     const auto var = node.readValue();  // may throw opcua::BadStatus
 } catch (const opcua::BadStatus& e) {
@@ -43,7 +43,7 @@ This approach avoids the performance overhead of exceptions and enhances clarity
 **Example:**
 
 ```cpp
-const opcua::NodeId id(opcua::VariableId::Server_ServerStatus_CurrentTime);
+const opcua::NodeId id{opcua::VariableId::Server_ServerStatus_CurrentTime};
 opcua::Result<opcua::Variant> result = opcua::services::readValue(client, id);
 if (result.code().isBad()) {
     std::cerr << "Bad status: " << result.code().get() << ": " << result.code().name() << std::endl;

--- a/tests/services_attribute.cpp
+++ b/tests/services_attribute.cpp
@@ -30,15 +30,17 @@ TEST_CASE("Attribute service set (highlevel)") {
         attr.setMinimumSamplingInterval(11.11);
 
         const NodeId id{1, "TestAttributes"};
-        REQUIRE(services::addVariable(
-            server,
-            objectsId,
-            id,
-            "TestAttributes",
-            attr,
-            VariableTypeId::BaseDataVariableType,
-            ReferenceTypeId::HasComponent
-        ));
+        REQUIRE(
+            services::addVariable(
+                server,
+                objectsId,
+                id,
+                "TestAttributes",
+                attr,
+                VariableTypeId::BaseDataVariableType,
+                ReferenceTypeId::HasComponent
+            )
+        );
 
         CHECK(services::readDisplayName(server, id).value() == attr.displayName());
         CHECK(services::readDescription(server, id).value() == attr.description());
@@ -58,15 +60,17 @@ TEST_CASE("Attribute service set (highlevel)") {
 
     SECTION("Read/write object node attributes") {
         const NodeId id{1, "TestAttributes"};
-        REQUIRE(services::addObject(
-            server,
-            objectsId,
-            id,
-            "TestAttributes",
-            {},
-            ObjectTypeId::BaseObjectType,
-            ReferenceTypeId::HasComponent
-        ));
+        REQUIRE(
+            services::addObject(
+                server,
+                objectsId,
+                id,
+                "TestAttributes",
+                {},
+                ObjectTypeId::BaseObjectType,
+                ReferenceTypeId::HasComponent
+            )
+        );
 
         // write new attributes
         const auto eventNotifier = EventNotifier::HistoryRead | EventNotifier::HistoryWrite;
@@ -78,15 +82,17 @@ TEST_CASE("Attribute service set (highlevel)") {
 
     SECTION("Read/write variable node attributes") {
         const NodeId id{1, "TestAttributes"};
-        REQUIRE(services::addVariable(
-            server,
-            objectsId,
-            id,
-            "TestAttributes",
-            {},
-            VariableTypeId::BaseDataVariableType,
-            ReferenceTypeId::HasComponent
-        ));
+        REQUIRE(
+            services::addVariable(
+                server,
+                objectsId,
+                id,
+                "TestAttributes",
+                {},
+                VariableTypeId::BaseDataVariableType,
+                ReferenceTypeId::HasComponent
+            )
+        );
 
         // write new attributes
         CHECK(services::writeDisplayName(server, id, {{}, "NewDisplayName"}).isGood());
@@ -118,9 +124,19 @@ TEST_CASE("Attribute service set (highlevel)") {
 #ifdef UA_ENABLE_METHODCALLS
     SECTION("Read/write method node attributes") {
         const NodeId id{1, "TestMethod"};
-        REQUIRE(services::addMethod(
-            server, objectsId, id, "TestMethod", nullptr, {}, {}, {}, ReferenceTypeId::HasComponent
-        ));
+        REQUIRE(
+            services::addMethod(
+                server,
+                objectsId,
+                id,
+                "TestMethod",
+                [](Span<const Variant>, Span<Variant>) {},
+                {},
+                {},
+                {},
+                ReferenceTypeId::HasComponent
+            )
+        );
 
         // write new attributes
         CHECK(services::writeExecutable(server, id, true).isGood());
@@ -133,14 +149,16 @@ TEST_CASE("Attribute service set (highlevel)") {
 
     SECTION("Read/write reference type node attributes") {
         const NodeId id{1, "TestReferenceType"};
-        REQUIRE(services::addReferenceType(
-            server,
-            {0, UA_NS0ID_ORGANIZES},
-            id,
-            "TestReferenceType",
-            {},
-            ReferenceTypeId::HasSubtype
-        ));
+        REQUIRE(
+            services::addReferenceType(
+                server,
+                {0, UA_NS0ID_ORGANIZES},
+                id,
+                "TestReferenceType",
+                {},
+                ReferenceTypeId::HasSubtype
+            )
+        );
 
         // read default attributes
         CHECK(services::readIsAbstract(server, id).value() == false);
@@ -160,15 +178,17 @@ TEST_CASE("Attribute service set (highlevel)") {
 
     SECTION("Value rank and array dimension combinations") {
         const NodeId id{1, "TestDimensions"};
-        REQUIRE(services::addVariable(
-            server,
-            objectsId,
-            id,
-            "TestDimensions",
-            {},
-            VariableTypeId::BaseDataVariableType,
-            ReferenceTypeId::HasComponent
-        ));
+        REQUIRE(
+            services::addVariable(
+                server,
+                objectsId,
+                id,
+                "TestDimensions",
+                {},
+                VariableTypeId::BaseDataVariableType,
+                ReferenceTypeId::HasComponent
+            )
+        );
 
         SECTION("Unspecified dimension (ValueRank <= 0)") {
             const std::vector<ValueRank> valueRanks = {
@@ -214,15 +234,17 @@ TEST_CASE("Attribute service set (highlevel)") {
 
     SECTION("Read/write value") {
         const NodeId id{1, "TestValue"};
-        REQUIRE(services::addVariable(
-            server,
-            objectsId,
-            id,
-            "TestValue",
-            {},
-            VariableTypeId::BaseDataVariableType,
-            ReferenceTypeId::HasComponent
-        ));
+        REQUIRE(
+            services::addVariable(
+                server,
+                objectsId,
+                id,
+                "TestValue",
+                {},
+                VariableTypeId::BaseDataVariableType,
+                ReferenceTypeId::HasComponent
+            )
+        );
 
         Variant variantWrite{11.11};
         services::writeValue(server, id, variantWrite).throwIfBad();
@@ -233,15 +255,17 @@ TEST_CASE("Attribute service set (highlevel)") {
 
     SECTION("Read/write data value") {
         const NodeId id{1, "TestDataValue"};
-        REQUIRE(services::addVariable(
-            server,
-            objectsId,
-            id,
-            "TestDataValue",
-            {},
-            VariableTypeId::BaseDataVariableType,
-            ReferenceTypeId::HasComponent
-        ));
+        REQUIRE(
+            services::addVariable(
+                server,
+                objectsId,
+                id,
+                "TestDataValue",
+                {},
+                VariableTypeId::BaseDataVariableType,
+                ReferenceTypeId::HasComponent
+            )
+        );
 
         Variant variant{11};
         DataValue valueWrite{variant, {}, DateTime::now(), {}, uint16_t{1}, UA_STATUSCODE_GOOD};
@@ -300,17 +324,18 @@ TEST_CASE("Attribute service set (highlevel, async)") {
     SECTION("Read/write value") {
         // create variable node
         const NodeId id{1, 1000};
-        REQUIRE(services::addVariable(
-            server,
-            objectsId,
-            id,
-            "Variable",
-            VariableAttributes{}.setAccessLevel(
-                AccessLevel::CurrentRead | AccessLevel::CurrentWrite
-            ),
-            VariableTypeId::BaseDataVariableType,
-            ReferenceTypeId::HasComponent
-        ));
+        REQUIRE(
+            services::addVariable(
+                server,
+                objectsId,
+                id,
+                "Variable",
+                VariableAttributes{}
+                    .setAccessLevel(AccessLevel::CurrentRead | AccessLevel::CurrentWrite),
+                VariableTypeId::BaseDataVariableType,
+                ReferenceTypeId::HasComponent
+            )
+        );
 
         // write
         {
@@ -339,15 +364,18 @@ TEMPLATE_TEST_CASE("Attribute service set write/read", "", Server, Client, Async
 
     // create variable node
     const NodeId id{1, 1000};
-    REQUIRE(services::addVariable(
-        setup.server,
-        {0, UA_NS0ID_OBJECTSFOLDER},
-        id,
-        "Variable",
-        VariableAttributes{}.setAccessLevel(AccessLevel::CurrentRead | AccessLevel::CurrentWrite),
-        VariableTypeId::BaseDataVariableType,
-        ReferenceTypeId::HasComponent
-    ));
+    REQUIRE(
+        services::addVariable(
+            setup.server,
+            {0, UA_NS0ID_OBJECTSFOLDER},
+            id,
+            "Variable",
+            VariableAttributes{}
+                .setAccessLevel(AccessLevel::CurrentRead | AccessLevel::CurrentWrite),
+            VariableTypeId::BaseDataVariableType,
+            ReferenceTypeId::HasComponent
+        )
+    );
 
     const double value = 11.11;
     Result<DataValue> result;
@@ -360,8 +388,9 @@ TEMPLATE_TEST_CASE("Attribute service set write/read", "", Server, Client, Async
         client.runIterate();
         future.get().throwIfBad();
     } else {
-        services::writeAttribute(connection, id, AttributeId::Value, DataValue{Variant{value}})
-            .throwIfBad();
+        services::writeAttribute(
+            connection, id, AttributeId::Value, DataValue{Variant{value}}
+        ).throwIfBad();
     }
 
     // read

--- a/tests/services_method.cpp
+++ b/tests/services_method.cpp
@@ -15,33 +15,37 @@ TEMPLATE_TEST_CASE("Method service set", "", Server, Client, Async<Client>) {
     setup.client.connect(setup.endpointUrl);
     auto& connection = setup.instance<TestType>();
 
-    const NodeId objectsId{ObjectId::ObjectsFolder};
+    const NodeId objectId{ObjectId::ObjectsFolder};
     const NodeId methodId{1, 1000};
 
     bool throwException = false;
-    REQUIRE(services::addMethod(
-        setup.server,
-        objectsId,
-        methodId,
-        "Add",
-        [&](Span<const Variant> inputs, Span<Variant> outputs) {
-            if (throwException) {
-                throw BadStatus{UA_STATUSCODE_BADUNEXPECTEDERROR};
-            }
-            const auto a = inputs.at(0).scalar<int32_t>();
-            const auto b = inputs.at(1).scalar<int32_t>();
-            outputs.at(0) = a + b;
-        },
-        {
-            Argument("a", {"en-US", "first number"}, DataTypeId::Int32, ValueRank::Scalar),
-            Argument("b", {"en-US", "second number"}, DataTypeId::Int32, ValueRank::Scalar),
-        },
-        {
-            Argument("sum", {"en-US", "sum of both numbers"}, DataTypeId::Int32, ValueRank::Scalar),
-        },
-        MethodAttributes{},
-        ReferenceTypeId::HasComponent
-    ));
+    REQUIRE(
+        services::addMethod(
+            setup.server,
+            objectId,
+            methodId,
+            "Add",
+            [&](Span<const Variant> inputs, Span<Variant> outputs) {
+                if (throwException) {
+                    throw BadStatus{UA_STATUSCODE_BADUNEXPECTEDERROR};
+                }
+                const auto a = inputs.at(0).scalar<int32_t>();
+                const auto b = inputs.at(1).scalar<int32_t>();
+                outputs.at(0) = a + b;
+            },
+            {
+                Argument{"a", {"en-US", "first number"}, DataTypeId::Int32, ValueRank::Scalar},
+                Argument{"b", {"en-US", "second number"}, DataTypeId::Int32, ValueRank::Scalar},
+            },
+            {
+                Argument{
+                    "sum", {"en-US", "sum of both numbers"}, DataTypeId::Int32, ValueRank::Scalar
+                },
+            },
+            MethodAttributes{},
+            ReferenceTypeId::HasComponent
+        )
+    );
 
     auto call = [&](auto&&... args) {
         if constexpr (isAsync<TestType>) {
@@ -56,7 +60,7 @@ TEMPLATE_TEST_CASE("Method service set", "", Server, Client, Async<Client>) {
     SECTION("Check result") {
         const CallMethodResult result = call(
             connection,
-            objectsId,
+            objectId,
             methodId,
             Span<const Variant>{
                 Variant{int32_t{1}},
@@ -72,7 +76,7 @@ TEMPLATE_TEST_CASE("Method service set", "", Server, Client, Async<Client>) {
         throwException = true;
         const CallMethodResult result = call(
             connection,
-            objectsId,
+            objectId,
             methodId,
             Span<const Variant>{
                 Variant{int32_t{1}},
@@ -85,7 +89,7 @@ TEMPLATE_TEST_CASE("Method service set", "", Server, Client, Async<Client>) {
     SECTION("Invalid input arguments") {
         const CallMethodResult result = call(
             connection,
-            objectsId,
+            objectId,
             methodId,
             Span<const Variant>{
                 Variant{true},
@@ -96,16 +100,14 @@ TEMPLATE_TEST_CASE("Method service set", "", Server, Client, Async<Client>) {
     }
 
     SECTION("Missing arguments") {
-        const CallMethodResult result = call(
-            connection, objectsId, methodId, Span<const Variant>{}
-        );
+        const CallMethodResult result = call(connection, objectId, methodId, Span<const Variant>{});
         CHECK(result.statusCode() == UA_STATUSCODE_BADARGUMENTSMISSING);
     }
 
     SECTION("Too many arguments") {
         const CallMethodResult result = call(
             connection,
-            objectsId,
+            objectId,
             methodId,
             Span<const Variant>{
                 Variant{int32_t{1}},
@@ -115,5 +117,50 @@ TEMPLATE_TEST_CASE("Method service set", "", Server, Client, Async<Client>) {
         );
         CHECK(result.statusCode() == UA_STATUSCODE_BADTOOMANYARGUMENTS);
     }
+}
+
+TEST_CASE("Method service set (full callback signature)") {
+    Server server;
+    ServerRunner runner{server};
+
+    const NodeId objectId{ObjectId::ObjectsFolder};
+    const NodeId methodId{1, 1000};
+
+    bool executed = false;
+    NodeId callbackSessionId;
+    NodeId callbackMethodId;
+    NodeId callbackObjectId;
+
+    REQUIRE(
+        services::addMethod(
+            server,
+            objectId,
+            methodId,
+            "Method",
+            [&](Session& session,
+                Span<const Variant>,
+                Span<Variant>,
+                const NodeId& methodId,
+                const NodeId& objectId) {
+                executed = true;
+                callbackSessionId = session.id();
+                callbackMethodId = methodId;
+                callbackObjectId = objectId;
+                return UA_STATUSCODE_GOOD;
+            },
+            {},
+            {},
+            MethodAttributes{},
+            ReferenceTypeId::HasComponent
+        )
+    );
+
+    const auto result = services::call(server, objectId, methodId, {});
+    CHECK(result.statusCode().isGood());
+
+    CHECK(executed);
+    CHECK_FALSE(callbackSessionId.isNull());
+    CHECK(callbackMethodId == methodId);
+    CHECK(callbackObjectId == objectId);
 }
 #endif

--- a/tests/services_method.cpp
+++ b/tests/services_method.cpp
@@ -140,12 +140,12 @@ TEST_CASE("Method service set (full callback signature)") {
             [&](Session& session,
                 Span<const Variant>,
                 Span<Variant>,
-                const NodeId& methodId,
-                const NodeId& objectId) {
+                const NodeId& methodId_,
+                const NodeId& objectId_) {
                 executed = true;
                 callbackSessionId = session.id();
-                callbackMethodId = methodId;
-                callbackObjectId = objectId;
+                callbackMethodId = methodId_;
+                callbackObjectId = objectId_;
                 return UA_STATUSCODE_GOOD;
             },
             {},

--- a/tests/services_nodemanagement.cpp
+++ b/tests/services_nodemanagement.cpp
@@ -119,7 +119,7 @@ TEMPLATE_TEST_CASE("NodeManagement service set", "", Server, Client, Async<Clien
             objectsId,
             newId,
             "Method",
-            nullptr,  // callback
+            [](Span<const Variant>, Span<Variant>) {},
             opcua::Span<const opcua::Argument>{},  // input
             opcua::Span<const opcua::Argument>{},  // output
             MethodAttributes{},


### PR DESCRIPTION
Support full function signature for method callbacks with `session`, `methodId` and `objectId`.
The type `MethodCallback` is now a variant that takes either the simple signature with only input and output arguments or the full signature.

Full signature:
```cpp
StatusCode(
    Session& session,
    Span<const Variant> input,
    Span<Variant> output,
    const NodeId& methodId,
    const NodeId& objectId
)>
```

Closes #598.