### PR TITLE
fix: prevent custom datatype use-after-free and invalid free

### DIFF
--- a/src/datatype.cpp
+++ b/src/datatype.cpp
@@ -75,6 +75,14 @@ UA_DataTypeMember copy(const UA_DataTypeMember& src) {
 }
 
 static void copyMembers(const UA_DataTypeMember* members, size_t membersSize, UA_DataType& dst) {
+    // open62541's UA_cleanupDataTypeWithCustom calls UA_free(type->members) directly without
+    // stripping the empty-array sentinel. Use nullptr for empty to avoid crashing cleanup on
+    // types with no members (for example enums).
+    if (membersSize == 0) {
+        dst.members = nullptr;
+        dst.membersSize = 0;
+        return;
+    }
     dst.members = detail::allocateArray<UA_DataTypeMember>(membersSize);
     dst.membersSize = membersSize;
     std::transform(
@@ -154,9 +162,10 @@ const UA_DataType* findDataType(const NodeId& id) noexcept {
     // UA_TYPES array is sorted by typeId -> use binary search
     const Span types{UA_TYPES, UA_TYPES_COUNT};  // NOLINT(*decay)
     const auto* it = std::lower_bound(
-        types.begin(), types.end(), id, [](const UA_DataType& type, const NodeId& value) {
-            return type.typeId < value;
-        }
+        types.begin(),
+        types.end(),
+        id,
+        [](const UA_DataType& type, const NodeId& value) { return type.typeId < value; }
     );
     if (it != types.end() && it->typeId == id) {
         return it;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -392,11 +392,20 @@ void Server::Deleter::operator()(UA_Server* server) const noexcept {
     if (detail::getContext(server)->running) {
         UA_Server_run_shutdown(server);
     }
-    // Let UA_Server_delete -> UA_ServerConfig_clean free customDataTypes
+#if UAPP_OPEN62541_VER_GE(1, 4)
+    // UA_Server_delete -> UA_ServerConfig_clean frees customDataTypes.
     // Freeing here before UA_Server_delete is a use-after-free:
     // nodestore cleanup inside UA_Server_delete clears stored values whose DataType
     // member.memberType pointers reach into customDataTypes.
     UA_Server_delete(server);
+#else
+    // UA_ServerConfig_clean (<1.4) does not free customDataTypes. Save the pointer
+    // and free it after UA_Server_delete has finished, so nodestore cleanup inside
+    // UA_Server_delete can still traverse custom DataType members.
+    const auto* customTypes = UA_Server_getConfig(server)->customDataTypes;
+    UA_Server_delete(server);
+    detail::deallocate(customTypes);
+#endif
 }
 
 Server* asWrapper(UA_Server* server) noexcept {

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -392,9 +392,10 @@ void Server::Deleter::operator()(UA_Server* server) const noexcept {
     if (detail::getContext(server)->running) {
         UA_Server_run_shutdown(server);
     }
-    auto* config = UA_Server_getConfig(server);
-    detail::deallocate(config->customDataTypes);
-    config->customDataTypes = nullptr;
+    // Let UA_Server_delete -> UA_ServerConfig_clean free customDataTypes
+    // Freeing here before UA_Server_delete is a use-after-free:
+    // nodestore cleanup inside UA_Server_delete clears stored values whose DataType
+    // member.memberType pointers reach into customDataTypes.
     UA_Server_delete(server);
 }
 

--- a/tests/datatype.cpp
+++ b/tests/datatype.cpp
@@ -270,6 +270,7 @@ TEST_CASE("DataTypeBuilder") {
         CHECK(dt.typeKind() == UA_DATATYPEKIND_ENUM);
         CHECK(dt.pointerFree() == true);
         CHECK(dt.members().empty());
+        CHECK(dt.handle()->members == nullptr);
     }
 
     SECTION("Struct") {
@@ -382,14 +383,14 @@ TEST_CASE("DataTypeBuilder") {
             UniSwitch switchField;
 
             union Fields {
-                double optionA;
+                double optional;
                 UA_String optionB;
             } fields;
         };
 
         static UA_DataTypeMember uniMembers[2] = {
             makeDataTypeMember(
-                "optionA", UA_TYPES[UA_TYPES_DOUBLE], offsetof(Uni, fields.optionA), false, false
+                "optional", UA_TYPES[UA_TYPES_DOUBLE], offsetof(Uni, fields.optional), false, false
             ),
             makeDataTypeMember(
                 "optionB", UA_TYPES[UA_TYPES_STRING], offsetof(Uni, fields.optionB), false, false
@@ -410,7 +411,7 @@ TEST_CASE("DataTypeBuilder") {
 
         const auto dt =
             DataTypeBuilder<Uni>::createUnion("Uni", {1, 1004}, {1, 4})
-                .addUnionField<&Uni::fields, double>("optionA")
+                .addUnionField<&Uni::fields, double>("optional")
                 .addUnionField<&Uni::fields, UA_String>("optionB", UA_TYPES[UA_TYPES_STRING])
                 .build();
 
@@ -482,7 +483,7 @@ TEST_CASE("detail::deallocate(const UA_DataTypeArray*)") {
 
 #if UAPP_OPEN62541_VER_GE(1, 4)
     SECTION("cleanup=false does not free node or types") {
-        UA_DataType types[1]{};              // stack-allocated — must not be passed to UA_free
+        UA_DataType types[1]{};  // stack-allocated — must not be passed to UA_free
         UA_DataTypeArray node{nullptr, 1, types, false};  // stack-allocated
         // Bug: detail::deallocate(item) is called unconditionally, freeing the stack node.
         // This triggers an ASAN error (free of stack-allocated memory).

--- a/tests/server.cpp
+++ b/tests/server.cpp
@@ -332,47 +332,33 @@ TEST_CASE("DataSource") {
     }
 }
 
-TEST_CASE("Server teardown with custom struct types and a stored variable node") {
-    struct Inner {
-        size_t idsSize;
-        std::int64_t* ids;
-    };
-
-    struct Result {
-        Inner inner;
+TEST_CASE("Server teardown with custom struct type and a stored variable node") {
+    struct Point {
+        std::int32_t x;
+        std::int32_t y;
     };
 
     Server server;
 
-    auto inner = DataTypeBuilder<Inner>::createStructure("_Inner", {1, 3001}, {1, 3002})
-                     .addField<&Inner::idsSize, &Inner::ids>("ids")
-                     .build();
-    server.config().addCustomDataTypes({inner});
+    auto pointType =
+        DataTypeBuilder<Point>::createStructure("_Point", {1, 3001}, {1, 3002})
+            .addField<&Point::x>("x")
+            .addField<&Point::y>("y")
+            .build();
+    server.config().addCustomDataTypes({pointType});
 
-    const UA_NodeId innerId = UA_NODEID_NUMERIC(1, 3001);
-    const UA_DataType* innerRegistered = UA_Server_findDataType(server.handle(), &innerId);
-    REQUIRE(innerRegistered != nullptr);
+    const NodeId pointId{1, 3001};
+    const UA_DataType* pointRegistered = findDataType(server, pointId);
+    REQUIRE(pointRegistered != nullptr);
 
-    auto result = DataTypeBuilder<Result>::createStructure("_Result", {1, 3003}, {1, 3004})
-                      .addField<&Result::inner>("inner", *innerRegistered)
-                      .build();
-    server.config().addCustomDataTypes({result});
-
-    const UA_NodeId resultId = UA_NODEID_NUMERIC(1, 3003);
-    const UA_DataType* resultRegistered = UA_Server_findDataType(server.handle(), &resultId);
-    REQUIRE(resultRegistered != nullptr);
-
-    std::array<std::int64_t, 2> ids = {1, 2};
-    Result value{};
-    value.inner.idsSize = ids.size();
-    value.inner.ids = ids.data();
+    Point value{1, 2};
 
     CHECK_NOTHROW(Node{server, ObjectId::ObjectsFolder}.addVariable(
         {1, 5001},
-        "result",
+        "point",
         VariableAttributes{}
-            .setDataType(NodeId{resultId})
+            .setDataType(pointId)
             .setValueRank(ValueRank::Scalar)
-            .setValue(Variant{value, *resultRegistered})
+            .setValue(Variant{value, *pointRegistered})
     ));
 }

--- a/tests/server.cpp
+++ b/tests/server.cpp
@@ -1,3 +1,4 @@
+#include <array>
 #include <chrono>
 #include <thread>
 
@@ -5,6 +6,7 @@
 #include <catch2/matchers/catch_matchers_all.hpp>
 
 #include "open62541pp/config.hpp"
+#include "open62541pp/datatype.hpp"
 #include "open62541pp/detail/open62541/server.h"
 #include "open62541pp/detail/string_utils.hpp"  // detail::toString
 #include "open62541pp/node.hpp"
@@ -238,7 +240,7 @@ TEST_CASE("ValueCallback") {
     auto callbackPtr = std::make_unique<ValueCallbackTest>();
     auto& callback = *callbackPtr;
     setVariableNodeValueCallback(server, id, callback);
-    
+
     SECTION("move ownership") {
         setVariableNodeValueCallback(server, id, std::move(callbackPtr));
     }
@@ -328,4 +330,49 @@ TEST_CASE("DataSource") {
         CHECK_THROWS_MATCHES(node.readValue(), BadStatus, Message("BadUnexpectedError"));
         CHECK_THROWS_MATCHES(node.writeValue(Variant{2}), BadStatus, Message("BadUnexpectedError"));
     }
+}
+
+TEST_CASE("Server teardown with custom struct types and a stored variable node") {
+    struct Inner {
+        size_t idsSize;
+        std::int64_t* ids;
+    };
+
+    struct Result {
+        Inner inner;
+    };
+
+    Server server;
+
+    auto inner = DataTypeBuilder<Inner>::createStructure("_Inner", {1, 3001}, {1, 3002})
+                     .addField<&Inner::idsSize, &Inner::ids>("ids")
+                     .build();
+    server.config().addCustomDataTypes({inner});
+
+    const UA_NodeId innerId = UA_NODEID_NUMERIC(1, 3001);
+    const UA_DataType* innerRegistered = UA_Server_findDataType(server.handle(), &innerId);
+    REQUIRE(innerRegistered != nullptr);
+
+    auto result = DataTypeBuilder<Result>::createStructure("_Result", {1, 3003}, {1, 3004})
+                      .addField<&Result::inner>("inner", *innerRegistered)
+                      .build();
+    server.config().addCustomDataTypes({result});
+
+    const UA_NodeId resultId = UA_NODEID_NUMERIC(1, 3003);
+    const UA_DataType* resultRegistered = UA_Server_findDataType(server.handle(), &resultId);
+    REQUIRE(resultRegistered != nullptr);
+
+    std::array<std::int64_t, 2> ids = {1, 2};
+    Result value{};
+    value.inner.idsSize = ids.size();
+    value.inner.ids = ids.data();
+
+    CHECK_NOTHROW(Node{server, ObjectId::ObjectsFolder}.addVariable(
+        {1, 5001},
+        "result",
+        VariableAttributes{}
+            .setDataType(NodeId{resultId})
+            .setValueRank(ValueRank::Scalar)
+            .setValue(Variant{value, *resultRegistered})
+    ));
 }


### PR DESCRIPTION
[open62541pp_bug_repro.zip](https://github.com/user-attachments/files/26893921/open62541pp_bug_repro.zip)


    This MR fixes two custom datatype teardown bugs in open62541pp.
  >
    1. A use-after-free during server cleanup: open62541pp frees customDataTypes before UA_Server_delete() has finished cleaning node values that still reference that metadata.
    2. An invalid free for zero-member custom datatypes (for example enums): open62541pp stores an empty members array using the empty-array sentinel, but open62541 cleanup expects either
     nullptr or a real allocation.
  >
    Attached are two minimal repro scripts, one for each bug.
  >
    The fixes are related because the first change delegates custom datatype cleanup back to open62541, and the second ensures the resulting cleanup path is safe for zero-member 
    datatypes.

