### PR TITLE
test(node): add unit test for Node::hasChildren()

### DIFF
--- a/tests/node.cpp
+++ b/tests/node.cpp
@@ -241,7 +241,15 @@ TEMPLATE_TEST_CASE("Node", "", Server, Client, Async<Client>) {
         CHECK(nodes.size() > 0);
         CHECK(std::any_of(nodes.begin(), nodes.end(), [&](auto& node) { return node == root; }));
     }
-
+    
+    SECTION("hasChildren") {
+        Node root{connection, ObjectId::RootFolder};
+        CHECK(root.hasChildren(ReferenceTypeId::HasChild) ==
+              !root.browseChildren(ReferenceTypeId::HasChild).empty());
+        CHECK(root.hasChildren(ReferenceTypeId::HierarchicalReferences) ==
+              !root.browseChildren(ReferenceTypeId::HierarchicalReferences).empty());
+    }
+    
     SECTION("browseChildren") {
         Node root{connection, ObjectId::RootFolder};
         Node child{connection, ObjectId::ObjectsFolder};


### PR DESCRIPTION
Add a unit test for `Node::hasChildren()` to verify that it returns true if the node has forward hierarchical references, and false otherwise.

The test checks multiple reference types (HasChild and HierarchicalReferences) and ensures that `hasChildren()` is consistent with `!browseChildren().empty()`.

This ensures correctness of the new convenience function and protects against future regressions.