### PR TITLE
fix: dangling references when using useDeferred

### DIFF
--- a/include/open62541pp/services/detail/client_service.hpp
+++ b/include/open62541pp/services/detail/client_service.hpp
@@ -81,18 +81,18 @@ struct AsyncServiceAdapter {
         );
 
         return asyncInitiate<Response>(
-            [](auto&& handler, Client& client, auto&& initiation, auto&&... args) {
-                auto& catcher = opcua::detail::getExceptionCatcher(client);
+            [](auto&& handler, Client& innerClient, auto&& innerInitiation, auto&&... innerArgs) {
+                auto& catcher = opcua::detail::getExceptionCatcher(innerClient);
                 try {
                     // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks), false positive?
                     auto callbackAndContext = makeCallbackAndContext(
                         catcher, std::forward<decltype(handler)>(handler)
                     );
                     std::invoke(
-                        std::forward<decltype(initiation)>(initiation),
+                        std::forward<decltype(innerInitiation)>(innerInitiation),
                         callbackAndContext.callback,
                         callbackAndContext.context.get(),
-                        std::forward<decltype(args)>(args)...
+                        std::forward<decltype(innerArgs)>(innerArgs)...
                     );
                     // initiation call might raise an exception
                     // transfer ownership to the callback afterwards
@@ -116,11 +116,11 @@ auto sendRequestAsync(Client& client, const Request& request, CompletionToken&& 
         client,
         [](UA_ClientAsyncServiceCallback callback,
            void* userdata,
-           Client& client,
-           const Request& request) {
+           Client& innerClient,
+           const Request& innerRequest) {
             throwIfBad(__UA_Client_AsyncService(
-                opcua::detail::getHandle(client),
-                &request,
+                opcua::detail::getHandle(innerClient),
+                &innerRequest,
                 &getDataType<Request>(),
                 callback,
                 &getDataType<Response>(),

--- a/include/open62541pp/services/detail/client_service.hpp
+++ b/include/open62541pp/services/detail/client_service.hpp
@@ -81,8 +81,8 @@ struct AsyncServiceAdapter {
         );
 
         return asyncInitiate<Response>(
-            [](auto&& handler, Client& innerClient, auto&& innerInitiation, auto&&... innerArgs) {
-                auto& catcher = opcua::detail::getExceptionCatcher(innerClient);
+            [&client](auto&& handler, auto&& innerInitiation, auto&&... innerArgs) {
+                auto& catcher = opcua::detail::getExceptionCatcher(client);
                 try {
                     // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks), false positive?
                     auto callbackAndContext = makeCallbackAndContext(
@@ -102,7 +102,6 @@ struct AsyncServiceAdapter {
                 }
             },
             std::forward<CompletionToken>(token),
-            std::ref(client),
             std::forward<Initiation>(initiation),
             std::forward<Args>(args)...
         );
@@ -114,12 +113,11 @@ template <typename Request, typename Response, typename CompletionToken>
 auto sendRequestAsync(Client& client, const Request& request, CompletionToken&& token) {
     return AsyncServiceAdapter<Response>::initiate(
         client,
-        [](UA_ClientAsyncServiceCallback callback,
-           void* userdata,
-           Client& innerClient,
-           const Request& innerRequest) {
+        [&client](
+            UA_ClientAsyncServiceCallback callback, void* userdata, const Request& innerRequest
+        ) {
             throwIfBad(__UA_Client_AsyncService(
-                opcua::detail::getHandle(innerClient),
+                opcua::detail::getHandle(client),
                 &innerRequest,
                 &getDataType<Request>(),
                 callback,
@@ -129,7 +127,6 @@ auto sendRequestAsync(Client& client, const Request& request, CompletionToken&& 
             ));
         },
         std::forward<CompletionToken>(token),
-        std::ref(client),
         request
     );
 }

--- a/include/open62541pp/services/detail/client_service.hpp
+++ b/include/open62541pp/services/detail/client_service.hpp
@@ -64,15 +64,24 @@ struct AsyncServiceAdapter {
      * Initiate open62541 async client operation with user-defined completion token.
      * @param client Instance of type Client
      * @param initiation Callable to initiate the async operation. Following signature is expected:
-     *                   `void(UA_ClientAsyncServiceCallback callback, void* userdata)`
+     *                   ```
+     *                   void(
+     *                       UA_ClientAsyncServiceCallback callback,
+     *                       void* userdata,
+     *                       Args... args)
+     *                   ```
      * @param token Completion token
      */
-    template <typename Initiation, typename CompletionToken>
-    static auto initiate(Client& client, Initiation&& initiation, CompletionToken&& token) {
-        static_assert(std::is_invocable_v<Initiation, UA_ClientAsyncServiceCallback, void*>);
+    template <typename Initiation, typename CompletionToken, typename... Args>
+    static auto initiate(
+        Client& client, Initiation&& initiation, CompletionToken&& token, Args&&... args
+    ) {
+        static_assert(
+            std::is_invocable_v<Initiation, UA_ClientAsyncServiceCallback, void*, Args&&...>
+        );
 
         return asyncInitiate<Response>(
-            [&](auto&& handler) {
+            [](auto&& handler, Client& client, auto&& initiation, auto&&... args) {
                 auto& catcher = opcua::detail::getExceptionCatcher(client);
                 try {
                     // NOLINTNEXTLINE(clang-analyzer-cplusplus.NewDeleteLeaks), false positive?
@@ -80,9 +89,10 @@ struct AsyncServiceAdapter {
                         catcher, std::forward<decltype(handler)>(handler)
                     );
                     std::invoke(
-                        std::forward<Initiation>(initiation),
+                        std::forward<decltype(initiation)>(initiation),
                         callbackAndContext.callback,
-                        callbackAndContext.context.get()
+                        callbackAndContext.context.get(),
+                        std::forward<decltype(args)>(args)...
                     );
                     // initiation call might raise an exception
                     // transfer ownership to the callback afterwards
@@ -91,7 +101,10 @@ struct AsyncServiceAdapter {
                     catcher.setException(std::current_exception());
                 }
             },
-            std::forward<CompletionToken>(token)
+            std::forward<CompletionToken>(token),
+            std::ref(client),
+            std::forward<Initiation>(initiation),
+            std::forward<Args>(args)...
         );
     }
 };
@@ -101,7 +114,10 @@ template <typename Request, typename Response, typename CompletionToken>
 auto sendRequestAsync(Client& client, const Request& request, CompletionToken&& token) {
     return AsyncServiceAdapter<Response>::initiate(
         client,
-        [&](UA_ClientAsyncServiceCallback callback, void* userdata) {
+        [](UA_ClientAsyncServiceCallback callback,
+           void* userdata,
+           Client& client,
+           const Request& request) {
             throwIfBad(__UA_Client_AsyncService(
                 opcua::detail::getHandle(client),
                 &request,
@@ -112,7 +128,9 @@ auto sendRequestAsync(Client& client, const Request& request, CompletionToken&& 
                 nullptr
             ));
         },
-        std::forward<CompletionToken>(token)
+        std::forward<CompletionToken>(token),
+        std::ref(client),
+        request
     );
 }
 

--- a/include/open62541pp/services/monitoreditem.hpp
+++ b/include/open62541pp/services/monitoreditem.hpp
@@ -177,17 +177,17 @@ auto createMonitoredItemsDataChangeAsync(
         connection,
         [](UA_ClientAsyncServiceCallback callback,
            void* userdata,
-           Client& connection,
-           const CreateMonitoredItemsRequest& request,
-           Span<detail::MonitoredItemContext*> contextsPtr,
-           Span<UA_Client_DataChangeNotificationCallback> dataChangeCallbacks,
-           Span<UA_Client_DeleteMonitoredItemCallback> deleteCallbacks) {
+           Client& innerConnection,
+           const CreateMonitoredItemsRequest& innerRequest,
+           Span<detail::MonitoredItemContext*> innerContextsPtr,
+           Span<UA_Client_DataChangeNotificationCallback> innerDataChangeCallbacks,
+           Span<UA_Client_DeleteMonitoredItemCallback> innerDeleteCallbacks) {
             throwIfBad(UA_Client_MonitoredItems_createDataChanges_async(
-                opcua::detail::getHandle(connection),
-                asNative(request),
-                reinterpret_cast<void**>(contextsPtr.data()),  // NOLINT
-                dataChangeCallbacks.data(),
-                deleteCallbacks.data(),
+                opcua::detail::getHandle(innerConnection),
+                asNative(innerRequest),
+                reinterpret_cast<void**>(innerContextsPtr.data()),  // NOLINT
+                innerDataChangeCallbacks.data(),
+                innerDeleteCallbacks.data(),
                 callback,
                 userdata,
                 nullptr
@@ -317,17 +317,17 @@ auto createMonitoredItemsEventAsync(
         connection,
         [](UA_ClientAsyncServiceCallback callback,
            void* userdata,
-           Client& connection,
-           const CreateMonitoredItemsRequest& request,
-           Span<detail::MonitoredItemContext*> contextsPtr,
-           Span<UA_Client_EventNotificationCallback> eventCallbacks,
-           Span<UA_Client_DeleteMonitoredItemCallback> deleteCallbacks) {
+           Client& innerConnection,
+           const CreateMonitoredItemsRequest& innerRequest,
+           Span<detail::MonitoredItemContext*> innerContextsPtr,
+           Span<UA_Client_EventNotificationCallback> innerEventCallbacks,
+           Span<UA_Client_DeleteMonitoredItemCallback> innerDeleteCallbacks) {
             throwIfBad(UA_Client_MonitoredItems_createEvents_async(
-                opcua::detail::getHandle(connection),
-                asNative(request),
-                reinterpret_cast<void**>(contextsPtr.data()),  // NOLINT
-                eventCallbacks.data(),
-                deleteCallbacks.data(),
+                opcua::detail::getHandle(innerConnection),
+                asNative(innerRequest),
+                reinterpret_cast<void**>(innerContextsPtr.data()),  // NOLINT
+                innerEventCallbacks.data(),
+                innerDeleteCallbacks.data(),
                 callback,
                 userdata,
                 nullptr
@@ -441,10 +441,14 @@ auto modifyMonitoredItemsAsync(
         connection,
         [](UA_ClientAsyncServiceCallback callback,
            void* userdata,
-           Client& connection,
-           const ModifyMonitoredItemsRequest& request) {
+           Client& innerConnection,
+           const ModifyMonitoredItemsRequest& innerRequest) {
             throwIfBad(UA_Client_MonitoredItems_modify_async(
-                opcua::detail::getHandle(connection), asNative(request), callback, userdata, nullptr
+                opcua::detail::getHandle(innerConnection),
+                asNative(innerRequest),
+                callback,
+                userdata,
+                nullptr
             ));
         },
         std::forward<CompletionToken>(token),
@@ -651,10 +655,14 @@ auto deleteMonitoredItemsAsync(
         connection,
         [](UA_ClientAsyncServiceCallback callback,
            void* userdata,
-           Client& connection,
-           const DeleteMonitoredItemsRequest& request) {
+           Client& innerConnection,
+           const DeleteMonitoredItemsRequest& innerRequest) {
             throwIfBad(UA_Client_MonitoredItems_delete_async(
-                opcua::detail::getHandle(connection), asNative(request), callback, userdata, nullptr
+                opcua::detail::getHandle(innerConnection),
+                asNative(innerRequest),
+                callback,
+                userdata,
+                nullptr
             ));
         },
         std::forward<CompletionToken>(token),

--- a/include/open62541pp/services/monitoreditem.hpp
+++ b/include/open62541pp/services/monitoreditem.hpp
@@ -175,15 +175,16 @@ auto createMonitoredItemsDataChangeAsync(
     );
     return detail::AsyncServiceAdapter<CreateMonitoredItemsResponse>::initiate(
         connection,
-        [](UA_ClientAsyncServiceCallback callback,
-           void* userdata,
-           Client& innerConnection,
-           const CreateMonitoredItemsRequest& innerRequest,
-           Span<detail::MonitoredItemContext*> innerContextsPtr,
-           Span<UA_Client_DataChangeNotificationCallback> innerDataChangeCallbacks,
-           Span<UA_Client_DeleteMonitoredItemCallback> innerDeleteCallbacks) {
+        [&connection](
+            UA_ClientAsyncServiceCallback callback,
+            void* userdata,
+            const CreateMonitoredItemsRequest& innerRequest,
+            Span<detail::MonitoredItemContext*> innerContextsPtr,
+            Span<UA_Client_DataChangeNotificationCallback> innerDataChangeCallbacks,
+            Span<UA_Client_DeleteMonitoredItemCallback> innerDeleteCallbacks
+        ) {
             throwIfBad(UA_Client_MonitoredItems_createDataChanges_async(
-                opcua::detail::getHandle(innerConnection),
+                opcua::detail::getHandle(connection),
                 asNative(innerRequest),
                 reinterpret_cast<void**>(innerContextsPtr.data()),  // NOLINT
                 innerDataChangeCallbacks.data(),
@@ -201,7 +202,6 @@ auto createMonitoredItemsDataChangeAsync(
             },
             std::forward<CompletionToken>(token)
         ),
-        std::ref(connection),
         request,
         std::move(contextsPtr),
         std::move(dataChangeCallbacks),
@@ -315,15 +315,16 @@ auto createMonitoredItemsEventAsync(
     );
     return detail::AsyncServiceAdapter<CreateMonitoredItemsResponse>::initiate(
         connection,
-        [](UA_ClientAsyncServiceCallback callback,
-           void* userdata,
-           Client& innerConnection,
-           const CreateMonitoredItemsRequest& innerRequest,
-           Span<detail::MonitoredItemContext*> innerContextsPtr,
-           Span<UA_Client_EventNotificationCallback> innerEventCallbacks,
-           Span<UA_Client_DeleteMonitoredItemCallback> innerDeleteCallbacks) {
+        [&connection](
+            UA_ClientAsyncServiceCallback callback,
+            void* userdata,
+            const CreateMonitoredItemsRequest& innerRequest,
+            Span<detail::MonitoredItemContext*> innerContextsPtr,
+            Span<UA_Client_EventNotificationCallback> innerEventCallbacks,
+            Span<UA_Client_DeleteMonitoredItemCallback> innerDeleteCallbacks
+        ) {
             throwIfBad(UA_Client_MonitoredItems_createEvents_async(
-                opcua::detail::getHandle(innerConnection),
+                opcua::detail::getHandle(connection),
                 asNative(innerRequest),
                 reinterpret_cast<void**>(innerContextsPtr.data()),  // NOLINT
                 innerEventCallbacks.data(),
@@ -341,7 +342,6 @@ auto createMonitoredItemsEventAsync(
             },
             std::forward<CompletionToken>(token)
         ),
-        std::ref(connection),
         request,
         std::move(contextsPtr),
         std::move(eventCallbacks),
@@ -439,12 +439,13 @@ auto modifyMonitoredItemsAsync(
 ) {
     return detail::AsyncServiceAdapter<ModifyMonitoredItemsResponse>::initiate(
         connection,
-        [](UA_ClientAsyncServiceCallback callback,
-           void* userdata,
-           Client& innerConnection,
-           const ModifyMonitoredItemsRequest& innerRequest) {
+        [&connection](
+            UA_ClientAsyncServiceCallback callback,
+            void* userdata,
+            const ModifyMonitoredItemsRequest& innerRequest
+        ) {
             throwIfBad(UA_Client_MonitoredItems_modify_async(
-                opcua::detail::getHandle(innerConnection),
+                opcua::detail::getHandle(connection),
                 asNative(innerRequest),
                 callback,
                 userdata,
@@ -452,7 +453,6 @@ auto modifyMonitoredItemsAsync(
             ));
         },
         std::forward<CompletionToken>(token),
-        std::ref(connection),
         request
     );
 }
@@ -653,12 +653,13 @@ auto deleteMonitoredItemsAsync(
 ) {
     return detail::AsyncServiceAdapter<DeleteMonitoredItemsResponse>::initiate(
         connection,
-        [](UA_ClientAsyncServiceCallback callback,
-           void* userdata,
-           Client& innerConnection,
-           const DeleteMonitoredItemsRequest& innerRequest) {
+        [&connection](
+            UA_ClientAsyncServiceCallback callback,
+            void* userdata,
+            const DeleteMonitoredItemsRequest& innerRequest
+        ) {
             throwIfBad(UA_Client_MonitoredItems_delete_async(
-                opcua::detail::getHandle(innerConnection),
+                opcua::detail::getHandle(connection),
                 asNative(innerRequest),
                 callback,
                 userdata,
@@ -666,7 +667,6 @@ auto deleteMonitoredItemsAsync(
             ));
         },
         std::forward<CompletionToken>(token),
-        std::ref(connection),
         request
     );
 }

--- a/include/open62541pp/services/monitoreditem.hpp
+++ b/include/open62541pp/services/monitoreditem.hpp
@@ -118,7 +118,7 @@ std::vector<std::unique_ptr<MonitoredItemContext>> makeMonitoredItemContexts(
 
 void convertMonitoredItemContexts(
     Span<const std::unique_ptr<MonitoredItemContext>> contexts,
-    Span<MonitoredItemContext*> contextsPtr,
+    Span<void*> contextsPtr,
     Span<UA_Client_DataChangeNotificationCallback> dataChangeCallbacksNative,
     Span<UA_Client_EventNotificationCallback> eventCallbacksNative,
     Span<UA_Client_DeleteMonitoredItemCallback> deleteCallbacksNative
@@ -167,7 +167,7 @@ auto createMonitoredItemsDataChangeAsync(
     auto contexts = detail::makeMonitoredItemContexts(
         connection, request, std::move(dataChangeCallback), {}, std::move(deleteCallback)
     );
-    std::vector<detail::MonitoredItemContext*> contextsPtr{contexts.size()};
+    std::vector<void*> contextsPtr{contexts.size()};
     std::vector<UA_Client_DataChangeNotificationCallback> dataChangeCallbacks{contexts.size()};
     std::vector<UA_Client_DeleteMonitoredItemCallback> deleteCallbacks{contexts.size()};
     detail::convertMonitoredItemContexts(
@@ -179,16 +179,20 @@ auto createMonitoredItemsDataChangeAsync(
             UA_ClientAsyncServiceCallback callback,
             void* userdata,
             const CreateMonitoredItemsRequest& innerRequest,
-            Span<detail::MonitoredItemContext*> innerContextsPtr,
-            Span<UA_Client_DataChangeNotificationCallback> innerDataChangeCallbacks,
-            Span<UA_Client_DeleteMonitoredItemCallback> innerDeleteCallbacks
+            Span<void* const> innerContextsPtr,
+            Span<const UA_Client_DataChangeNotificationCallback> innerDataChangeCallbacks,
+            Span<const UA_Client_DeleteMonitoredItemCallback> innerDeleteCallbacks
         ) {
             throwIfBad(UA_Client_MonitoredItems_createDataChanges_async(
                 opcua::detail::getHandle(connection),
                 asNative(innerRequest),
-                reinterpret_cast<void**>(innerContextsPtr.data()),  // NOLINT
-                innerDataChangeCallbacks.data(),
-                innerDeleteCallbacks.data(),
+                // NOLINTBEGIN
+                const_cast<void**>(innerContextsPtr.data()),
+                const_cast<UA_Client_DataChangeNotificationCallback*>(
+                    innerDataChangeCallbacks.data()
+                ),
+                const_cast<UA_Client_DeleteMonitoredItemCallback*>(innerDeleteCallbacks.data()),
+                // NOLINTEND
                 callback,
                 userdata,
                 nullptr
@@ -307,7 +311,7 @@ auto createMonitoredItemsEventAsync(
     auto contexts = detail::makeMonitoredItemContexts(
         connection, request, {}, std::move(eventCallback), std::move(deleteCallback)
     );
-    std::vector<detail::MonitoredItemContext*> contextsPtr{contexts.size()};
+    std::vector<void*> contextsPtr{contexts.size()};
     std::vector<UA_Client_EventNotificationCallback> eventCallbacks{contexts.size()};
     std::vector<UA_Client_DeleteMonitoredItemCallback> deleteCallbacks{contexts.size()};
     detail::convertMonitoredItemContexts(
@@ -319,16 +323,18 @@ auto createMonitoredItemsEventAsync(
             UA_ClientAsyncServiceCallback callback,
             void* userdata,
             const CreateMonitoredItemsRequest& innerRequest,
-            Span<detail::MonitoredItemContext*> innerContextsPtr,
-            Span<UA_Client_EventNotificationCallback> innerEventCallbacks,
-            Span<UA_Client_DeleteMonitoredItemCallback> innerDeleteCallbacks
+            Span<void* const> innerContextsPtr,
+            Span<const UA_Client_EventNotificationCallback> innerEventCallbacks,
+            Span<const UA_Client_DeleteMonitoredItemCallback> innerDeleteCallbacks
         ) {
             throwIfBad(UA_Client_MonitoredItems_createEvents_async(
                 opcua::detail::getHandle(connection),
                 asNative(innerRequest),
-                reinterpret_cast<void**>(innerContextsPtr.data()),  // NOLINT
-                innerEventCallbacks.data(),
-                innerDeleteCallbacks.data(),
+                // NOLINGBEGIN
+                const_cast<void**>(innerContextsPtr.data()),
+                const_cast<UA_Client_EventNotificationCallback*>(innerEventCallbacks.data()),
+                const_cast<UA_Client_DeleteMonitoredItemCallback*>(innerDeleteCallbacks.data()),
+                // NOLINTEND
                 callback,
                 userdata,
                 nullptr

--- a/include/open62541pp/services/monitoreditem.hpp
+++ b/include/open62541pp/services/monitoreditem.hpp
@@ -175,7 +175,13 @@ auto createMonitoredItemsDataChangeAsync(
     );
     return detail::AsyncServiceAdapter<CreateMonitoredItemsResponse>::initiate(
         connection,
-        [&](UA_ClientAsyncServiceCallback callback, void* userdata) {
+        [](UA_ClientAsyncServiceCallback callback,
+           void* userdata,
+           Client& connection,
+           const CreateMonitoredItemsRequest& request,
+           Span<detail::MonitoredItemContext*> contextsPtr,
+           Span<UA_Client_DataChangeNotificationCallback> dataChangeCallbacks,
+           Span<UA_Client_DeleteMonitoredItemCallback> deleteCallbacks) {
             throwIfBad(UA_Client_MonitoredItems_createDataChanges_async(
                 opcua::detail::getHandle(connection),
                 asNative(request),
@@ -194,7 +200,12 @@ auto createMonitoredItemsDataChangeAsync(
                 detail::storeMonitoredItemContexts(connection, subscriptionId, response, contexts);
             },
             std::forward<CompletionToken>(token)
-        )
+        ),
+        std::ref(connection),
+        request,
+        std::move(contextsPtr),
+        std::move(dataChangeCallbacks),
+        std::move(deleteCallbacks)
     );
 }
 #endif
@@ -304,7 +315,13 @@ auto createMonitoredItemsEventAsync(
     );
     return detail::AsyncServiceAdapter<CreateMonitoredItemsResponse>::initiate(
         connection,
-        [&](UA_ClientAsyncServiceCallback callback, void* userdata) {
+        [](UA_ClientAsyncServiceCallback callback,
+           void* userdata,
+           Client& connection,
+           const CreateMonitoredItemsRequest& request,
+           Span<detail::MonitoredItemContext*> contextsPtr,
+           Span<UA_Client_EventNotificationCallback> eventCallbacks,
+           Span<UA_Client_DeleteMonitoredItemCallback> deleteCallbacks) {
             throwIfBad(UA_Client_MonitoredItems_createEvents_async(
                 opcua::detail::getHandle(connection),
                 asNative(request),
@@ -323,7 +340,12 @@ auto createMonitoredItemsEventAsync(
                 detail::storeMonitoredItemContexts(connection, subscriptionId, response, contexts);
             },
             std::forward<CompletionToken>(token)
-        )
+        ),
+        std::ref(connection),
+        request,
+        std::move(contextsPtr),
+        std::move(eventCallbacks),
+        std::move(deleteCallbacks)
     );
 }
 #endif
@@ -417,12 +439,17 @@ auto modifyMonitoredItemsAsync(
 ) {
     return detail::AsyncServiceAdapter<ModifyMonitoredItemsResponse>::initiate(
         connection,
-        [&](UA_ClientAsyncServiceCallback callback, void* userdata) {
+        [](UA_ClientAsyncServiceCallback callback,
+           void* userdata,
+           Client& connection,
+           const ModifyMonitoredItemsRequest& request) {
             throwIfBad(UA_Client_MonitoredItems_modify_async(
                 opcua::detail::getHandle(connection), asNative(request), callback, userdata, nullptr
             ));
         },
-        std::forward<CompletionToken>(token)
+        std::forward<CompletionToken>(token),
+        std::ref(connection),
+        request
     );
 }
 #endif
@@ -622,12 +649,17 @@ auto deleteMonitoredItemsAsync(
 ) {
     return detail::AsyncServiceAdapter<DeleteMonitoredItemsResponse>::initiate(
         connection,
-        [&](UA_ClientAsyncServiceCallback callback, void* userdata) {
+        [](UA_ClientAsyncServiceCallback callback,
+           void* userdata,
+           Client& connection,
+           const DeleteMonitoredItemsRequest& request) {
             throwIfBad(UA_Client_MonitoredItems_delete_async(
                 opcua::detail::getHandle(connection), asNative(request), callback, userdata, nullptr
             ));
         },
-        std::forward<CompletionToken>(token)
+        std::forward<CompletionToken>(token),
+        std::ref(connection),
+        request
     );
 }
 #endif

--- a/include/open62541pp/services/subscription.hpp
+++ b/include/open62541pp/services/subscription.hpp
@@ -131,13 +131,18 @@ auto createSubscriptionAsync(
     auto context = detail::createSubscriptionContext(
         connection, std::move(statusChangeCallback), std::move(deleteCallback)
     );
+    auto contextPtr = context.get();
     return detail::AsyncServiceAdapter<CreateSubscriptionResponse>::initiate(
         connection,
-        [&, context = context.get()](UA_ClientAsyncServiceCallback callback, void* userdata) {
+        [](UA_ClientAsyncServiceCallback callback,
+           void* userdata,
+           Client& connection,
+           const CreateSubscriptionRequest& request,
+           detail::SubscriptionContext* contextPtr) {
             throwIfBad(UA_Client_Subscriptions_create_async(
                 opcua::detail::getHandle(connection),
                 asNative(request),
-                context,
+                contextPtr,
                 detail::SubscriptionContext::statusChangeCallbackNative,
                 detail::SubscriptionContext::deleteCallbackNative,
                 callback,
@@ -154,7 +159,10 @@ auto createSubscriptionAsync(
                 }
             },
             std::forward<CompletionToken>(token)
-        )
+        ),
+        std::ref(connection),
+        request,
+        contextPtr
     );
 }
 
@@ -216,12 +224,17 @@ auto modifySubscriptionAsync(
 ) {
     return detail::AsyncServiceAdapter<ModifySubscriptionResponse>::initiate(
         connection,
-        [&](UA_ClientAsyncServiceCallback callback, void* userdata) {
+        [](UA_ClientAsyncServiceCallback callback,
+           void* userdata,
+           Client& connection,
+           const ModifySubscriptionRequest& request) {
             throwIfBad(UA_Client_Subscriptions_modify_async(
                 opcua::detail::getHandle(connection), asNative(request), callback, userdata, nullptr
             ));
         },
-        std::forward<CompletionToken>(token)
+        std::forward<CompletionToken>(token),
+        std::ref(connection),
+        request
     );
 }
 
@@ -339,12 +352,17 @@ auto deleteSubscriptionsAsync(
 ) {
     return detail::AsyncServiceAdapter<DeleteSubscriptionsResponse>::initiate(
         connection,
-        [&](UA_ClientAsyncServiceCallback callback, void* userdata) {
+        [](UA_ClientAsyncServiceCallback callback,
+           void* userdata,
+           Client& connection,
+           const DeleteSubscriptionsRequest& request) {
             throwIfBad(UA_Client_Subscriptions_delete_async(
                 opcua::detail::getHandle(connection), asNative(request), callback, userdata, nullptr
             ));
         },
-        std::forward<CompletionToken>(token)
+        std::forward<CompletionToken>(token),
+        std::ref(connection),
+        request
     );
 }
 #endif

--- a/include/open62541pp/services/subscription.hpp
+++ b/include/open62541pp/services/subscription.hpp
@@ -134,13 +134,14 @@ auto createSubscriptionAsync(
     auto* contextPtr = context.get();
     return detail::AsyncServiceAdapter<CreateSubscriptionResponse>::initiate(
         connection,
-        [](UA_ClientAsyncServiceCallback callback,
-           void* userdata,
-           Client& innerConnection,
-           const CreateSubscriptionRequest& innerRequest,
-           detail::SubscriptionContext* innerContextPtr) {
+        [&connection](
+            UA_ClientAsyncServiceCallback callback,
+            void* userdata,
+            const CreateSubscriptionRequest& innerRequest,
+            detail::SubscriptionContext* innerContextPtr
+        ) {
             throwIfBad(UA_Client_Subscriptions_create_async(
-                opcua::detail::getHandle(innerConnection),
+                opcua::detail::getHandle(connection),
                 asNative(innerRequest),
                 innerContextPtr,
                 detail::SubscriptionContext::statusChangeCallbackNative,
@@ -160,7 +161,6 @@ auto createSubscriptionAsync(
             },
             std::forward<CompletionToken>(token)
         ),
-        std::ref(connection),
         request,
         contextPtr
     );
@@ -224,12 +224,13 @@ auto modifySubscriptionAsync(
 ) {
     return detail::AsyncServiceAdapter<ModifySubscriptionResponse>::initiate(
         connection,
-        [](UA_ClientAsyncServiceCallback callback,
-           void* userdata,
-           Client& innerConnection,
-           const ModifySubscriptionRequest& innerRequest) {
+        [&connection](
+            UA_ClientAsyncServiceCallback callback,
+            void* userdata,
+            const ModifySubscriptionRequest& innerRequest
+        ) {
             throwIfBad(UA_Client_Subscriptions_modify_async(
-                opcua::detail::getHandle(innerConnection),
+                opcua::detail::getHandle(connection),
                 asNative(innerRequest),
                 callback,
                 userdata,
@@ -237,7 +238,6 @@ auto modifySubscriptionAsync(
             ));
         },
         std::forward<CompletionToken>(token),
-        std::ref(connection),
         request
     );
 }
@@ -356,12 +356,13 @@ auto deleteSubscriptionsAsync(
 ) {
     return detail::AsyncServiceAdapter<DeleteSubscriptionsResponse>::initiate(
         connection,
-        [](UA_ClientAsyncServiceCallback callback,
-           void* userdata,
-           Client& innerConnection,
-           const DeleteSubscriptionsRequest& innerRequest) {
+        [&connection](
+            UA_ClientAsyncServiceCallback callback,
+            void* userdata,
+            const DeleteSubscriptionsRequest& innerRequest
+        ) {
             throwIfBad(UA_Client_Subscriptions_delete_async(
-                opcua::detail::getHandle(innerConnection),
+                opcua::detail::getHandle(connection),
                 asNative(innerRequest),
                 callback,
                 userdata,
@@ -369,7 +370,6 @@ auto deleteSubscriptionsAsync(
             ));
         },
         std::forward<CompletionToken>(token),
-        std::ref(connection),
         request
     );
 }

--- a/include/open62541pp/services/subscription.hpp
+++ b/include/open62541pp/services/subscription.hpp
@@ -131,18 +131,18 @@ auto createSubscriptionAsync(
     auto context = detail::createSubscriptionContext(
         connection, std::move(statusChangeCallback), std::move(deleteCallback)
     );
-    auto contextPtr = context.get();
+    auto* contextPtr = context.get();
     return detail::AsyncServiceAdapter<CreateSubscriptionResponse>::initiate(
         connection,
         [](UA_ClientAsyncServiceCallback callback,
            void* userdata,
-           Client& connection,
-           const CreateSubscriptionRequest& request,
-           detail::SubscriptionContext* contextPtr) {
+           Client& innerConnection,
+           const CreateSubscriptionRequest& innerRequest,
+           detail::SubscriptionContext* innerContextPtr) {
             throwIfBad(UA_Client_Subscriptions_create_async(
-                opcua::detail::getHandle(connection),
-                asNative(request),
-                contextPtr,
+                opcua::detail::getHandle(innerConnection),
+                asNative(innerRequest),
+                innerContextPtr,
                 detail::SubscriptionContext::statusChangeCallbackNative,
                 detail::SubscriptionContext::deleteCallbackNative,
                 callback,
@@ -226,10 +226,14 @@ auto modifySubscriptionAsync(
         connection,
         [](UA_ClientAsyncServiceCallback callback,
            void* userdata,
-           Client& connection,
-           const ModifySubscriptionRequest& request) {
+           Client& innerConnection,
+           const ModifySubscriptionRequest& innerRequest) {
             throwIfBad(UA_Client_Subscriptions_modify_async(
-                opcua::detail::getHandle(connection), asNative(request), callback, userdata, nullptr
+                opcua::detail::getHandle(innerConnection),
+                asNative(innerRequest),
+                callback,
+                userdata,
+                nullptr
             ));
         },
         std::forward<CompletionToken>(token),
@@ -354,10 +358,14 @@ auto deleteSubscriptionsAsync(
         connection,
         [](UA_ClientAsyncServiceCallback callback,
            void* userdata,
-           Client& connection,
-           const DeleteSubscriptionsRequest& request) {
+           Client& innerConnection,
+           const DeleteSubscriptionsRequest& innerRequest) {
             throwIfBad(UA_Client_Subscriptions_delete_async(
-                opcua::detail::getHandle(connection), asNative(request), callback, userdata, nullptr
+                opcua::detail::getHandle(innerConnection),
+                asNative(innerRequest),
+                callback,
+                userdata,
+                nullptr
             ));
         },
         std::forward<CompletionToken>(token),

--- a/src/services_monitoreditem.cpp
+++ b/src/services_monitoreditem.cpp
@@ -54,17 +54,16 @@ std::vector<std::unique_ptr<MonitoredItemContext>> makeMonitoredItemContexts(
 
 void convertMonitoredItemContexts(
     Span<const std::unique_ptr<MonitoredItemContext>> contexts,
-    Span<MonitoredItemContext*> contextsPtr,
+    Span<void*> contextsPtr,
     Span<UA_Client_DataChangeNotificationCallback> dataChangeCallbacksNative,
     Span<UA_Client_EventNotificationCallback> eventCallbacksNative,
     Span<UA_Client_DeleteMonitoredItemCallback> deleteCallbacksNative
 ) noexcept {
     assert(contextsPtr.size() == contexts.size());
     std::transform(
-        contexts.begin(),
-        contexts.end(),
-        contextsPtr.begin(),
-        [](const auto& context) noexcept { return context.get(); }
+        contexts.begin(), contexts.end(), contextsPtr.begin(), [](const auto& context) noexcept {
+            return context.get();
+        }
     );
     if (!dataChangeCallbacksNative.empty()) {
         assert(dataChangeCallbacksNative.size() == contexts.size());
@@ -133,7 +132,7 @@ CreateMonitoredItemsResponse createMonitoredItemsDataChange(
     auto contexts = detail::makeMonitoredItemContexts(
         connection, request, std::move(dataChangeCallback), {}, std::move(deleteCallback)
     );
-    std::vector<detail::MonitoredItemContext*> contextsPtr(contexts.size());
+    std::vector<void*> contextsPtr(contexts.size());
     std::vector<UA_Client_DataChangeNotificationCallback> dataChangeCallbacks(contexts.size());
     std::vector<UA_Client_DeleteMonitoredItemCallback> deleteCallbacks(contexts.size());
     detail::convertMonitoredItemContexts(
@@ -142,7 +141,7 @@ CreateMonitoredItemsResponse createMonitoredItemsDataChange(
     CreateMonitoredItemsResponse response = UA_Client_MonitoredItems_createDataChanges(
         connection.handle(),
         request,
-        reinterpret_cast<void**>(contextsPtr.data()),  // NOLINT
+        contextsPtr.data(),
         dataChangeCallbacks.data(),
         deleteCallbacks.data()
     );
@@ -207,7 +206,7 @@ CreateMonitoredItemsResponse createMonitoredItemsEvent(
     auto contexts = detail::makeMonitoredItemContexts(
         connection, request, {}, std::move(eventCallback), std::move(deleteCallback)
     );
-    std::vector<detail::MonitoredItemContext*> contextsPtr(contexts.size());
+    std::vector<void*> contextsPtr(contexts.size());
     std::vector<UA_Client_EventNotificationCallback> eventCallbacks(contexts.size());
     std::vector<UA_Client_DeleteMonitoredItemCallback> deleteCallbacks(contexts.size());
     detail::convertMonitoredItemContexts(
@@ -216,7 +215,7 @@ CreateMonitoredItemsResponse createMonitoredItemsEvent(
     CreateMonitoredItemsResponse response = UA_Client_MonitoredItems_createEvents(
         connection.handle(),
         request,
-        reinterpret_cast<void**>(contextsPtr.data()),  // NOLINT
+        contextsPtr.data(),
         eventCallbacks.data(),
         deleteCallbacks.data()
     );


### PR DESCRIPTION
Fixes #709.

When calling an async function with `useDeferred`, the initiation object isn't called immediately, it's wrapped and returned to the caller. For `AsyncServiceAdapter::initiate()` and the functions that called it, some of the initiation lambda's captures were references to objects that only existed for the duration of the call to the async function. Those objects would be destroyed by the time the deferred operation was actually started.

The proposed solution is to use `asyncInitiate()`'s existing mechanism to pass-through trailing arguments, rather than capturing any references whatsoever. Out of an abundance of caution, I did the same with the `Client&` arguments, with `std::ref` to ensure that the reference remains when it's decay-copied. For `Client` specifically, it would be ok to explicitly capture it by reference.

~~I also made a small change to `Span`: when updating `createMonitoredItems...Async()`, I found that the two existing Span constructors prevents construction of a `Span<T>` (where T is non-const) to be constructed from a `vector<T>` rvalue. `std::span` defines construction from a container with `span(Container&&)`, so I changed this Span's constructors to behave similarly.~~

Note that I didn't add any new test cases. I wasn't too sure where they would fit in, or exactly which operations to add tests for. Is `auto op = ...Async(..., useDeferred); op(useFuture)` (for some or all of the modified operations) something you would like me to add tests for somewhere?