### PR TITLE
feat!: assign session context in AccessControl::activateSession with void* pointer

### DIFF
--- a/include/open62541pp/plugin/accesscontrol.hpp
+++ b/include/open62541pp/plugin/accesscontrol.hpp
@@ -49,7 +49,8 @@ public:
         Session& session,
         const EndpointDescription& endpointDescription,
         const ByteString& secureChannelRemoteCertificate,
-        const ExtensionObject& userIdentityToken
+        const ExtensionObject& userIdentityToken,
+        void*& sessionContext
     ) = 0;
 
     /// Deauthenticate a session and cleanup session context.

--- a/include/open62541pp/plugin/accesscontrol_default.hpp
+++ b/include/open62541pp/plugin/accesscontrol_default.hpp
@@ -32,7 +32,8 @@ public:
         Session& session,
         const EndpointDescription& endpointDescription,
         const ByteString& secureChannelRemoteCertificate,
-        const ExtensionObject& userIdentityToken
+        const ExtensionObject& userIdentityToken,
+        void*& sessionContext
     ) override;
 
     void closeSession(Session& session) override;

--- a/src/plugin/accesscontrol.cpp
+++ b/src/plugin/accesscontrol.cpp
@@ -69,17 +69,18 @@ static UA_StatusCode activateSessionNative(
     const UA_ByteString* secureChannelRemoteCertificate,
     const UA_NodeId* sessionId,
     const UA_ExtensionObject* userIdentityToken,
-    [[maybe_unused]] void** sessionContext
+    void** sessionContext
 ) {
     return invokeAccessCallback(server, "activateSession", UA_STATUSCODE_BADINTERNALERROR, [&] {
-        // TODO: allow user to set sessionContext
+        assert(sessionContext != nullptr);
         auto session = getSession(server, sessionId, nullptr);
         return getAdapter(ac)
             .activateSession(
                 session.value(),
                 asWrapperRef<EndpointDescription>(endpointDescription),
                 asWrapperRef<ByteString>(secureChannelRemoteCertificate),
-                asWrapperRef<ExtensionObject>(userIdentityToken)
+                asWrapperRef<ExtensionObject>(userIdentityToken),
+                *sessionContext
             )
             .get();
     });

--- a/src/plugin/accesscontrol_default.cpp
+++ b/src/plugin/accesscontrol_default.cpp
@@ -49,7 +49,8 @@ StatusCode AccessControlDefault::activateSession(
     [[maybe_unused]] Session& session,
     [[maybe_unused]] const EndpointDescription& endpointDescription,
     [[maybe_unused]] const ByteString& secureChannelRemoteCertificate,
-    const ExtensionObject& userIdentityToken
+    const ExtensionObject& userIdentityToken,
+    [[maybe_unused]] void*& sessionContext
 ) {
     // https://github.com/open62541/open62541/blob/v1.3.6/plugins/ua_accesscontrol_default.c#L38-L134
 

--- a/tests/plugin_accesscontrol.cpp
+++ b/tests/plugin_accesscontrol.cpp
@@ -36,7 +36,7 @@ TEST_CASE("AccessControlDefault") {
             const ByteString secureChannelRemoteCertificate{};
 
             const auto activateSessionWithToken = [&](const ExtensionObject& userIdentityToken) {
-                void* sessionContext;
+                void* sessionContext{nullptr};
                 return ac.activateSession(
                     session,
                     endpointDescription,
@@ -143,12 +143,13 @@ TEST_CASE("AccessControlBase") {
     Server server;
     AccessControlTest accessControl;
     UA_AccessControl native = accessControl.create(false);
-
+    
     CHECK(native.context != nullptr);
     CHECK(native.userTokenPoliciesSize == 1);  // anonymous only
     CHECK(native.userTokenPolicies != nullptr);
     CHECK(native.userTokenPolicies[0].tokenType == UA_USERTOKENTYPE_ANONYMOUS);
-
+    
+    void* sessionContext{nullptr};
     CHECK(native.activateSession != nullptr);
     CHECK(
         native.activateSession(
@@ -158,7 +159,7 @@ TEST_CASE("AccessControlBase") {
             nullptr,  // secure channel remote certificate
             nullptr,  // session id
             nullptr,  // user identity token
-            nullptr  // session context
+            &sessionContext  // session context
         ) == UA_STATUSCODE_GOOD
     );
 

--- a/tests/plugin_accesscontrol.cpp
+++ b/tests/plugin_accesscontrol.cpp
@@ -36,8 +36,13 @@ TEST_CASE("AccessControlDefault") {
             const ByteString secureChannelRemoteCertificate{};
 
             const auto activateSessionWithToken = [&](const ExtensionObject& userIdentityToken) {
+                void* sessionContext;
                 return ac.activateSession(
-                    session, endpointDescription, secureChannelRemoteCertificate, userIdentityToken
+                    session,
+                    endpointDescription,
+                    secureChannelRemoteCertificate,
+                    userIdentityToken,
+                    sessionContext
                 );
             };
 


### PR DESCRIPTION
Simple solution for #537 using `void*` to assign and cast the session context, but it offers less type safety compared to the `std::any` approach in #611.

What do you think @17steen? Do we need the high complexity for type and memory safety?
The challenge with `std::any` remains the C interoperability as described here https://github.com/open62541pp/open62541pp/issues/537#issuecomment-2888810638.