### PR TITLE
feat: add findDataType overload set

### DIFF
--- a/include/open62541pp/client.hpp
+++ b/include/open62541pp/client.hpp
@@ -266,4 +266,10 @@ inline bool operator!=(const Client& lhs, const Client& rhs) noexcept {
     return !(lhs == rhs);
 }
 
+/* -------------------------------------- Utility functions ------------------------------------- */
+
+inline const UA_DataType* findDataType(Client& client, const NodeId& id) noexcept {
+    return findDataType(id, client.config()->customDataTypes);
+}
+
 }  // namespace opcua

--- a/include/open62541pp/datatype.hpp
+++ b/include/open62541pp/datatype.hpp
@@ -580,6 +580,11 @@ template <typename T, typename Tag, typename U>
     return dataType_;
 }
 
+/* --------------------------------------- Free functions --------------------------------------- */
+
+const UA_DataType* findDataType(const NodeId& id) noexcept;
+const UA_DataType* findDataType(const NodeId& id, const UA_DataTypeArray* custom) noexcept;
+
 /* ------------------------------------------- Helper ------------------------------------------- */
 
 namespace detail {

--- a/include/open62541pp/server.hpp
+++ b/include/open62541pp/server.hpp
@@ -228,6 +228,12 @@ inline bool operator!=(const Server& lhs, const Server& rhs) noexcept {
     return !(lhs == rhs);
 }
 
+/* -------------------------------------- Utility functions ------------------------------------- */
+
+inline const UA_DataType* findDataType(Server& server, const NodeId& id) noexcept {
+    return findDataType(id, server.config()->customDataTypes);
+}
+
 /* ---------------------------- Variable node value backend/callback ---------------------------- */
 
 /// Set value callback for variable node.

--- a/tests/datatype.cpp
+++ b/tests/datatype.cpp
@@ -449,6 +449,7 @@ TEST_CASE("findDataType") {
 
         const auto& dt = UA_TYPES[UA_TYPES_FLOAT];
         CHECK(findDataType(NodeId{dt.typeId}) == &dt);
+        CHECK(findDataType(NodeId{dt.typeId}, nullptr) == &dt);
     }
 
     SECTION("With custom") {
@@ -468,6 +469,7 @@ TEST_CASE("findDataType") {
         const UA_DataTypeArray next{nullptr, 3, types2};
         const UA_DataTypeArray head{&next, 2, types1};
 
+        CHECK(findDataType(NodeId{0, 0}, nullptr) == nullptr);
         CHECK(findDataType(NodeId{0, 0}, &head) == nullptr);
         CHECK(findDataType(NodeId{0, 0}, &next) == nullptr);
         CHECK(findDataType(NodeId{1, 1001}, &head) == &types1[0]);

--- a/tests/datatype.cpp
+++ b/tests/datatype.cpp
@@ -442,3 +442,40 @@ TEST_CASE("DataTypeBuilder") {
         checkEqual(dtNative, dtWrapper);
     }
 }
+
+TEST_CASE("findDataType") {
+    SECTION("Builtin") {
+        CHECK(findDataType(NodeId{0, 0}) == nullptr);
+
+        const auto& dt = UA_TYPES[UA_TYPES_FLOAT];
+        CHECK(findDataType(NodeId{dt.typeId}) == &dt);
+    }
+
+    SECTION("With custom") {
+        UA_DataType dt1{};
+        dt1.typeId = UA_NODEID_NUMERIC(1, 1001);
+        UA_DataType dt2{};
+        dt2.typeId = UA_NODEID_NUMERIC(1, 1002);
+        UA_DataType dt3{};
+        dt3.typeId = UA_NODEID_NUMERIC(1, 1003);
+        UA_DataType dt4{};
+        dt4.typeId = UA_NODEID_NUMERIC(1, 1004);
+        UA_DataType dt5{};
+        dt5.typeId = UA_NODEID_NUMERIC(1, 1005);
+
+        const UA_DataType types1[2]{dt1, dt2};
+        const UA_DataType types2[3]{dt3, dt4, dt5};
+        const UA_DataTypeArray next{nullptr, 3, types2};
+        const UA_DataTypeArray head{&next, 2, types1};
+
+        CHECK(findDataType(NodeId{0, 0}, &head) == nullptr);
+        CHECK(findDataType(NodeId{0, 0}, &next) == nullptr);
+        CHECK(findDataType(NodeId{1, 1001}, &head) == &types1[0]);
+        CHECK(findDataType(NodeId{1, 1001}, &next) == nullptr);
+        CHECK(findDataType(NodeId{1, 1002}, &head) == &types1[1]);
+        CHECK(findDataType(NodeId{1, 1003}, &head) == &types2[0]);
+        CHECK(findDataType(NodeId{1, 1004}, &head) == &types2[1]);
+        CHECK(findDataType(NodeId{1, 1005}, &head) == &types2[2]);
+        CHECK(findDataType(NodeId{1, 1006}, &head) == nullptr);
+    }
+}


### PR DESCRIPTION
Add function overload set to find `UA_DataType` by `typeId`:

```cpp
const UA_DataType* findDataType(const NodeId& id) noexcept;
const UA_DataType* findDataType(const NodeId& id, const UA_DataTypeArray* custom) noexcept;
const UA_DataType* findDataType(Client& client, const NodeId& id) noexcept;
const UA_DataType* findDataType(Server& server, const NodeId& id) noexcept;
```