### PR TITLE
perf: move-aware variant construction and assignment

### DIFF
--- a/include/open62541pp/span.hpp
+++ b/include/open62541pp/span.hpp
@@ -28,9 +28,13 @@ namespace opcua {
 template <typename T>
 class Span {
 private:
+    using HasSizeAndData = std::conjunction<
+        detail::HasSize<T>,
+        detail::HasData<T>>;
+
     template <typename C>
     using EnableIfHasSizeAndData =
-        typename std::enable_if_t<detail::HasSize<C>::value && detail::HasData<C>::value>;
+        std::enable_if_t<detail::HasSize<C>::value && detail::HasData<C>::value>;
 
 public:
     // clang-format off

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -1456,8 +1456,8 @@ private:
         if constexpr (detail::IsRegistered<T>::value) {
             return scalar<T>();
         } else {
-            using NativeType = typename TypeConverter<T>::NativeType;
-            return detail::fromNative<T>(scalar<NativeType>());
+            using Native = typename TypeConverter<T>::NativeType;
+            return detail::fromNative<T>(scalar<Native>());
         }
     }
 
@@ -1469,8 +1469,8 @@ private:
             auto native = array<ValueType>();
             return T(native.begin(), native.end());
         } else {
-            using NativeType = typename TypeConverter<ValueType>::NativeType;
-            auto native = array<NativeType>();
+            using Native = typename TypeConverter<ValueType>::NativeType;
+            auto native = array<Native>();
             return T(
                 detail::TransformIterator(native.begin(), detail::fromNative<ValueType>),
                 detail::TransformIterator(native.end(), detail::fromNative<ValueType>)
@@ -1509,9 +1509,9 @@ private:
     template <typename T>
     void setScalarCopyConvertImpl(T&& value) {
         using ValueType = std::remove_cv_t<std::remove_reference_t<T>>;
-        using NativeType = typename TypeConverter<ValueType>::NativeType;
-        const auto& type = opcua::getDataType<NativeType>();
-        auto native = detail::allocateUniquePtr<NativeType>(type);
+        using Native = typename TypeConverter<ValueType>::NativeType;
+        const auto& type = opcua::getDataType<Native>();
+        auto native = detail::allocateUniquePtr<Native>(type);
         *native = detail::toNative<ValueType>(std::forward<T>(value));
         setScalarImpl(native.release(), type, UA_VARIANT_DATA);  // move ownership
     }
@@ -1530,10 +1530,10 @@ private:
     template <typename InputIt>
     void setArrayCopyConvertImpl(InputIt first, InputIt last) {
         using ValueType = typename std::iterator_traits<InputIt>::value_type;
-        using NativeType = typename TypeConverter<ValueType>::NativeType;
-        const auto& type = opcua::getDataType<NativeType>();
+        using Native = typename TypeConverter<ValueType>::NativeType;
+        const auto& type = opcua::getDataType<Native>();
         const size_t size = std::distance(first, last);
-        auto native = detail::allocateArrayUniquePtr<NativeType>(size, type);
+        auto native = detail::allocateArrayUniquePtr<Native>(size, type);
         std::transform(first, last, native.get(), detail::toNative<ValueType>);
         setArrayImpl(native.release(), size, type, UA_VARIANT_DATA);  // move ownership
     }

--- a/tests/types_builtin.cpp
+++ b/tests/types_builtin.cpp
@@ -542,11 +542,17 @@ TEST_CASE("Variant") {
         }
 
         SECTION("Copy") {
-            SECTION("Constructor") {
+            SECTION("Constructor lvalue") {
                 var = Variant{value};
             }
-            SECTION("Constructor with type") {
+            SECTION("Constructor rvalue") {
+                var = Variant{std::move(value)};
+            }
+            SECTION("Constructor lvalue with type") {
                 var = Variant{value, type};
+            }
+            SECTION("Constructor rvalue with type") {
+                var = Variant{std::move(value), type};
             }
             CHECK(var.isScalar());
             CHECK(var.type() == &type);
@@ -581,10 +587,10 @@ TEST_CASE("Variant") {
                 var = Variant{array, type};
             }
             SECTION("Constructor with iterator pair") {
-                var = Variant(array.begin(), array.end());
+                var = Variant{array.begin(), array.end()};
             }
             SECTION("Constructor with iterator pair and type") {
-                var = Variant(array.begin(), array.end(), type);
+                var = Variant{array.begin(), array.end(), type};
             }
             CHECK(var.isArray());
             CHECK(var.type() == &type);
@@ -669,6 +675,21 @@ TEST_CASE("Variant") {
         CHECK(&var.scalar<double>() != &value);
         CHECK(var.scalar<double>() == value);
         CHECK(var.to<double>() == value);
+    }
+
+    SECTION("Set/get scalar (move)") {
+        Variant var;
+        String value{"test"};
+        auto* data = value->data;
+        SECTION("assign") {
+            var.assign(std::move(value));
+        }
+        SECTION("assignment operator") {
+            var = std::move(value);
+        }
+        CHECK(var.scalar<String>()->data == data);
+        CHECK(var.scalar<String>() == "test");
+        CHECK(var.to<String>() == "test");
     }
 
     SECTION("Set/get array (pointer)") {


### PR DESCRIPTION
Move values to `Variant` if passed as rvalue reference (if possible).