### PR TITLE
Bugfix/dont double disconnect client

### DIFF
--- a/include/open62541pp/client.hpp
+++ b/include/open62541pp/client.hpp
@@ -244,7 +244,7 @@ private:
     friend detail::ClientContext& detail::getContext(Client& client) noexcept;
 
     struct Deleter {
-        void operator()(UA_Client* client) noexcept;
+        void operator()(UA_Client* client) const noexcept;
     };
 
     std::unique_ptr<detail::ClientContext> context_;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -488,9 +488,8 @@ const detail::ClientContext& Client::context() const noexcept {
     return *context_;
 }
 
-void Client::Deleter::operator()(UA_Client* client) noexcept {
+void Client::Deleter::operator()(UA_Client* client) const noexcept {
     if (client != nullptr) {
-        UA_Client_disconnect(client);
         deleteClient(client);
     }
 }


### PR DESCRIPTION
bugfix: don't double disconnect client
    
The custom deleter of the `UA_Client*` manually disconnects it while `UA_Client_clear` already does it.
    
Resolves #636
