### PR TITLE
feat(node): add hasChildren() convenience function

### DIFF
--- a/include/open62541pp/node.hpp
+++ b/include/open62541pp/node.hpp
@@ -609,6 +609,26 @@ public:
         return nodes;
     }
 
+	/// Check if the node has children (only local nodes).
+    bool hasChildren(
+        const NodeId& referenceType = ReferenceTypeId::HierarchicalReferences,
+        Bitmask<NodeClass> nodeClassMask = NodeClass::Unspecified
+    ) {
+        const BrowseDescription bd(
+            id(),
+            BrowseDirection::Forward,
+            referenceType,
+            true,
+            nodeClassMask,
+            BrowseResultMask::None
+        );
+
+        // Request only 1 reference
+        BrowseResult result = services::browse(connection(), bd, 1U);
+
+        return !result.references().empty();
+    }
+
     /// Browse child nodes (only local nodes).
     std::vector<Node> browseChildren(
         const NodeId& referenceType = ReferenceTypeId::HierarchicalReferences,

--- a/tests/node.cpp
+++ b/tests/node.cpp
@@ -241,7 +241,15 @@ TEMPLATE_TEST_CASE("Node", "", Server, Client, Async<Client>) {
         CHECK(nodes.size() > 0);
         CHECK(std::any_of(nodes.begin(), nodes.end(), [&](auto& node) { return node == root; }));
     }
-
+    
+    SECTION("hasChildren") {
+        Node root{connection, ObjectId::RootFolder};
+        CHECK(root.hasChildren(ReferenceTypeId::HasChild) ==
+              !root.browseChildren(ReferenceTypeId::HasChild).empty());
+        CHECK(root.hasChildren(ReferenceTypeId::HierarchicalReferences) ==
+              !root.browseChildren(ReferenceTypeId::HierarchicalReferences).empty());
+    }
+    
     SECTION("browseChildren") {
         Node root{connection, ObjectId::RootFolder};
         Node child{connection, ObjectId::ObjectsFolder};


### PR DESCRIPTION
feat(node): add hasChildren() convenience function

Add `Node::hasChildren()` to check whether a node has forward hierarchical references.

The implementation performs a single browse call with maxReferences = 1 to avoid collecting all references and handling continuation points when only a boolean result is required.

This provides a lightweight alternative to `!browseChildren().empty()`.