### PR TITLE
feat!: make Server::setVariableNode* free functions

### DIFF
--- a/examples/server_datasource.cpp
+++ b/examples/server_datasource.cpp
@@ -54,7 +54,7 @@ int main() {
 
     // Define data source
     DataSource<int> dataSource;
-    server.setVariableNodeDataSource(id, dataSource);
+    opcua::setVariableNodeValueBackend(server, id, dataSource);
 
     server.run();
 }

--- a/examples/server_valuecallback.cpp
+++ b/examples/server_valuecallback.cpp
@@ -39,7 +39,7 @@ int main() {
         .writeValue(opcua::Variant{opcua::DateTime::now()});
 
     CurrentTimeCallback currentTimeCallback;
-    server.setVariableNodeValueCallback(currentTimeId, currentTimeCallback);
+    opcua::setVariableNodeValueCallback(server, currentTimeId, currentTimeCallback);
 
     server.run();
 }

--- a/include/open62541pp/server.hpp
+++ b/include/open62541pp/server.hpp
@@ -175,15 +175,15 @@ public:
     /// Register namespace. The new namespace index will be returned.
     [[nodiscard]] NamespaceIndex registerNamespace(std::string_view uri);
 
-    /// Set value callback for variable node.
+    [[deprecated("use free function setVariableNodeValueCallback instead")]]
     void setVariableNodeValueCallback(const NodeId& id, ValueCallbackBase& callback);
-    /// Set value callback for variable node (move ownership to server).
+    [[deprecated("use free function setVariableNodeValueCallback instead")]]
     void setVariableNodeValueCallback(
         const NodeId& id, std::unique_ptr<ValueCallbackBase>&& callback
     );
-    /// Set data source for variable node.
+    [[deprecated("use free function setVariableNodeValueBackend instead")]]
     void setVariableNodeDataSource(const NodeId& id, DataSourceBase& source);
-    /// Set data source for variable node (move ownership to server).
+    [[deprecated("use free function setVariableNodeValueBackend instead")]]
     void setVariableNodeDataSource(const NodeId& id, std::unique_ptr<DataSourceBase>&& source);
 
     /// Run a single iteration of the server's main loop.
@@ -227,6 +227,22 @@ inline bool operator==(const Server& lhs, const Server& rhs) noexcept {
 inline bool operator!=(const Server& lhs, const Server& rhs) noexcept {
     return !(lhs == rhs);
 }
+
+/* ---------------------------- Variable node value backend/callback ---------------------------- */
+
+/// Set value callback for variable node.
+void setVariableNodeValueCallback(Server& server, const NodeId& id, ValueCallbackBase& callback);
+/// Set value callback for variable node (move ownership to server).
+void setVariableNodeValueCallback(
+    Server& server, const NodeId& id, std::unique_ptr<ValueCallbackBase>&& callback
+);
+
+/// Set data source value backend for variable node.
+void setVariableNodeValueBackend(Server& server, const NodeId& id, DataSourceBase& source);
+/// Set data source value backend for variable node (move ownership to server).
+void setVariableNodeValueBackend(
+    Server& server, const NodeId& id, std::unique_ptr<DataSourceBase>&& source
+);
 
 /* -------------------------------------- Async operations -------------------------------------- */
 

--- a/tests/server.cpp
+++ b/tests/server.cpp
@@ -237,10 +237,10 @@ TEST_CASE("ValueCallback") {
 
     auto callbackPtr = std::make_unique<ValueCallbackTest>();
     auto& callback = *callbackPtr;
-    server.setVariableNodeValueCallback(id, callback);
-
+    setVariableNodeValueCallback(server, id, callback);
+    
     SECTION("move ownership") {
-        server.setVariableNodeValueCallback(id, std::move(callbackPtr));
+        setVariableNodeValueCallback(server, id, std::move(callbackPtr));
     }
 
     SECTION("trigger onRead callback with read operation") {
@@ -302,9 +302,9 @@ TEST_CASE("DataSource") {
 
     auto sourcePtr = std::make_unique<DataSourceTest>();
     auto& source = *sourcePtr;
-    server.setVariableNodeDataSource(id, source);
+    setVariableNodeValueBackend(server, id, source);
     SECTION("move ownership") {
-        server.setVariableNodeDataSource(id, std::move(sourcePtr));
+        setVariableNodeValueBackend(server, id, std::move(sourcePtr));
     }
 
     SECTION("read") {


### PR DESCRIPTION
Use free functions instead of member functions:

- `opcua::Server::setVariableNodeValueCallback` -> `opcua::setVariableNodeValueCallback`
- `opcua::Server::setVariableNodeDataSource` -> `opcua::setVariableNodeValueBackend`

The member functions are marked as deprecated and will be removed in the future in favor of the free functions.