### PR TITLE
ci: don't run retired windows 2019 runner os

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,10 +107,6 @@ jobs:
             os: macos-15
             compiler: clang++
 
-          - name: Windows Visual Studio 16
-            os: windows-2019
-            compiler: msvc
-
           - name: Windows Visual Studio 17
             os: windows-2022
             compiler: msvc


### PR DESCRIPTION
Closes #659.