### PR TITLE
feat: make traits IsWrapper, IsRegistered, IsConvertible public

### DIFF
--- a/include/open62541pp/services/detail/response_handling.hpp
+++ b/include/open62541pp/services/detail/response_handling.hpp
@@ -15,7 +15,7 @@ namespace opcua::services::detail {
 
 template <typename WrapperType>
 struct Wrap {
-    static_assert(opcua::detail::IsWrapper<WrapperType>::value);
+    static_assert(IsWrapper<WrapperType>::value);
     using NativeType = typename WrapperType::NativeType;
 
     [[nodiscard]] constexpr WrapperType operator()(const NativeType& native) noexcept {
@@ -33,7 +33,7 @@ struct Wrap {
 
 template <typename Response>
 const UA_ResponseHeader& getResponseHeader(const Response& response) noexcept {
-    if constexpr (opcua::detail::IsWrapper<Response>::value) {
+    if constexpr (IsWrapper<Response>::value) {
         return asNative(response).responseHeader;
     } else {
         return response.responseHeader;
@@ -48,7 +48,7 @@ StatusCode getServiceResult(const Response& response) noexcept {
 template <typename Response>
 auto getSingleResultRef(Response& response) noexcept {
     auto* native = [&] {
-        if constexpr (opcua::detail::IsWrapper<Response>::value) {
+        if constexpr (IsWrapper<Response>::value) {
             return asNative(&response);
         } else {
             return &response;

--- a/include/open62541pp/typeconverter.hpp
+++ b/include/open62541pp/typeconverter.hpp
@@ -27,15 +27,15 @@ struct TypeConverter;
 
 /* -------------------------------------- Traits and helper ------------------------------------- */
 
-namespace detail {
-
 template <typename T, typename = void>
 struct IsConvertible : std::false_type {};
 
 template <typename T>
 struct IsConvertible<T, std::void_t<decltype(TypeConverter<T>{})>> : std::true_type {};
 
-template <typename T, typename = std::enable_if_t<detail::IsConvertible<T>::value>>
+namespace detail {
+
+template <typename T, typename = std::enable_if_t<IsConvertible<T>::value>>
 [[nodiscard]] constexpr T fromNative(const typename TypeConverter<T>::NativeType& src) {
     using NativeType = typename TypeConverter<T>::NativeType;
     if constexpr (std::is_invocable_r_v<T, decltype(TypeConverter<T>::fromNative), NativeType>) {
@@ -47,7 +47,7 @@ template <typename T, typename = std::enable_if_t<detail::IsConvertible<T>::valu
     }
 }
 
-template <typename T, typename = std::enable_if_t<detail::IsConvertible<T>::value>>
+template <typename T, typename = std::enable_if_t<IsConvertible<T>::value>>
 [[nodiscard]] constexpr auto toNative(const T& src) -> typename TypeConverter<T>::NativeType {
     using NativeType = typename TypeConverter<T>::NativeType;
     if constexpr (std::is_invocable_r_v<NativeType, decltype(TypeConverter<T>::toNative), T>) {

--- a/include/open62541pp/typeregistry.hpp
+++ b/include/open62541pp/typeregistry.hpp
@@ -29,21 +29,17 @@ struct TypeRegistry;
 
 /* -------------------------------------- Traits and helper ------------------------------------- */
 
-namespace detail {
-
 template <typename T, typename = void>
 struct IsRegistered : std::false_type {};
 
 template <typename T>
 struct IsRegistered<T, std::void_t<decltype(TypeRegistry<T>{})>> : std::true_type {};
 
-}  // namespace detail
-
 template <typename T>
 const UA_DataType& getDataType() noexcept {
     using ValueType = typename std::remove_cv_t<T>;
     static_assert(
-        detail::IsRegistered<ValueType>::value,
+        IsRegistered<ValueType>::value,
         "The provided template type is not registered. "
         "Specify the data type manually or add a template specialization for TypeRegistry."
     );

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -1158,7 +1158,7 @@ public:
             assign(std::begin(value), std::end(value));
         } else {
             assertIsRegisteredOrConvertible<ValueType>();
-            if constexpr (detail::IsRegistered<ValueType>::value) {
+            if constexpr (IsRegistered<ValueType>::value) {
                 setScalarCopyImpl(std::forward<T>(value), opcua::getDataType<ValueType>());
             } else {
                 setScalarCopyConvertImpl(std::forward<T>(value));
@@ -1194,7 +1194,7 @@ public:
     void assign(InputIt first, InputIt last) {
         using ValueType = typename std::iterator_traits<InputIt>::value_type;
         assertIsRegisteredOrConvertible<ValueType>();
-        if constexpr (detail::IsRegistered<ValueType>::value) {
+        if constexpr (IsRegistered<ValueType>::value) {
             setArrayCopyImpl(first, last, opcua::getDataType<ValueType>());
         } else {
             setArrayCopyConvertImpl(first, last);
@@ -1388,7 +1388,7 @@ public:
 private:
     template <typename T>
     static constexpr bool isScalarType() noexcept {
-        return detail::IsRegistered<T>::value || detail::IsConvertible<T>::value;
+        return IsRegistered<T>::value || detail::IsConvertible<T>::value;
     }
 
     template <typename T>
@@ -1399,7 +1399,7 @@ private:
     template <typename T>
     static constexpr void assertIsRegistered() {
         static_assert(
-            detail::IsRegistered<T>::value,
+            IsRegistered<T>::value,
             "Template type must be a native/wrapper type to assign or get scalar/array without copy"
         );
     }
@@ -1407,7 +1407,7 @@ private:
     template <typename T>
     static constexpr void assertIsRegisteredOrConvertible() {
         static_assert(
-            detail::IsRegistered<T>::value || detail::IsConvertible<T>::value,
+            IsRegistered<T>::value || detail::IsConvertible<T>::value,
             "Template type must be either a native/wrapper type or a convertible type. "
             "If the type is a native type: Provide the type definition (UA_DataType) manually or "
             "register the type with a TypeRegistry template specialization. "
@@ -1530,7 +1530,7 @@ private:
     template <typename T, typename Self>
     static T toScalarImpl(Self&& self) {
         assertIsRegisteredOrConvertible<T>();
-        if constexpr (detail::IsRegistered<T>::value) {
+        if constexpr (IsRegistered<T>::value) {
             return std::forward<Self>(self).template scalar<T>();
         } else {
             using Native = typename TypeConverter<T>::NativeType;
@@ -1542,7 +1542,7 @@ private:
     static T toArrayImpl(Self&& self) {
         using ValueType = detail::RangeValueT<T>;
         assertIsRegisteredOrConvertible<ValueType>();
-        if constexpr (detail::IsRegistered<ValueType>::value) {
+        if constexpr (IsRegistered<ValueType>::value) {
             auto native = std::forward<Self>(self).template array<ValueType>();
             return T(native.begin(), native.end());
         } else {
@@ -2108,7 +2108,7 @@ String toString(const T& object, const UA_DataType& type) {
  * @relates TypeWrapper
  * @ingroup Wrapper
  */
-template <typename T, typename = std::enable_if_t<detail::IsRegistered<T>::value>>
+template <typename T, typename = std::enable_if_t<IsRegistered<T>::value>>
 String toString(const T& object) {
     return toString(object, getDataType<T>());
 }
@@ -2119,42 +2119,42 @@ String toString(const T& object) {
 
 /// @relates TypeWrapper
 /// @ingroup Wrapper
-template <typename T, typename = std::enable_if_t<detail::IsRegistered<T>::value>>
+template <typename T, typename = std::enable_if_t<IsRegistered<T>::value>>
 inline bool operator==(const T& lhs, const T& rhs) noexcept {
     return UA_order(&lhs, &rhs, &getDataType<T>()) == UA_ORDER_EQ;
 }
 
 /// @relates TypeWrapper
 /// @ingroup Wrapper
-template <typename T, typename = std::enable_if_t<detail::IsRegistered<T>::value>>
+template <typename T, typename = std::enable_if_t<IsRegistered<T>::value>>
 inline bool operator!=(const T& lhs, const T& rhs) noexcept {
     return UA_order(&lhs, &rhs, &getDataType<T>()) != UA_ORDER_EQ;
 }
 
 /// @relates TypeWrapper
 /// @ingroup Wrapper
-template <typename T, typename = std::enable_if_t<detail::IsRegistered<T>::value>>
+template <typename T, typename = std::enable_if_t<IsRegistered<T>::value>>
 inline bool operator<(const T& lhs, const T& rhs) noexcept {
     return UA_order(&lhs, &rhs, &getDataType<T>()) == UA_ORDER_LESS;
 }
 
 /// @relates TypeWrapper
 /// @ingroup Wrapper
-template <typename T, typename = std::enable_if_t<detail::IsRegistered<T>::value>>
+template <typename T, typename = std::enable_if_t<IsRegistered<T>::value>>
 inline bool operator<=(const T& lhs, const T& rhs) noexcept {
     return UA_order(&lhs, &rhs, &getDataType<T>()) <= UA_ORDER_EQ;
 }
 
 /// @relates TypeWrapper
 /// @ingroup Wrapper
-template <typename T, typename = std::enable_if_t<detail::IsRegistered<T>::value>>
+template <typename T, typename = std::enable_if_t<IsRegistered<T>::value>>
 inline bool operator>(const T& lhs, const T& rhs) noexcept {
     return UA_order(&lhs, &rhs, &getDataType<T>()) == UA_ORDER_MORE;
 }
 
 /// @relates TypeWrapper
 /// @ingroup Wrapper
-template <typename T, typename = std::enable_if_t<detail::IsRegistered<T>::value>>
+template <typename T, typename = std::enable_if_t<IsRegistered<T>::value>>
 inline bool operator>=(const T& lhs, const T& rhs) noexcept {
     return UA_order(&lhs, &rhs, &getDataType<T>()) >= UA_ORDER_EQ;
 }

--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -1388,7 +1388,7 @@ public:
 private:
     template <typename T>
     static constexpr bool isScalarType() noexcept {
-        return IsRegistered<T>::value || detail::IsConvertible<T>::value;
+        return IsRegistered<T>::value || IsConvertible<T>::value;
     }
 
     template <typename T>
@@ -1407,7 +1407,7 @@ private:
     template <typename T>
     static constexpr void assertIsRegisteredOrConvertible() {
         static_assert(
-            IsRegistered<T>::value || detail::IsConvertible<T>::value,
+            IsRegistered<T>::value || IsConvertible<T>::value,
             "Template type must be either a native/wrapper type or a convertible type. "
             "If the type is a native type: Provide the type definition (UA_DataType) manually or "
             "register the type with a TypeRegistry template specialization. "

--- a/include/open62541pp/wrapper.hpp
+++ b/include/open62541pp/wrapper.hpp
@@ -16,14 +16,14 @@ namespace opcua {
  * Native open62541 objects can be accessed using the Wrapper::handle() member function.
  *
  * Wrapper types are pointer-interconvertible to the wrapped native type and vice versa:
- * - Use asNative(T*) or asNative(const T*) to cast wrapper object pointers to
- * native object pointers.
- * - Use asNative(T&) or asNative(const T&) to cast wrapper object references to
- * native object references.
- * - Use asWrapper<T>(typename T::NativeType*) or asWrapper<T>(const typename T::NativeType*) to cast native object pointers to
- * wrapper object pointers.
- * - Use asWrapper<T>(typename T::NativeType&) or asWrapper<T>(const typename T::NativeType&) to cast native object references to
- * wrapper object references.
+ * - Use asNative(T*) or asNative(const T*)
+ *   to cast wrapper object pointers to native object pointers.
+ * - Use asNative(T&) or asNative(const T&)
+ *   to cast wrapper object references to native object references.
+ * - Use asWrapper<T>(typename T::NativeType*) or asWrapper<T>(const typename T::NativeType*)
+ *   to cast native object pointers to wrapper object pointers.
+ * - Use asWrapper<T>(typename T::NativeType&) or asWrapper<T>(const typename T::NativeType&)
+ *   to cast native object references to wrapper object references.
  *
  * According to the standard:
  * > Two objects `a` and `b` are pointer-interconvertible if:
@@ -31,7 +31,7 @@ namespace opcua {
  * > member of that object [wrapped native type].
  * Derived classes must fulfill the requirements of standard-layout types to be convertible.
  * @see https://en.cppreference.com/w/cpp/language/static_cast#pointer-interconvertible
- * 
+ *
  * @{
  */
 
@@ -280,8 +280,6 @@ public:
 
 /* -------------------------------------------- Trait ------------------------------------------- */
 
-namespace detail {
-
 template <typename T>
 struct IsWrapper {
     // https://stackoverflow.com/a/51910887
@@ -293,17 +291,18 @@ struct IsWrapper {
     static constexpr bool value = type::value;
 };
 
+/* ------------------------------ Cast native type to wrapper type ------------------------------ */
+
+namespace detail {
+
 template <typename T>
-struct IsPointerInterconvertibleWrapper
-    : std::conjunction<
-          IsWrapper<T>,
-          std::is_standard_layout<T>,
-          std::is_standard_layout<typename T::NativeType>,
-          std::bool_constant<sizeof(T) == sizeof(typename T::NativeType)>> {};
+using IsPointerInterconvertibleWrapper = std::conjunction<
+    IsWrapper<T>,
+    std::is_standard_layout<T>,
+    std::is_standard_layout<typename T::NativeType>,
+    std::bool_constant<sizeof(T) == sizeof(typename T::NativeType)>>;
 
 }  // namespace detail
-
-/* ------------------------------ Cast native type to wrapper type ------------------------------ */
 
 // NOLINTBEGIN(*casting-through-void)
 
@@ -374,8 +373,7 @@ constexpr const typename T::NativeType& asNative(const T& wrapper) noexcept {
 template <typename T>
 struct TypeRegistry<
     T,
-    std::enable_if_t<
-        detail::IsWrapper<T>::value && detail::IsRegistered<typename T::NativeType>::value>> {
+    std::enable_if_t<IsWrapper<T>::value && detail::IsRegistered<typename T::NativeType>::value>> {
     static const UA_DataType& getDataType() noexcept {
         return TypeRegistry<typename T::NativeType>::getDataType();
     }

--- a/include/open62541pp/wrapper.hpp
+++ b/include/open62541pp/wrapper.hpp
@@ -373,7 +373,7 @@ constexpr const typename T::NativeType& asNative(const T& wrapper) noexcept {
 template <typename T>
 struct TypeRegistry<
     T,
-    std::enable_if_t<IsWrapper<T>::value && detail::IsRegistered<typename T::NativeType>::value>> {
+    std::enable_if_t<IsWrapper<T>::value && IsRegistered<typename T::NativeType>::value>> {
     static const UA_DataType& getDataType() noexcept {
         return TypeRegistry<typename T::NativeType>::getDataType();
     }

--- a/tests/typeregistry.cpp
+++ b/tests/typeregistry.cpp
@@ -23,10 +23,10 @@ struct TypeRegistry<Custom> {
 
 TEST_CASE("TypeRegistry") {
     SECTION("Builtin") {
-        CHECK(detail::IsRegistered<float>::value);
-        CHECK_FALSE(detail::IsRegistered<const volatile float>::value);
-        CHECK_FALSE(detail::IsRegistered<float*>::value);
-        CHECK_FALSE(detail::IsRegistered<float&>::value);
+        CHECK(IsRegistered<float>::value);
+        CHECK_FALSE(IsRegistered<const volatile float>::value);
+        CHECK_FALSE(IsRegistered<float*>::value);
+        CHECK_FALSE(IsRegistered<float&>::value);
 
         CHECK(&TypeRegistry<float>::getDataType() == &UA_TYPES[UA_TYPES_FLOAT]);
         CHECK(&getDataType<float>() == &UA_TYPES[UA_TYPES_FLOAT]);

--- a/tests/types_builtin.cpp
+++ b/tests/types_builtin.cpp
@@ -1253,7 +1253,7 @@ TEST_CASE("toString") {
 #if UAPP_HAS_ORDER
 TEST_CASE("Comparison operators") {
     // use simple registered type without custom comparison overloads
-    STATIC_REQUIRE(detail::IsRegistered<UA_Range>::value);
+    STATIC_REQUIRE(IsRegistered<UA_Range>::value);
     const UA_Range r1{1, 2};
     const UA_Range r2{3, 4};
     const UA_Range r3{5, 6};


### PR DESCRIPTION
Move traits from namespace `opcua::detail` to `opcua` to make them public:
- `IsWrapper<T>` to check if a type is based on `Wrapper`
- `IsRegistered<T>` to check if a type is registered with a `TypeRegistry` template specialization
- `IsConvertible<T>` to check if a type is convertible with a `TypeConverter` template specialization