### PR TITLE
fix: move only owned scalars from Variant

### DIFF
--- a/include/open62541pp/wrapper.hpp
+++ b/include/open62541pp/wrapper.hpp
@@ -126,7 +126,7 @@ public:
  * Use @ref TypeHandlerNative for native open62541 types.
  * @ref WrapperNative is a convenience alias for Wrapper using TypeHandlerNative.
  *
- * @warning No virtual constructor is defined; do not implement a destructor in derived classes.
+ * @warning No virtual destructor is defined; do not implement a destructor in derived classes.
  */
 template <typename T, typename Handler = TypeHandler<T>>
 class Wrapper

--- a/tests/types_builtin.cpp
+++ b/tests/types_builtin.cpp
@@ -854,26 +854,39 @@ TEST_CASE("Variant") {
         }
     }
 
-    SECTION("Get scalar ref qualifiers") {
+    SECTION("scalar ref qualifiers") {
         Variant var{"test"};
-        void* data = var.scalar<String>()->data;
+        const void* data = var.scalar<String>()->data;
 
         SECTION("lvalue") {
-            auto dst = var.scalar<String>();
+            const auto dst = var.scalar<String>();
             CHECK(dst->data != data);  // copy
         }
         SECTION("const lvalue") {
-            auto dst = std::as_const(var).scalar<String>();
+            const auto dst = std::as_const(var).scalar<String>();
             CHECK(dst->data != data);  // copy
         }
         SECTION("rvalue") {
-            auto dst = std::move(var).scalar<String>();
+            const auto dst = std::move(var).scalar<String>();
             CHECK(dst->data == data);  // move
         }
         SECTION("const rvalue") {
-            auto dst = std::move(std::as_const(var)).scalar<String>();
+            const auto dst = std::move(std::as_const(var)).scalar<String>();
             CHECK(dst->data != data);  // can not move const -> copy
         }
+    }
+
+    SECTION("scalar ref qualifiers with borrowed value") {
+        String str{"test"};
+        Variant var{&str};
+        const void* data = var.scalar<String>()->data;
+
+        SECTION("rvalue") {
+            const auto dst = std::move(var).scalar<String>();
+            CHECK(dst->data != data);  // copy
+        }
+
+        CHECK(str == "test");
     }
 }
 


### PR DESCRIPTION
The `&&` and `const&&` ref-qualified overloads for `Variant::scalar<T>()` move the value only if the `Variant` owns it; otherwise, they copy it.