### PR TITLE
feat: timed/repeated callbacks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,7 @@ deprecated_header(typewrapper.hpp wrapper.hpp)
 
 add_library(
     open62541pp
+    src/callback.cpp
     src/client.cpp
     src/datatype.cpp
     src/event.cpp

--- a/doc/examples.dox
+++ b/doc/examples.dox
@@ -3,6 +3,7 @@
 @example server.cpp
 @example server_instantiation.cpp
 @example server_logger.cpp
+@example server_callback.cpp
 @example server_valuecallback.cpp
 @example server_datasource.cpp
 @example server_accesscontrol.cpp

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -60,6 +60,7 @@ add_example(client_minimal.cpp)
 
 add_example(server.cpp)
 add_example(server_accesscontrol.cpp)
+add_example(server_callback.cpp)
 add_example(server_datasource.cpp)
 add_example(server_instantiation.cpp)
 add_example(server_logger.cpp)

--- a/examples/server_callback.cpp
+++ b/examples/server_callback.cpp
@@ -1,0 +1,33 @@
+#include <chrono>
+#include <iostream>
+
+#include "open62541pp/callback.hpp"
+#include "open62541pp/server.hpp"
+
+int main() {
+    opcua::Server server;
+
+    size_t counter = 0;
+    const double interval = 500;  // milliseconds
+    const opcua::CallbackId id1 = opcua::addRepeatedCallback(
+        server,
+        [&] {
+            ++counter;
+            std::cout << "Repeated callback: " << counter << "\n"; },
+        interval
+    );
+
+    const opcua::CallbackId id2 = opcua::addTimedCallback(
+        server,
+        [&] {
+            std::cout << "Timed callback: Double interval of repeated callback\n";
+            opcua::changeRepeatedCallbackInterval(server, id1, interval * 2);
+        },
+        std::chrono::system_clock::now() + std::chrono::seconds(2)
+    );
+
+    server.run();
+
+    opcua::removeCallback(server, id1);
+    opcua::removeCallback(server, id2);
+}

--- a/include/open62541pp/callback.hpp
+++ b/include/open62541pp/callback.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+
+#include "open62541pp/types.hpp"  // DateTime
+
+namespace opcua {
+
+class Client;
+class Server;
+
+using CallbackId = uint64_t;
+using TimedCallback = std::function<void()>;
+using RepeatedCallback = std::function<void()>;
+
+/**
+ * Add a callback for execution at a specified time.
+ * If the indicated time lies in the past, then the callback is executed at the next iteration of
+ * the event loop.
+ * @param connection Instance of type Client or Server
+ * @param callback Callback to be executed
+ * @param date Execution time for the callback
+ * @return Callback identifier
+ */
+template <typename T>
+[[nodiscard]] CallbackId addTimedCallback(T& connection, TimedCallback callback, DateTime date);
+
+/**
+ * Add a callback for repeated execution.
+ * @param connection Instance of type Client or Server
+ * @param callback Callback to be executed
+ * @param intervalMilliseconds Execution interval in milliseconds (must be > 0).
+ *        The first execution occurs at now() + interval at the latest.
+ * @return Callback identifier
+ */
+template <typename T>
+[[nodiscard]] CallbackId addRepeatedCallback(
+    T& connection, RepeatedCallback callback, double intervalMilliseconds
+);
+
+/**
+ * Change the execution interval of an existing repeated callback.
+ * @param connection Instance of type Client or Server
+ * @param callbackId Callback identifier
+ * @param intervalMilliseconds New interval in milliseconds (must be > 0)
+ */
+template <typename T>
+void changeRepeatedCallbackInterval(
+    T& connection, CallbackId callbackId, double intervalMilliseconds
+);
+
+/**
+ * Remove a previously registered callback.
+ * @param connection Instance of type Client or Server
+ * @param callbackId Callback identifier
+ */
+template <typename T>
+void removeCallback(T& connection, CallbackId callbackId);
+
+}  // namespace opcua

--- a/include/open62541pp/detail/client_context.hpp
+++ b/include/open62541pp/detail/client_context.hpp
@@ -39,6 +39,7 @@ struct ClientContext {
 #endif
     std::array<std::function<void()>, clientStateCount> stateCallbacks;
     std::function<void()> inactivityCallback;
+    ContextMap<uint64_t, Staleable<std::function<void()>>> callbacks;
 
 #ifdef UA_ENABLE_SUBSCRIPTIONS
     using SubId = IntegerId;

--- a/include/open62541pp/detail/contextmap.hpp
+++ b/include/open62541pp/detail/contextmap.hpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <mutex>
 #include <type_traits>
+#include <utility>
 
 namespace opcua::detail {
 
@@ -24,6 +25,12 @@ struct IsStaleable : std::false_type {};
 template <typename T>
 struct IsStaleable<T, std::void_t<decltype(std::declval<T>().stale)>>
     : std::is_same<decltype(std::declval<T>().stale), bool> {};
+
+template <typename T>
+struct Staleable {
+    bool stale;
+    T item;
+};
 
 /**
  * Thread-safe map for context objects.

--- a/include/open62541pp/detail/server_context.hpp
+++ b/include/open62541pp/detail/server_context.hpp
@@ -60,14 +60,15 @@ struct ServerContext {
     std::atomic<bool> running{false};
     std::mutex mutexRun;
 
+    ContextMap<uint64_t, Staleable<std::function<void()>>> callbacks;
+    ContextMap<NodeId, NodeContext> nodeContexts;
+
 #ifdef UA_ENABLE_SUBSCRIPTIONS
     using SubId = IntegerId;  // always 0
     using MonId = IntegerId;
     using SubMonId = std::pair<SubId, MonId>;
     ContextMap<SubMonId, services::detail::MonitoredItemContext> monitoredItems;
 #endif
-
-    ContextMap<NodeId, NodeContext> nodeContexts;
 };
 
 }  // namespace opcua::detail

--- a/src/callback.cpp
+++ b/src/callback.cpp
@@ -1,0 +1,117 @@
+#include "open62541pp/callback.hpp"
+
+#include <cassert>
+#include <utility>  // move
+
+#include "open62541pp/client.hpp"
+#include "open62541pp/detail/client_context.hpp"
+#include "open62541pp/detail/client_utils.hpp"
+#include "open62541pp/detail/result_utils.hpp"
+#include "open62541pp/detail/server_context.hpp"
+#include "open62541pp/detail/server_utils.hpp"
+#include "open62541pp/server.hpp"
+
+namespace opcua {
+
+using CallbackContext = detail::Staleable<std::function<void()>>;
+
+template <typename T>
+struct CallbackFunctions;
+
+template <>
+struct CallbackFunctions<Client> {
+    static constexpr auto addTimedCallback = &UA_Client_addTimedCallback;
+    static constexpr auto addRepeatedCallback = &UA_Client_addRepeatedCallback;
+    static constexpr auto changeRepeatedCallbackInterval = &UA_Client_changeRepeatedCallbackInterval;
+    static constexpr auto removeCallback = &UA_Client_removeCallback;
+};
+
+template <>
+struct CallbackFunctions<Server> {
+    static constexpr auto addTimedCallback = &UA_Server_addTimedCallback;
+    static constexpr auto addRepeatedCallback = &UA_Server_addRepeatedCallback;
+    static constexpr auto changeRepeatedCallbackInterval = &UA_Server_changeRepeatedCallbackInterval;
+    static constexpr auto removeCallback = &UA_Server_removeCallback;
+};
+
+template <typename T>
+static void invokeCallback([[maybe_unused]] T* connection, void* data, bool remove) {
+    assert(data != nullptr);
+    auto* context = static_cast<CallbackContext*>(data);
+    if (context->item) {
+        [[maybe_unused]] const auto result = detail::tryInvoke(context->item);
+    }
+    if (remove) {
+        context->stale = true;
+        context->item = {};
+    }
+}
+
+template <typename T>
+static void timedCallback(T* connection, void* data) {
+    return invokeCallback(connection, data, true);
+}
+
+template <typename T>
+static void repeatedCallback(T* connection, void* data) {
+    return invokeCallback(connection, data, false);
+}
+
+static UA_DateTime toMonotonic(DateTime date) noexcept {
+    const auto now = UA_DateTime_now();
+    const auto nowMonotonic = UA_DateTime_nowMonotonic();
+    const auto dateMonotonic = date - now + nowMonotonic;
+    return std::max(dateMonotonic, UA_DateTime{0});
+}
+
+template <typename T>
+CallbackId addTimedCallback(T& connection, TimedCallback callback, DateTime date) {
+    auto context = std::make_unique<CallbackContext>(CallbackContext{false, std::move(callback)});
+    CallbackId callbackId = 0;
+    const auto status = CallbackFunctions<T>::addTimedCallback(
+        connection.handle(), timedCallback, context.get(), toMonotonic(date), &callbackId
+    );
+    throwIfBad(status);
+    detail::getContext(connection).callbacks.insert(callbackId, std::move(context));
+    return callbackId;
+}
+
+template <typename T>
+CallbackId addRepeatedCallback(T& connection, RepeatedCallback callback, double intervalMilliseconds) {
+    auto context = std::make_unique<CallbackContext>(CallbackContext{false, std::move(callback)});
+    CallbackId callbackId = 0;
+    const auto status = CallbackFunctions<T>::addRepeatedCallback(
+        connection.handle(), repeatedCallback, context.get(), intervalMilliseconds, &callbackId
+    );
+    throwIfBad(status);
+    detail::getContext(connection).callbacks.insert(callbackId, std::move(context));
+    return callbackId;
+}
+
+template <typename T>
+void changeRepeatedCallbackInterval(
+    T& connection, CallbackId callbackId, double intervalMilliseconds
+) {
+    const auto status = CallbackFunctions<T>::changeRepeatedCallbackInterval(
+        connection.handle(), callbackId, intervalMilliseconds
+    );
+    throwIfBad(status);
+}
+
+template <typename T>
+void removeCallback(T& connection, CallbackId callbackId) {
+    CallbackFunctions<T>::removeCallback(connection.handle(), callbackId);
+    detail::getContext(connection).callbacks.erase(callbackId);
+}
+
+// explicit template instantiations
+template CallbackId addTimedCallback<Client>(Client&, TimedCallback, DateTime);
+template CallbackId addTimedCallback<Server>(Server&, TimedCallback, DateTime);
+template CallbackId addRepeatedCallback<Client>(Client&, RepeatedCallback, double);
+template CallbackId addRepeatedCallback<Server>(Server&, RepeatedCallback, double);
+template void changeRepeatedCallbackInterval<Client>(Client&, CallbackId, double);
+template void changeRepeatedCallbackInterval<Server>(Server&, CallbackId, double);
+template void removeCallback<Client>(Client&, CallbackId);
+template void removeCallback<Server>(Server&, CallbackId);
+
+}  // namespace opcua

--- a/src/callback.cpp
+++ b/src/callback.cpp
@@ -57,7 +57,7 @@ static void repeatedCallback(T* connection, void* data) {
     return invokeCallback(connection, data, false);
 }
 
-static UA_DateTime toMonotonic(DateTime date) noexcept {
+static UA_DateTime toMonotonic(UA_DateTime date) noexcept {
     const auto now = UA_DateTime_now();
     const auto nowMonotonic = UA_DateTime_nowMonotonic();
     const auto dateMonotonic = date - now + nowMonotonic;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(
     open62541pp_tests
     async.cpp
     bitmask.cpp
+    callback.cpp
     client_server_common.cpp
     client_service.cpp
     client.cpp

--- a/tests/callback.cpp
+++ b/tests/callback.cpp
@@ -10,6 +10,15 @@
 
 using namespace opcua;
 
+TEST_CASE("Empty callback") {
+    Server server;
+
+    const auto id = addTimedCallback(server, nullptr, DateTime::now());
+    CAPTURE(id);
+    server.runIterate();
+    CHECK_NOTHROW(removeCallback(server, id));
+}
+
 TEST_CASE("Timed callback") {
     Server server;
 
@@ -28,7 +37,6 @@ TEST_CASE("Repeated callback") {
     size_t counter = 0;
     const auto id = addRepeatedCallback(server, [&] { ++counter; }, 10);
     CAPTURE(id);
-
     server.runIterate();
     CHECK(counter == 0);
 

--- a/tests/callback.cpp
+++ b/tests/callback.cpp
@@ -1,0 +1,59 @@
+#include <chrono>
+#include <thread>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "open62541pp/callback.hpp"
+#include "open62541pp/server.hpp"
+
+#include "helper/server_client_setup.hpp"
+
+using namespace opcua;
+
+TEST_CASE("Timed callback") {
+    Server server;
+
+    bool executed = false;
+    const auto id = addTimedCallback(server, [&] { executed = true; }, DateTime::now());
+    CAPTURE(id);
+    server.runIterate();
+    CHECK(executed == true);
+
+    CHECK_NOTHROW(removeCallback(server, id));
+}
+
+TEST_CASE("Repeated callback") {
+    Server server;
+
+    size_t counter = 0;
+    const auto id = addRepeatedCallback(server, [&] { ++counter; }, 10);
+    CAPTURE(id);
+
+    server.runIterate();
+    CHECK(counter == 0);
+
+    SECTION("Initial interval") {
+        std::this_thread::sleep_for(std::chrono::milliseconds{10});
+        server.runIterate();
+        CHECK(counter == 1);
+        std::this_thread::sleep_for(std::chrono::milliseconds{10});
+        server.runIterate();
+        CHECK(counter == 2);
+    }
+
+    SECTION("Changed interval") {
+        CHECK_NOTHROW(changeRepeatedCallbackInterval(server, id, 1));
+        std::this_thread::sleep_for(std::chrono::milliseconds{1});
+        server.runIterate();
+        CHECK(counter == 1);
+        std::this_thread::sleep_for(std::chrono::milliseconds{1});
+        server.runIterate();
+        CHECK(counter == 2);
+    }
+
+    const auto counterBeforeRemove = counter;
+    CHECK_NOTHROW(removeCallback(server, id));
+    std::this_thread::sleep_for(std::chrono::milliseconds{10});
+    server.runIterate();
+    CHECK(counter == counterBeforeRemove);
+}


### PR DESCRIPTION
New header `open62541pp/callback.hpp` with free functions to define timed/repeated callbacks for both `Client` and `Server`:

- `addTimedCallback`
- `addRepeatedCallback`
- `changeRepeatedCallbackInterval`
- `removeCallback`