### PR TITLE
fix: race condition between Server::run() and Server::stop()

### DIFF
--- a/include/open62541pp/detail/server_context.hpp
+++ b/include/open62541pp/detail/server_context.hpp
@@ -59,6 +59,8 @@ struct ServerContext {
     SessionRegistry sessionRegistry;
     std::atomic<bool> running{false};
     std::mutex mutexRun;
+    std::mutex mutexStartup;
+    bool stopRequested{false};  // guarded by mutexStartup
 
     ContextMap<uint64_t, Staleable<std::function<void()>>> callbacks;
     ContextMap<NodeId, NodeContext> nodeContexts;

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -323,6 +323,11 @@ void Server::setVariableNodeDataSource(const NodeId& id, std::unique_ptr<DataSou
 }
 
 static void runStartup(Server& server, detail::ServerContext& context) {
+    const std::scoped_lock startupLock{context.mutexStartup};
+    if (context.running || context.stopRequested) {
+        context.stopRequested = false;
+        return;
+    }
     applySessionRegistry(server.config(), context);
     throwIfBad(UA_Server_run_startup(server.handle()));
     context.running = true;
@@ -332,17 +337,20 @@ uint16_t Server::runIterate() {
     if (!context().running) {
         runStartup(*this, context());
     }
+    if (!context().running) {
+        return 0;
+    }
     auto interval = UA_Server_run_iterate(handle(), false /* don't wait */);
     context().exceptionCatcher.rethrow();
     return interval;
 }
 
 void Server::run() {
-    if (context().running) {
+    runStartup(*this, context());
+    if (!context().running) {
         return;
     }
-    runStartup(*this, context());
-    const std::lock_guard lock(context().mutexRun);
+    const std::scoped_lock runLock{context().mutexRun};
     try {
         while (context().running) {
             // https://github.com/open62541/open62541/blob/master/examples/server_mainloop.c
@@ -356,12 +364,16 @@ void Server::run() {
 }
 
 void Server::stop() {
-    if (!context().running) {
-        return;
+    {
+        const std::scoped_lock startupLock{context().mutexStartup};
+        if (!context().running) {
+            context().stopRequested = true;
+            return;
+        }
+        context().running = false;
     }
-    context().running = false;
     // wait for run loop to complete
-    const std::lock_guard<std::mutex> lock(context().mutexRun);
+    const std::scoped_lock runLock{context().mutexRun};
     throwIfBad(UA_Server_run_shutdown(handle()));
 }
 

--- a/tests/server.cpp
+++ b/tests/server.cpp
@@ -130,6 +130,13 @@ TEST_CASE("Server run/stop/runIterate") {
         t.join();  // wait until stopped
     }
 
+    // https://github.com/open62541pp/open62541pp/issues/714
+    SECTION("stop before startup completes") {
+        auto t = std::thread([&] { server.run(); });
+        server.stop();
+        t.join();
+    }
+
     SECTION("runIterate") {
         const auto waitInterval = server.runIterate();
         CHECK(waitInterval > 0);


### PR DESCRIPTION
`stop()` could return as a no-op when called concurrently with `run()` during the startup window (while `UA_Server_run_startup()` was executing or before `run()` had acquired its lock), leaving the server running with no way to stop it.

Fix: guard the startup phase in `runStartup()` with `mutexStartup` so that `stop()` either waits for startup to complete or leaves a `stopRequested` flag for `run()` to check on entry. Both `run()` and `runIterate()` now go through `runStartup()`, so the protection covers both entry points.

Closes #714.