### PR TITLE
feat!: remove deprecations ≤ v0.18.0

### DIFF
--- a/include/open62541pp/client.hpp
+++ b/include/open62541pp/client.hpp
@@ -12,7 +12,7 @@
 #include "open62541pp/detail/client_utils.hpp"
 #include "open62541pp/detail/open62541/client.h"
 #include "open62541pp/span.hpp"
-#include "open62541pp/subscription.hpp"  // TODO: remove with Client::createSubscription
+#include "open62541pp/subscription.hpp"
 #include "open62541pp/types.hpp"
 #include "open62541pp/ua/types.hpp"
 #include "open62541pp/wrapper.hpp"
@@ -216,11 +216,6 @@ public:
     std::vector<String> namespaceArray();
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
-    /// Create a subscription to monitor data changes and events.
-    /// @deprecated Use Subscription constructor
-    [[deprecated("use Subscription constructor")]]
-    Subscription<Client> createSubscription(const SubscriptionParameters& parameters = {});
-
     /// Get all active subscriptions
     std::vector<Subscription<Client>> subscriptions();
 #endif

--- a/include/open62541pp/server.hpp
+++ b/include/open62541pp/server.hpp
@@ -14,7 +14,6 @@
 #include "open62541pp/detail/server_utils.hpp"
 #include "open62541pp/session.hpp"
 #include "open62541pp/span.hpp"
-#include "open62541pp/subscription.hpp"  // TODO: remove with Server::createSubscription
 #include "open62541pp/types.hpp"
 #include "open62541pp/ua/nodeids.hpp"
 #include "open62541pp/ua/types.hpp"
@@ -184,13 +183,6 @@ public:
     void setVariableNodeDataSource(const NodeId& id, DataSourceBase& source);
     /// Set data source for variable node (move ownership to server).
     void setVariableNodeDataSource(const NodeId& id, std::unique_ptr<DataSourceBase>&& source);
-
-#ifdef UA_ENABLE_SUBSCRIPTIONS
-    /// Create a (pseudo) subscription to monitor local data changes and events.
-    /// @deprecated Use Subscription constructor
-    [[deprecated("use Subscription constructor")]]
-    Subscription<Server> createSubscription() noexcept;
-#endif
 
     /// Run a single iteration of the server's main loop.
     /// @return Maximum wait period until next Server::runIterate call (in ms)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -434,12 +434,6 @@ std::vector<String> Client::namespaceArray() {
 }
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
-Subscription<Client> Client::createSubscription(const SubscriptionParameters& parameters) {
-    const auto response = services::createSubscription(*this, parameters, true, {}, {});
-    response.responseHeader().serviceResult().throwIfBad();
-    return {*this, response.subscriptionId()};
-}
-
 std::vector<Subscription<Client>> Client::subscriptions() {
     std::vector<Subscription<Client>> result;
     auto& subscriptions = context().subscriptions;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -336,12 +336,6 @@ void Server::setVariableNodeDataSource(const NodeId& id, std::unique_ptr<DataSou
     setVariableNodeDataSourceImpl(*this, id, detail::UniqueOrRawPtr{std::move(source)});
 }
 
-#ifdef UA_ENABLE_SUBSCRIPTIONS
-Subscription<Server> Server::createSubscription() noexcept {
-    return {*this, 0U};
-}
-#endif
-
 static void runStartup(Server& server, detail::ServerContext& context) {
     applySessionRegistry(server.config(), context);
     throwIfBad(UA_Server_run_startup(server.handle()));


### PR DESCRIPTION
Remove functions that have been deprecated in v0.18.0:

- `Client::createSubscription`
- `Server::createSubscription`