### PR TITLE
feat!: remove String constructor from initializer list

### DIFF
--- a/include/open62541pp/types.hpp
+++ b/include/open62541pp/types.hpp
@@ -6,7 +6,6 @@
 #include <chrono>
 #include <cstdint>
 #include <functional>  // hash
-#include <initializer_list>
 #include <iosfwd>  // forward declare ostream
 #include <iterator>  // reverse_iterator
 #include <optional>
@@ -263,10 +262,6 @@ public:
     template <typename InputIt>
     String(InputIt first, InputIt last) {
         init(first, last);
-    }
-
-    String(std::initializer_list<char> values) {
-        init(values.begin(), values.end());
     }
 
     /// Assign null-termined character string.

--- a/tests/types_builtin.cpp
+++ b/tests/types_builtin.cpp
@@ -90,19 +90,10 @@ TEMPLATE_TEST_CASE("StringLikeMixin constructors", "", String, const String) {
         CHECK(str.data() != nullptr);
         CHECK(std::string_view(str.data(), str.size()) == "abc");
     }
-
-    SECTION("From initializer list") {
-        TestType str{'a', 'b', 'c'};
-        CHECK(str.size() == 3);
-        CHECK(str.length() == 3);
-        CHECK_FALSE(str.empty());
-        CHECK(str.data() != nullptr);
-        CHECK(std::string_view(str.data(), str.size()) == "abc");
-    }
 }
 
 TEMPLATE_TEST_CASE("StringLikeMixin element access", "", String, const String) {
-    TestType str{'a', 'b', 'c'};
+    TestType str{"abc"};
 
     SECTION("operator[]") {
         CHECK(str[0] == 'a');
@@ -117,7 +108,7 @@ TEMPLATE_TEST_CASE("StringLikeMixin element access", "", String, const String) {
 }
 
 TEMPLATE_TEST_CASE("StringLikeMixin iterators", "", String, const String) {
-    TestType str{'a', 'b', 'c'};
+    TestType str{"abc"};
 
     SECTION("begin(), end() iterators") {
         CHECK(*str.begin() == 'a');


### PR DESCRIPTION
Avoid `<initializer_list>` include in commonly used `types.hpp` header.