### PR TITLE
fix: confusing log output when creating client/server with non-default config

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -283,7 +283,7 @@ Client::Client(ClientConfig&& config)
     if (handle() == nullptr) {
         throw BadStatus{UA_STATUSCODE_BADOUTOFMEMORY};
     }
-    config = {};
+    *config.handle() = {};
     this->config()->stateCallback = stateCallback;
     updateLoggerStackPointer(this->config());
     setWrapperAsContextPointer(*this);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -16,7 +16,7 @@
 
 namespace opcua {
 
-static UA_Client* allocateClient(UA_ClientConfig& config) noexcept {
+static UA_Client* allocateClient(const UA_ClientConfig& config) noexcept {
 #if UAPP_OPEN62541_VER_LE(1, 0)
     auto* client = UA_Client_new();
     auto* clientConfig = UA_Client_getConfig(client);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -270,7 +270,7 @@ Server::Server(ServerConfig&& config)
     if (handle() == nullptr) {
         throw BadStatus(UA_STATUSCODE_BADOUTOFMEMORY);
     }
-    config = {};
+    *config.handle() = {};
 #if UAPP_OPEN62541_VER_GE(1, 2)
     this->config()->allowEmptyVariables = UA_RULEHANDLING_ACCEPT;  // allow empty variables
 #endif


### PR DESCRIPTION
The default constructor of `ClientConfig`/`ServerConfig` is accidentally called when passing a config to the server/client constructor causing confusing log outputs.

Closes #600.