### PR TITLE
feat: Allow user to set the session context in a type safe manner.

### DIFF
--- a/include/open62541pp/plugin/accesscontrol.hpp
+++ b/include/open62541pp/plugin/accesscontrol.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <any>
+
 #include "open62541pp/bitmask.hpp"
 #include "open62541pp/common.hpp"  // AccessLevel, WriteMask
 #include "open62541pp/detail/open62541/common.h"  // UA_AccessControl

--- a/src/plugin/accesscontrol.cpp
+++ b/src/plugin/accesscontrol.cpp
@@ -1,5 +1,6 @@
 #include "open62541pp/plugin/accesscontrol.hpp"
 
+#include <any>
 #include <cassert>
 #include <exception>
 #include <functional>  // invoke
@@ -29,10 +30,11 @@ static std::optional<Session> getSession(
     UA_Server* server, const UA_NodeId* sessionId, void* sessionContext
 ) noexcept {
     auto* wrapper = asWrapper(server);
-    if (wrapper == nullptr) {
+    if (wrapper == nullptr|| sessionId == nullptr) {
         return std::nullopt;
     }
-    return Session(*wrapper, asWrapperRef<NodeId>(sessionId), sessionContext);
+
+    return Session(*wrapper, asWrapperRef<NodeId>(sessionId), static_cast<std::any*>(sessionContext));
 }
 
 static void logException(
@@ -69,11 +71,19 @@ static UA_StatusCode activateSessionNative(
     const UA_ByteString* secureChannelRemoteCertificate,
     const UA_NodeId* sessionId,
     const UA_ExtensionObject* userIdentityToken,
-    [[maybe_unused]] void** sessionContext
+    void** sessionContext
 ) {
+    // make sessionContext point to a std::any
+    *sessionContext = new std::any{};
+
+    // make sure to delete the context in closeSession
+    if (*sessionContext == nullptr) {
+        return UA_STATUSCODE_BADOUTOFMEMORY;
+    }
+
     return invokeAccessCallback(server, "activateSession", UA_STATUSCODE_BADINTERNALERROR, [&] {
         // TODO: allow user to set sessionContext
-        auto session = getSession(server, sessionId, nullptr);
+        auto session = getSession(server, sessionId, *sessionContext);
         return getAdapter(ac)
             .activateSession(
                 session.value(),
@@ -94,6 +104,10 @@ static void closeSessionNative(
     invokeAccessCallback(server, "activateSession", UA_STATUSCODE_GOOD, [&] {
         auto session = getSession(server, sessionId, sessionContext);
         getAdapter(ac).closeSession(session.value());  // NOLINT(bugprone-unchecked-optional-access)
+
+        const auto any_ptr = static_cast<std::any*>(sessionContext);
+        delete any_ptr;
+
         return UA_STATUSCODE_GOOD;
     });
 }

--- a/src/plugin/accesscontrol_default.cpp
+++ b/src/plugin/accesscontrol_default.cpp
@@ -9,6 +9,7 @@ namespace opcua {
 
 constexpr std::string_view policyIdAnonymous = "open62541-anonymous-policy";
 constexpr std::string_view policyIdUsername = "open62541-username-policy";
+// constexpr std::string_view noSecurityPolicy = "http://opcfoundation.org/UA/SecurityPolicy#None";
 
 AccessControlDefault::AccessControlDefault(bool allowAnonymous, Span<const Login> logins)
     : allowAnonymous_{allowAnonymous},
@@ -16,6 +17,7 @@ AccessControlDefault::AccessControlDefault(bool allowAnonymous, Span<const Login
     const std::string_view issuedTokenType{};
     const std::string_view issuerEndpointUrl{};
     const std::string_view securityPolicyUri{};
+
     if (allowAnonymous_) {
         userTokenPolicies_.emplace_back(
             policyIdAnonymous,
@@ -67,9 +69,23 @@ StatusCode AccessControlDefault::activateSession(
         if (!allowAnonymous_) {
             return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
         }
-        if (token->policyId().empty() || token->policyId() == policyIdAnonymous) {
+
+        /* Match the beginnig of the PolicyId.
+         * Compatibility notice: Siemens OPC Scout v10 provides an empty
+         * policyId. This is not compliant. For compatibility, assume that empty
+         * policyId == ANONYMOUS_POLICY */
+        if (token->policyId().empty()) {
             return UA_STATUSCODE_GOOD;
         }
+
+        if (token->policyId().size() < policyIdAnonymous.size()) {
+            return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
+        }
+
+        if (std::string_view{token->policyId()}.substr(0, policyIdAnonymous.size()) == policyIdAnonymous) {
+            return UA_STATUSCODE_GOOD;
+        }
+
         return UA_STATUSCODE_BADIDENTITYTOKENINVALID;
     }
 

--- a/src/plugin/nodestore.cpp
+++ b/src/plugin/nodestore.cpp
@@ -18,7 +18,8 @@ static std::optional<Session> getSession(
     if (wrapper == nullptr || sessionId == nullptr) {
         return std::nullopt;
     }
-    return Session(*wrapper, asWrapper<NodeId>(*sessionId), sessionContext);
+
+    return Session(*wrapper, asWrapper<NodeId>(*sessionId), static_cast<std::any*>(sessionContext));
 }
 
 static void onReadNative(

--- a/src/services_nodemanagement.cpp
+++ b/src/services_nodemanagement.cpp
@@ -115,7 +115,7 @@ static UA_StatusCode methodCallback(
         assert(sessionId != nullptr);
         assert(methodId != nullptr);
         assert(objectId != nullptr);
-        Session session{*asWrapper(server), asWrapper<NodeId>(*sessionId), sessionContext};
+        Session session{*asWrapper(server), asWrapper<NodeId>(*sessionId), static_cast<std::any*>(sessionContext)};
         const auto result = opcua::detail::tryInvoke(
             *cb,
             session,


### PR DESCRIPTION
This enables the use of the session context by assigning a `std::any` to it. Which will allow the user to set it to anything they like while being type safe.

This would resolve #537 