### PR TITLE
fix: UA_DataTypeArray with cleanup=false freed stack-allocated (or externally-owned) memory

### DIFF
--- a/src/datatype.cpp
+++ b/src/datatype.cpp
@@ -45,8 +45,8 @@ void clear(UA_DataTypeArray& native) noexcept {
             native.typesSize,
             [](auto& type) { clear(type); }
         );
+        deallocateArray(const_cast<UA_DataType*>(native.types));  // NOLINT
     }
-    deallocateArray(const_cast<UA_DataType*>(native.types));  // NOLINT
     native.types = nullptr;
 }
 

--- a/src/datatype.cpp
+++ b/src/datatype.cpp
@@ -53,9 +53,15 @@ void clear(UA_DataTypeArray& native) noexcept {
 void deallocate(const UA_DataTypeArray* head) noexcept {
     while (head != nullptr) {
         const auto* next = head->next;
-        auto* item = const_cast<UA_DataTypeArray*>(head);  // NOLINT(*const-cast)
-        detail::clear(*item);
-        detail::deallocate(item);
+#if UAPP_OPEN62541_VER_GE(1, 4)
+        if (head->cleanup) {
+#endif
+            auto* item = const_cast<UA_DataTypeArray*>(head);  // NOLINT(*const-cast)
+            detail::clear(*item);
+            detail::deallocate(item);
+#if UAPP_OPEN62541_VER_GE(1, 4)
+        }
+#endif
         head = next;
     }
 }

--- a/tests/datatype.cpp
+++ b/tests/datatype.cpp
@@ -468,6 +468,29 @@ TEST_CASE("detail::clear(UA_DataTypeArray&)") {
 #endif
 }
 
+TEST_CASE("detail::deallocate(const UA_DataTypeArray*)") {
+    SECTION("cleanup=true frees node and types") {
+        auto* types = detail::allocateArray<UA_DataType>(1);
+        auto* node = detail::allocate<UA_DataTypeArray>();
+#if UAPP_OPEN62541_VER_GE(1, 4)
+        new (node) UA_DataTypeArray{nullptr, 1, types, true};
+#else
+        new (node) UA_DataTypeArray{nullptr, 1, types};
+#endif
+        detail::deallocate(static_cast<const UA_DataTypeArray*>(node));  // must not leak or crash
+    }
+
+#if UAPP_OPEN62541_VER_GE(1, 4)
+    SECTION("cleanup=false does not free node or types") {
+        UA_DataType types[1]{};              // stack-allocated — must not be passed to UA_free
+        UA_DataTypeArray node{nullptr, 1, types, false};  // stack-allocated
+        // Bug: detail::deallocate(item) is called unconditionally, freeing the stack node.
+        // This triggers an ASAN error (free of stack-allocated memory).
+        detail::deallocate(static_cast<const UA_DataTypeArray*>(&node));
+    }
+#endif
+}
+
 TEST_CASE("findDataType") {
     SECTION("Builtin") {
         CHECK(findDataType(NodeId{0, 0}) == nullptr);

--- a/tests/datatype.cpp
+++ b/tests/datatype.cpp
@@ -5,6 +5,7 @@
 
 #include "open62541pp/config.hpp"
 #include "open62541pp/datatype.hpp"
+#include "open62541pp/detail/types_handling.hpp"
 #include "open62541pp/types.hpp"
 
 using namespace opcua;
@@ -441,6 +442,30 @@ TEST_CASE("DataTypeBuilder") {
 
         checkEqual(dtNative, dtWrapper);
     }
+}
+
+TEST_CASE("detail::clear(UA_DataTypeArray&)") {
+    SECTION("cleanup=true frees and nullifies types") {
+        auto* types = detail::allocateArray<UA_DataType>(2);
+#if UAPP_OPEN62541_VER_GE(1, 4)
+        UA_DataTypeArray native{nullptr, 2, types, true};
+#else
+        UA_DataTypeArray native{nullptr, 2, types};
+#endif
+        detail::clear(native);
+        CHECK(native.types == nullptr);
+    }
+
+#if UAPP_OPEN62541_VER_GE(1, 4)
+    SECTION("cleanup=false does not free types") {
+        UA_DataType types[1]{};  // stack-allocated — must not be passed to UA_free
+        UA_DataTypeArray native{nullptr, 1, types, false};
+        // Bug: deallocateArray is called unconditionally, freeing the stack array.
+        // This triggers an ASAN error (free of stack-allocated memory).
+        detail::clear(native);
+        CHECK(native.types == nullptr);
+    }
+#endif
 }
 
 TEST_CASE("findDataType") {


### PR DESCRIPTION
Using open62541pp with a lot of compiled nodesets, I got recurring memory errors in teardown when running tests under ASan. I think I have found the issue.

In open62541 v1.4 `UA_DataTypeArray` gained a **cleanup** boolean field that signals whether the node and its types array are heap-allocated and therefore owned by the library (and should be freed), versus being statically/stack-allocated or externally owned (and must not be freed).

Two functions in `datatype.cpp` ignored the cleanup flag and unconditionally freed memory:

1. `detail::clear(UA_DataTypeArray&)`

2. `detail::deallocate(const UA_DataTypeArray*)`

I have written tests that fail under ASan if the fixes are not implemented.

I have updated both functions to gate the freeing calls on cleanup, in case open62541 v>1.4

