### PR TITLE
Fix overwriting of method callbacks

### DIFF
--- a/src/services_nodemanagement.cpp
+++ b/src/services_nodemanagement.cpp
@@ -142,7 +142,7 @@ Result<NodeId> addMethod(
     const NodeId& referenceType
 ) noexcept {
     return opcua::detail::tryInvoke([&] {
-        auto* nodeContext = opcua::detail::getContext(connection).nodeContexts[id];
+        auto nodeContext = std::make_unique<opcua::detail::NodeContext>();
         nodeContext->methodCallback = std::move(callback);
         NodeId outputNodeId;
         throwIfBad(UA_Server_addMethodNode(
@@ -157,9 +157,10 @@ Result<NodeId> addMethod(
             asNative(inputArguments.data()),
             outputArguments.size(),
             asNative(outputArguments.data()),
-            nodeContext,
+            nodeContext.get(),
             outputNodeId.handle()  // outNewNodeId
         ));
+        opcua::detail::getContext(connection).nodeContexts.insert(outputNodeId, std::move(nodeContext));
         return outputNodeId;
     });
 }


### PR DESCRIPTION
This PR fixes a bug in the function `opcua::services::addMethod`. The caller may want it to automatically assign a node ID to the method being added. In this case the requested node ID will be empty. Currently, the callback is added to the ContextMap using the requested ID as a key, which is incorrect. Another method added may overwrite the callback assigned to empty ID. The proposal is to use `outNewNodeId` as a key.