### PR TITLE
ci: remove GCC 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,6 @@ jobs:
       fail-fast: true
       matrix:
         config:
-          - name: Linux GCC 9
-            os: ubuntu-22.04
-            compiler: g++-9
-            coverage: true
-            gcov: gcov-9
-
           - name: Linux GCC 10
             os: ubuntu-22.04
             compiler: g++-10


### PR DESCRIPTION
Not included in Ubuntu 22.04 runner anymore.