### PR TITLE
fix: strip empty array sentinel from Variant data pointer

### DIFF
--- a/include/open62541pp/detail/types_handling.hpp
+++ b/include/open62541pp/detail/types_handling.hpp
@@ -147,7 +147,7 @@ template <typename T>
 inline constexpr uintptr_t emptyArraySentinel = 0x01;
 
 template <typename T>
-T* stripEmptyArraySentinel(T* array) noexcept {
+[[nodiscard]] T* stripEmptyArraySentinel(T* array) noexcept {
     // NOLINTNEXTLINE
     return reinterpret_cast<T*>(reinterpret_cast<uintptr_t>(array) & ~emptyArraySentinel);
 }

--- a/include/open62541pp/detail/types_handling.hpp
+++ b/include/open62541pp/detail/types_handling.hpp
@@ -36,23 +36,6 @@ struct IsPointerFree
           UA_StatusCode> {};
 
 template <typename T>
-constexpr bool isBorrowed(const T& /* unused */) noexcept {
-    return false;
-}
-
-constexpr bool isBorrowed(const UA_Variant& native) noexcept {
-    return native.storageType == UA_VARIANT_DATA_NODELETE;
-}
-
-constexpr bool isBorrowed(const UA_DataValue& native) noexcept {
-    return native.value.storageType == UA_VARIANT_DATA_NODELETE;
-}
-
-constexpr bool isBorrowed(const UA_ExtensionObject& native) noexcept {
-    return native.encoding == UA_EXTENSIONOBJECT_DECODED_NODELETE;
-}
-
-template <typename T>
 constexpr bool isValidTypeCombination(const UA_DataType& type) {
     if constexpr (std::is_void_v<T>) {
         return true;  // allow type-erasure
@@ -64,10 +47,7 @@ constexpr bool isValidTypeCombination(const UA_DataType& type) {
 template <typename T>
 constexpr void clear(T& native, const UA_DataType& type) noexcept {
     assert(isValidTypeCombination<T>(type));
-    // NOLINTNEXTLINE(bugprone-branch-clone)
     if constexpr (IsPointerFree<T>::value) {
-        native = {};
-    } else if (isBorrowed(native)) {
         native = {};
     } else {
         UA_clear(&native, &type);

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -1299,13 +1299,15 @@ public:
     /// Get pointer to the underlying data.
     /// Check the properties and data type before casting it to the actual type.
     /// Use the methods @ref isScalar, @ref isArray, @ref isType / @ref type.
+    /// @note The @ref UA_EMPTY_ARRAY_SENTINEL sentinel, used to indicate an empty array, is
+    ///       stripped from the returned pointer.
     void* data() noexcept {
-        return handle()->data;
+        return detail::stripEmptyArraySentinel(handle()->data);
     }
 
     /// @copydoc data
     const void* data() const noexcept {
-        return handle()->data;
+        return detail::stripEmptyArraySentinel(handle()->data);
     }
 
     /// Get scalar value with given template type (only native or wrapper types).
@@ -1313,14 +1315,14 @@ public:
     template <typename T>
     T& scalar() & {
         checkIsScalarType<T>();
-        return *static_cast<T*>(handle()->data);
+        return *static_cast<T*>(data());
     }
 
     /// @copydoc scalar()&
     template <typename T>
     const T& scalar() const& {
         checkIsScalarType<T>();
-        return *static_cast<const T*>(handle()->data);
+        return *static_cast<const T*>(data());
     }
 
     /// @copydoc scalar()&
@@ -1340,14 +1342,14 @@ public:
     template <typename T>
     Span<T> array() {
         checkIsArrayType<T>();
-        return Span<T>(static_cast<T*>(handle()->data), handle()->arrayLength);
+        return Span<T>(static_cast<T*>(data()), arrayLength());
     }
 
     /// @copydoc array()
     template <typename T>
     Span<const T> array() const {
         checkIsArrayType<T>();
-        return Span<const T>(static_cast<const T*>(handle()->data), handle()->arrayLength);
+        return Span<const T>(static_cast<const T*>(data()), arrayLength());
     }
 
     /**

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -1236,15 +1236,12 @@ public:
 
     /// Check if the variant is empty.
     bool empty() const noexcept {
-        return handle()->type == nullptr;
+        return UA_Variant_isEmpty(handle());
     }
 
     /// Check if the variant is a scalar.
     bool isScalar() const noexcept {
-        return (
-            !empty() && handle()->arrayLength == 0 &&
-            handle()->data > UA_EMPTY_ARRAY_SENTINEL  // NOLINT
-        );
+        return UA_Variant_isScalar(handle());
     }
 
     /// Check if the variant is an array.
@@ -1254,9 +1251,7 @@ public:
 
     /// Check if the variant type is equal to the provided data type.
     bool isType(const UA_DataType* type) const noexcept {
-        return (
-            handle()->type != nullptr && type != nullptr && handle()->type->typeId == type->typeId
-        );
+        return type != nullptr && isType(asWrapper<NodeId>(type->typeId));
     }
 
     /// Check if the variant type is equal to the provided data type.
@@ -1264,9 +1259,9 @@ public:
         return isType(&type);
     }
 
-    /// Check if the variant type is equal to the provided data type node id.
+    /// Check if the variant type is equal to the provided data type id.
     bool isType(const NodeId& id) const noexcept {
-        return (handle()->type != nullptr) && (handle()->type->typeId == id);
+        return type() != nullptr && type()->typeId == id;
     }
 
     /// Check if the variant type is equal to the provided template type.

--- a/src/services_view.cpp
+++ b/src/services_view.cpp
@@ -89,23 +89,4 @@ UnregisterNodesResponse unregisterNodes(
     return UA_Client_Service_unregisterNodes(connection.handle(), request);
 }
 
-Result<std::vector<ExpandedNodeId>> browseRecursive(
-    Server& connection, const BrowseDescription& bd
-) {
-    size_t arraySize{};
-    UA_ExpandedNodeId* array{};
-    const StatusCode status = UA_Server_browseRecursive(
-        connection.handle(), bd.handle(), &arraySize, &array
-    );
-    std::vector<ExpandedNodeId> result(
-        std::make_move_iterator(array),
-        std::make_move_iterator(array + arraySize)  // NOLINT
-    );
-    UA_free(array);  // NOLINT
-    if (status.isBad()) {
-        return BadResult{status};
-    }
-    return result;
-}
-
 }  // namespace opcua::services

--- a/tests/types_builtin.cpp
+++ b/tests/types_builtin.cpp
@@ -748,9 +748,9 @@ TEST_CASE("Variant") {
         CHECK(var.array<String>().data() == array.data());
     }
 
-    SECTION("Set/get array of std::string (copy & convert)") {
+    SECTION("Set/get empty array (copy)") {
         Variant var;
-        std::vector<std::string> array{"a", "b", "c"};
+        std::vector<float> array;
         SECTION("assign") {
             var.assign(array);
         }
@@ -761,10 +761,10 @@ TEST_CASE("Variant") {
             var = array;
         }
         CHECK(var.isArray());
-        CHECK(var.type() == &UA_TYPES[UA_TYPES_STRING]);
-        CHECK(var.arrayLength() == array.size());
-        CHECK_NOTHROW(var.array<String>());
-        CHECK(var.to<std::vector<std::string>>() == array);
+        CHECK(var.type() == &UA_TYPES[UA_TYPES_FLOAT]);
+        CHECK(var.data() == nullptr);
+        CHECK(var.arrayLength() == 0);
+        CHECK(var.array<float>().data() == nullptr);
     }
 
     SECTION("Set/get array (copy)") {
@@ -792,6 +792,25 @@ TEST_CASE("Variant") {
         CHECK(var.isArray());
         CHECK(var.type() == &UA_TYPES[UA_TYPES_INT32]);
         CHECK(var.arrayLength() == 3);
+    }
+
+    SECTION("Set/get array of std::string (copy & convert)") {
+        Variant var;
+        std::vector<std::string> array{"a", "b", "c"};
+        SECTION("assign") {
+            var.assign(array);
+        }
+        SECTION("assign with iterator pair") {
+            var.assign(array.begin(), array.end());
+        }
+        SECTION("assignment operator") {
+            var = array;
+        }
+        CHECK(var.isArray());
+        CHECK(var.type() == &UA_TYPES[UA_TYPES_STRING]);
+        CHECK(var.arrayLength() == array.size());
+        CHECK_NOTHROW(var.array<String>());
+        CHECK(var.to<std::vector<std::string>>() == array);
     }
 
     SECTION("Set/get array with std::vector<bool> (copy)") {


### PR DESCRIPTION
Strip `UA_EMPTY_ARRAY_SENTINEL` sentinel from data pointer/span returned by `Variant::data()` and `Variant::array<T>()`.